### PR TITLE
perf(cache): optional redis escrow read cache with strict ttl and ledger-gap invalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,15 @@ JWT_SECRET=your-super-secure-jwt-secret-key-at-least-32-chars-long-here
 
 # Cache
 ESCROW_CACHE_TTL_SECONDS=30
+REDIS_ESCROW_CACHE_ENABLED=false
+# REDIS_URL=redis://localhost:6379
+# Strict TTL for cached escrow summaries. Value is clamped to [5, 300].
+REDIS_ESCROW_CACHE_TTL_SECONDS=30
+# Invalidate cached summary when |currentLedger - cachedLedger| exceeds this threshold.
+REDIS_ESCROW_LEDGER_GAP_THRESHOLD=3
 
 # DB (when added)
 # DATABASE_URL=postgresql://user:pass@localhost:5432/liquifact
-# REDIS_URL=redis://localhost:6379
 
 # --------------------
 # JWT Authentication |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Part of the LiquiFact stack: frontend (Next.js) | backend (this repo) | contract
 | `npm run load:baseline` | Run the core endpoint load baseline suite |
 
 Default port: `3001`.
+Escrow Redis cache is optional and disabled by default; set `REDIS_ESCROW_CACHE_ENABLED=true` with `REDIS_URL` to enable it.
+`REDIS_ESCROW_CACHE_TTL_SECONDS` is strictly clamped to `5..300`, and `REDIS_ESCROW_LEDGER_GAP_THRESHOLD` controls ledger-gap invalidation.
 
 Core routes currently covered:
 

--- a/src/cache/redis.js
+++ b/src/cache/redis.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const DEFAULT_TTL_SECONDS = 30;
+const MIN_TTL_SECONDS = 5;
+const MAX_TTL_SECONDS = 300;
+
+const DEFAULT_LEDGER_GAP_THRESHOLD = 3;
+const MAX_LEDGER_GAP_THRESHOLD = 1000;
+
+function parsePositiveInt(rawValue, fallback, min, max) {
+  const parsed = Number.parseInt(String(rawValue || ''), 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function parseRedisEscrowCacheConfig(env = process.env) {
+  const enabled = String(env.REDIS_ESCROW_CACHE_ENABLED || '').toLowerCase() === 'true';
+  const redisUrl = env.REDIS_URL || '';
+
+  return {
+    enabled: enabled && Boolean(redisUrl),
+    redisUrl,
+    ttlSeconds: parsePositiveInt(
+      env.REDIS_ESCROW_CACHE_TTL_SECONDS,
+      DEFAULT_TTL_SECONDS,
+      MIN_TTL_SECONDS,
+      MAX_TTL_SECONDS
+    ),
+    ledgerGapThreshold: parsePositiveInt(
+      env.REDIS_ESCROW_LEDGER_GAP_THRESHOLD,
+      DEFAULT_LEDGER_GAP_THRESHOLD,
+      1,
+      MAX_LEDGER_GAP_THRESHOLD
+    ),
+  };
+}
+
+function createRedisClient(config = parseRedisEscrowCacheConfig(), RedisCtor) {
+  if (!config.enabled) {
+    return null;
+  }
+
+  const Redis = RedisCtor || require('ioredis');
+  return new Redis(config.redisUrl, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+  });
+}
+
+function isValidInvoiceId(invoiceId) {
+  return typeof invoiceId === 'string' && /^[a-zA-Z0-9:_-]{1,128}$/.test(invoiceId);
+}
+
+class RedisEscrowSummaryCache {
+  constructor({
+    client,
+    ttlSeconds = DEFAULT_TTL_SECONDS,
+    ledgerGapThreshold = DEFAULT_LEDGER_GAP_THRESHOLD,
+    keyPrefix = 'escrow:summary',
+  }) {
+    this.client = client;
+    this.ttlSeconds = ttlSeconds;
+    this.ledgerGapThreshold = ledgerGapThreshold;
+    this.keyPrefix = keyPrefix;
+  }
+
+  key(invoiceId) {
+    return `${this.keyPrefix}:${invoiceId}`;
+  }
+
+  async getSummary(invoiceId, currentLedger) {
+    if (!this.client || !isValidInvoiceId(invoiceId)) {
+      return { hit: false, reason: 'invalid_input' };
+    }
+
+    const key = this.key(invoiceId);
+
+    try {
+      const raw = await this.client.get(key);
+      if (!raw) {
+        return { hit: false, reason: 'miss' };
+      }
+
+      const entry = JSON.parse(raw);
+      if (
+        Number.isFinite(currentLedger) &&
+        Number.isFinite(entry.cachedLedger) &&
+        Math.abs(currentLedger - entry.cachedLedger) > this.ledgerGapThreshold
+      ) {
+        await this.client.del(key);
+        return { hit: false, reason: 'ledger_gap' };
+      }
+
+      return { hit: true, value: entry.summary };
+    } catch (_error) {
+      return { hit: false, reason: 'cache_error' };
+    }
+  }
+
+  async setSummary(invoiceId, summary, currentLedger) {
+    if (!this.client || !isValidInvoiceId(invoiceId)) {
+      return false;
+    }
+
+    const key = this.key(invoiceId);
+    const payload = JSON.stringify({
+      summary,
+      cachedLedger: Number.isFinite(currentLedger) ? currentLedger : null,
+      cachedAt: new Date().toISOString(),
+    });
+
+    try {
+      await this.client.set(key, payload, 'EX', this.ttlSeconds);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+}
+
+function createRedisEscrowSummaryCache({ env = process.env, client, RedisCtor } = {}) {
+  const config = parseRedisEscrowCacheConfig(env);
+  const redisClient = client || createRedisClient(config, RedisCtor);
+
+  if (!redisClient) {
+    return null;
+  }
+
+  return new RedisEscrowSummaryCache({
+    client: redisClient,
+    ttlSeconds: config.ttlSeconds,
+    ledgerGapThreshold: config.ledgerGapThreshold,
+  });
+}
+
+module.exports = {
+  RedisEscrowSummaryCache,
+  createRedisClient,
+  createRedisEscrowSummaryCache,
+  isValidInvoiceId,
+  parseRedisEscrowCacheConfig,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,24 @@ const logger = require('./logger');
 const requestId = require('./middleware/requestId');
 const pinoHttp = require('pino-http');
 const investRoutes = require('./routes/invest');
+const { createRedisEscrowSummaryCache } = require('./cache/redis');
 
 const PORT = process.env.PORT || 3001;
 
 // In-memory storage for invoices (Issue #25).
 let invoices = [];
+const escrowSummaryCache = createRedisEscrowSummaryCache();
+
+function parseLedgerSequence(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
 
 /**
  * Create the Express application instance.
@@ -186,18 +199,41 @@ function createApp(options = {}) {
 
   app.get('/api/escrow/:invoiceId', authenticateToken, async (req, res) => {
     const { invoiceId } = req.params;
+    const currentLedger =
+      parseLedgerSequence(req.query.ledgerSequence) ??
+      parseLedgerSequence(req.headers['x-ledger-sequence']);
 
     try {
+      if (escrowSummaryCache) {
+        const cached = await escrowSummaryCache.getSummary(invoiceId, currentLedger);
+        if (cached.hit) {
+          res.set('X-Cache', 'HIT');
+          return res.json({
+            data: cached.value,
+            message: 'Escrow summary served from Redis cache.',
+          });
+        }
+      }
+
       /**
        * Simulates a Soroban operation for escrow lookup.
        *
        * @returns {Promise<object>} Placeholder escrow state.
        */
       const operation = async () => {
-        return { invoiceId, status: 'not_found', fundedAmount: 0 };
+        return {
+          invoiceId,
+          status: 'not_found',
+          fundedAmount: 0,
+          ledgerSequence: currentLedger,
+        };
       };
 
       const data = await callSorobanContract(operation);
+      if (escrowSummaryCache) {
+        await escrowSummaryCache.setSummary(invoiceId, data, currentLedger);
+      }
+      res.set('X-Cache', 'MISS');
       return res.json({
         data,
         message: 'Escrow state read from Soroban contract via robust integration wrapper.',

--- a/tests/cache.redis.test.js
+++ b/tests/cache.redis.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const {
+  RedisEscrowSummaryCache,
+  createRedisEscrowSummaryCache,
+  parseRedisEscrowCacheConfig,
+} = require('../src/cache/redis');
+
+class FakeRedisClient {
+  constructor() {
+    this.map = new Map();
+    this.lastSetArgs = null;
+  }
+
+  async get(key) {
+    return this.map.get(key) || null;
+  }
+
+  async set(key, value, mode, ttl) {
+    this.lastSetArgs = { key, value, mode, ttl };
+    this.map.set(key, value);
+    return 'OK';
+  }
+
+  async del(key) {
+    this.map.delete(key);
+    return 1;
+  }
+}
+
+describe('redis escrow cache config', () => {
+  it('disables cache when REDIS_URL is not set', () => {
+    const config = parseRedisEscrowCacheConfig({
+      REDIS_ESCROW_CACHE_ENABLED: 'true',
+    });
+
+    expect(config.enabled).toBe(false);
+  });
+
+  it('clamps TTL and ledger gap threshold to strict limits', () => {
+    const config = parseRedisEscrowCacheConfig({
+      REDIS_ESCROW_CACHE_ENABLED: 'true',
+      REDIS_URL: 'redis://localhost:6379',
+      REDIS_ESCROW_CACHE_TTL_SECONDS: '9999',
+      REDIS_ESCROW_LEDGER_GAP_THRESHOLD: '0',
+    });
+
+    expect(config.enabled).toBe(true);
+    expect(config.ttlSeconds).toBe(300);
+    expect(config.ledgerGapThreshold).toBe(1);
+  });
+});
+
+describe('RedisEscrowSummaryCache', () => {
+  it('stores cache entries with EX TTL', async () => {
+    const client = new FakeRedisClient();
+    const cache = new RedisEscrowSummaryCache({
+      client,
+      ttlSeconds: 45,
+      ledgerGapThreshold: 3,
+    });
+
+    await cache.setSummary('inv_123', { invoiceId: 'inv_123', status: 'not_found' }, 120);
+
+    expect(client.lastSetArgs.mode).toBe('EX');
+    expect(client.lastSetArgs.ttl).toBe(45);
+  });
+
+  it('returns miss and invalidates entry when ledger gap exceeds threshold', async () => {
+    const client = new FakeRedisClient();
+    const cache = new RedisEscrowSummaryCache({
+      client,
+      ttlSeconds: 30,
+      ledgerGapThreshold: 2,
+    });
+
+    await cache.setSummary('inv_ledger', { invoiceId: 'inv_ledger', status: 'funded' }, 100);
+    const result = await cache.getSummary('inv_ledger', 104);
+
+    expect(result.hit).toBe(false);
+    expect(result.reason).toBe('ledger_gap');
+    expect(await client.get('escrow:summary:inv_ledger')).toBeNull();
+  });
+
+  it('returns hit when ledger gap is within threshold', async () => {
+    const client = new FakeRedisClient();
+    const cache = new RedisEscrowSummaryCache({
+      client,
+      ttlSeconds: 30,
+      ledgerGapThreshold: 5,
+    });
+
+    await cache.setSummary('inv_ok', { invoiceId: 'inv_ok', status: 'not_found' }, 250);
+    const result = await cache.getSummary('inv_ok', 254);
+
+    expect(result.hit).toBe(true);
+    expect(result.value).toEqual({ invoiceId: 'inv_ok', status: 'not_found' });
+  });
+
+  it('does not create cache instance when optional redis cache is disabled', () => {
+    const cache = createRedisEscrowSummaryCache({
+      env: {
+        REDIS_ESCROW_CACHE_ENABLED: 'false',
+        REDIS_URL: 'redis://localhost:6379',
+      },
+    });
+
+    expect(cache).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #126
## Summary
- Add optional Redis cache for escrow read summaries (`GET /api/escrow/:invoiceId`) with fail-open behavior when disabled/unavailable.
- Enforce strict TTL bounds (`REDIS_ESCROW_CACHE_TTL_SECONDS` clamped to `5..300`) and invalidate cache when ledger gap exceeds `REDIS_ESCROW_LEDGER_GAP_THRESHOLD`.
- Add unit tests for cache config, TTL semantics, and ledger-gap invalidation; update `.env.example` and README docs for operational guidance.

## API examples

### Cache miss (compute + store)
```bash
curl -i -H "Authorization: Bearer <JWT>" \
  "http://localhost:3001/api/escrow/inv_123?ledgerSequence=1200"