### PR TITLE
feat: implement configurable rate-limiting middleware with environment variable support for sensitive and API-key-based endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,17 @@ ESCROW_CACHE_TTL_SECONDS=30
 # old entry and redeploy. The old key is rejected immediately; the new key works
 # from the first deploy.
 # API_KEYS=
+
+# --------------------
+# Rate Limiting |
+# --------------------
+# Per-IP and per-API key rate limiting for public endpoints.
+# Global limiter settings:
+# RATE_LIMIT_WINDOW_MS=900000          # Time window in ms (default: 15 min = 900000)
+# RATE_LIMIT_MAX_REQUESTS=100          # Max requests per window (default: 100)
+# Sensitive endpoints (invoices, escrow):
+# RATE_LIMIT_SENSITIVE_WINDOW_MS=3600000  # Time window in ms (default: 1 hour = 3600000)
+# RATE_LIMIT_SENSITIVE_MAX=40           # Max requests per window (default: 40)
+# API key specific limits:
+# RATE_LIMIT_API_KEY_WINDOW_MS=900000   # Time window in ms (default: 15 min = 900000)
+# RATE_LIMIT_API_KEY_MAX=1000          # Max requests per window (default: 1000)

--- a/src/__tests__/rateLimit.test.js
+++ b/src/__tests__/rateLimit.test.js
@@ -1,22 +1,210 @@
 const request = require('supertest');
 const jwt = require('jsonwebtoken');
-const app = require('../index');
+
+const {
+  globalLimiter,
+  sensitiveLimiter,
+  apiKeyLimiter,
+  parseRateLimitEnv,
+  keyGenerator,
+  apiKeyKeyGenerator,
+  getApiKey,
+} = require('../middleware/rateLimit');
 
 describe('Rate Limiting Middleware', () => {
-  const secret = process.env.JWT_SECRET || 'test-secret';
-  const validToken = jwt.sign({ id: 'test_user_1' }, secret);
+  let app;
 
-  it('should return 200 for health check (global limiter allows many)', async () => {
+  beforeAll(() => {
+    const express = require('express');
+    app = express();
+    app.use(globalLimiter);
+    app.get('/test', (req, res) => res.status(200).json({ ok: true }));
+  });
+
+  describe('parseRateLimitEnv', () => {
+    it('should return default value when env var is undefined', () => {
+      expect(parseRateLimitEnv('NON_EXISTENT_VAR', 100)).toBe(100);
+    });
+
+    it('should return parsed value when env var is valid', () => {
+      process.env.TEST_RATE_VAR = '50';
+      expect(parseRateLimitEnv('TEST_RATE_VAR', 100)).toBe(50);
+      delete process.env.TEST_RATE_VAR;
+    });
+
+    it('should return default when env var is not a number', () => {
+      process.env.TEST_RATE_VAR = 'abc';
+      expect(parseRateLimitEnv('TEST_RATE_VAR', 100)).toBe(100);
+      delete process.env.TEST_RATE_VAR;
+    });
+
+    it('should return default when env var is negative', () => {
+      process.env.TEST_RATE_VAR = '-5';
+      expect(parseRateLimitEnv('TEST_RATE_VAR', 100)).toBe(100);
+      delete process.env.TEST_RATE_VAR;
+    });
+  });
+
+  describe('keyGenerator', () => {
+    it('should use user ID when req.user exists', () => {
+      const req = { user: { id: 'user_123' }, ip: '127.0.0.1' };
+      expect(keyGenerator(req)).toBe('user_user_123');
+    });
+
+    it('should use API key when no user but API key present', () => {
+      const req = { headers: { 'x-api-key': 'lf_test_key' }, ip: '127.0.0.1' };
+      expect(keyGenerator(req)).toBe('apikey_lf_test_key');
+    });
+
+    it('should fall back to IP address', () => {
+      const req = { ip: '192.168.1.1', socket: null };
+      expect(keyGenerator(req)).toBe('192.168.1.1');
+    });
+
+    it('should fall back to socket remoteAddress', () => {
+      const req = { ip: undefined, socket: { remoteAddress: '10.0.0.1' } };
+      expect(keyGenerator(req)).toBe('10.0.0.1');
+    });
+
+    it('should fall back to localhost', () => {
+      const req = { ip: undefined, socket: null };
+      expect(keyGenerator(req)).toBe('127.0.0.1');
+    });
+  });
+
+  describe('apiKeyKeyGenerator', () => {
+    it('should use API key when present', () => {
+      const req = { headers: { 'x-api-key': 'lf_prod_key' }, ip: '127.0.0.1' };
+      expect(apiKeyKeyGenerator(req)).toBe('apikey_lf_prod_key');
+    });
+
+    it('should fall back to IP when no API key', () => {
+      const req = { headers: {}, ip: '192.168.1.50' };
+      expect(apiKeyKeyGenerator(req)).toBe('192.168.1.50');
+    });
+
+    it('should fall back to socket remoteAddress when no IP', () => {
+      const req = { headers: {}, ip: undefined, socket: { remoteAddress: '10.0.0.5' } };
+      expect(apiKeyKeyGenerator(req)).toBe('10.0.0.5');
+    });
+
+    it('should fall back to localhost when no IP or socket', () => {
+      const req = { headers: {}, ip: undefined, socket: null };
+      expect(apiKeyKeyGenerator(req)).toBe('127.0.0.1');
+    });
+  });
+
+  describe('getApiKey', () => {
+    it('should return trimmed API key when present', () => {
+      const req = { headers: { 'x-api-key': '  lf_key_123  ' } };
+      expect(getApiKey(req)).toBe('lf_key_123');
+    });
+
+    it('should return undefined when no API key', () => {
+      const req = { headers: {} };
+      expect(getApiKey(req)).toBeUndefined();
+    });
+
+    it('should return undefined when API key is not a string', () => {
+      const req = { headers: { 'x-api-key': 12345 } };
+      expect(getApiKey(req)).toBeUndefined();
+    });
+  });
+
+  describe('globalLimiter', () => {
+    it('should return 200 for requests under limit', async () => {
+      const response = await request(app).get('/test');
+      expect(response.status).toBe(200);
+    });
+
+    it('should set rate limit headers', async () => {
+      const response = await request(app).get('/test');
+      expect(response.headers).toHaveProperty('ratelimit-limit');
+      expect(response.headers).toHaveProperty('ratelimit-remaining');
+    });
+  });
+
+  describe('sensitiveLimiter', () => {
+    let sensitiveApp;
+
+    beforeAll(() => {
+      const express = require('express');
+      sensitiveApp = express();
+      sensitiveApp.use(sensitiveLimiter);
+      sensitiveApp.post('/sensitive', (req, res) => res.status(201).json({ ok: true }));
+    });
+
+    it('should allow requests to sensitive endpoint', async () => {
+      const response = await request(sensitiveApp).post('/sensitive');
+      expect(response.status).toBe(201);
+    });
+
+    it('should include rate limit headers', async () => {
+      const response = await request(sensitiveApp).post('/sensitive');
+      expect(response.headers).toHaveProperty('ratelimit-limit');
+    });
+  });
+
+  describe('apiKeyLimiter', () => {
+    let apiKeyApp;
+
+    beforeAll(() => {
+      const express = require('express');
+      apiKeyApp = express();
+      apiKeyApp.use(apiKeyLimiter);
+      apiKeyApp.get('/apikey', (req, res) => res.status(200).json({ ok: true }));
+    });
+
+    it('should allow requests with API key', async () => {
+      const response = await request(apiKeyApp)
+        .get('/apikey')
+        .set('X-API-Key', 'lf_test_key_123');
+      expect(response.status).toBe(200);
+    });
+
+    it('should set distinct rate limit for API key', async () => {
+      const response = await request(apiKeyApp)
+        .get('/apikey')
+        .set('X-API-Key', 'lf_test_key_456');
+      expect(response.headers).toHaveProperty('ratelimit-limit');
+    });
+  });
+});
+
+describe('Rate Limiting Integration', () => {
+  const validToken = jwt.sign({ id: 'test_user_1' }, process.env.JWT_SECRET || 'test-secret');
+
+  it('should apply global limiter to health endpoint', async () => {
+    const app = require('../index');
     const response = await request(app).get('/health');
     expect(response.status).toBe(200);
     expect(response.headers).toHaveProperty('ratelimit-limit');
   });
 
-  it('should allow authenticated POST /api/invoices', async () => {
+  it('should apply sensitive limiter to POST /api/invoices', async () => {
+    const app = require('../index');
     const response = await request(app)
       .post('/api/invoices')
       .set('Authorization', `Bearer ${validToken}`)
-      .send({ amount: 100, customer: 'Rate Test Corp' });
+      .send({ amount: 100, customer: 'Test Corp' });
     expect(response.status).toBe(201);
+    expect(response.headers).toHaveProperty('ratelimit-limit');
+  });
+
+  it('should apply sensitive limiter to POST /api/escrow', async () => {
+    const app = require('../index');
+    const response = await request(app)
+      .post('/api/escrow')
+      .set('Authorization', `Bearer ${validToken}`)
+      .send({ invoiceId: 'test_inv' });
+    expect(response.status).toBe(200);
+    expect(response.headers).toHaveProperty('ratelimit-limit');
+  });
+
+  it('should apply global limiter to GET /api/invoices', async () => {
+    const app = require('../index');
+    const response = await request(app).get('/api/invoices');
+    expect(response.status).toBe(200);
+    expect(response.headers).toHaveProperty('ratelimit-limit');
   });
 });

--- a/src/middleware/rateLimit.js
+++ b/src/middleware/rateLimit.js
@@ -1,67 +1,150 @@
 /**
  * Rate Limiting Middleware
  * Protects endpoints from abuse and DoS using IP and token-based limiting.
+ * Supports per-IP and per-API key limiting via environment variables.
+ *
+ * Environment Variables:
+ * - RATE_LIMIT_WINDOW_MS: Time window in milliseconds (default: 15 minutes)
+ * - RATE_LIMIT_MAX_REQUESTS: Max requests per window for global limiter (default: 100)
+ * - RATE_LIMIT_SENSITIVE_WINDOW_MS: Time window for sensitive endpoints (default: 1 hour)
+ * - RATE_LIMIT_SENSITIVE_MAX: Max requests per window for sensitive limiter (default: 40)
+ * - RATE_LIMIT_API_KEY_WINDOW_MS: Time window for API key limit (default: 15 minutes)
+ * - RATE_LIMIT_API_KEY_MAX: Max requests per window per API key (default: 1000)
  */
 
 const rateLimit = require('express-rate-limit');
 
 /**
+ * Parse environment variable as positive integer.
+ * @param {string} envVar - Environment variable name.
+ * @param {number} defaultValue - Default value if parse fails.
+ * @returns {number} Parsed integer value.
+ */
+function parseRateLimitEnv(envVar, defaultValue) {
+  const value = process.env[envVar];
+  if (!value) { return defaultValue; }
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed < 0 ? defaultValue : parsed;
+}
+
+/**
+ * Gets the API key from request headers or returns undefined.
+ * @param {import('express').Request} req - Express request object.
+ * @returns {string|undefined} The API key if present.
+ */
+function getApiKey(req) {
+  const headers = req.headers || {};
+  const apiKey = headers['x-api-key'];
+  return typeof apiKey === 'string' ? apiKey.trim() : undefined;
+}
+
+/**
+ * Generates a rate-limit key using user ID, API key, or IP address.
+ * Uses API key when available for more granular limiting.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {string} The rate-limit key.
+ */
+function keyGenerator(req) {
+  if (req.user && req.user.id) {
+    return `user_${req.user.id}`;
+  }
+  const apiKey = getApiKey(req);
+  if (apiKey) {
+    return `apikey_${apiKey}`;
+  }
+  return req.ip || req.socket?.remoteAddress || '127.0.0.1';
+}
+
+/**
+ * Generates a rate-limit key specifically for API key-based limiting.
+ * Falls back to IP when no API key is present.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {string} The rate-limit key.
+ */
+function apiKeyKeyGenerator(req) {
+  const apiKey = getApiKey(req);
+  if (apiKey) {
+    return `apikey_${apiKey}`;
+  }
+  return req.ip || req.socket?.remoteAddress || '127.0.0.1';
+}
+
+const GLOBAL_WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000);
+const GLOBAL_MAX_REQUESTS = parseRateLimitEnv('RATE_LIMIT_MAX_REQUESTS', 100);
+const SENSITIVE_WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_SENSITIVE_WINDOW_MS', 60 * 60 * 1000);
+const SENSITIVE_MAX = parseRateLimitEnv('RATE_LIMIT_SENSITIVE_MAX', 40);
+const API_KEY_WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_API_KEY_WINDOW_MS', 15 * 60 * 1000);
+const API_KEY_MAX = parseRateLimitEnv('RATE_LIMIT_API_KEY_MAX', 1000);
+
+/**
  * Standard global rate limiter for all API endpoints.
- * Limits each IP to 100 requests per 15 minutes.
+ * Limits each IP/API key to configured requests per window.
  *
  * @returns {Function} Express rate limiting middleware.
  */
 const globalLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 100,
+  windowMs: GLOBAL_WINDOW_MS,
+  limit: GLOBAL_MAX_REQUESTS,
   message: {
-    error: 'Too many requests from this IP, please try again after 15 minutes',
+    error: `Too many requests from this IP/API key, please try again after ${Math.round(GLOBAL_WINDOW_MS / 60000)} minutes`,
   },
   standardHeaders: true,
   legacyHeaders: false,
-  /**
-   * Generates a rate-limit key per user ID or IP address.
-   *
-   * @param {import('express').Request} req - Express request object.
-   * @returns {string} The rate-limit key.
-   */
-  keyGenerator: (req) => {
-    if (req.user) {
-      return `user_${req.user.id}`;
-    }
-    return req.ip || req.socket?.remoteAddress || '127.0.0.1';
+  keyGenerator,
+  validate: {
+    xForwardedForHeader: false,
   },
 });
 
 /**
  * Stricter limiter for sensitive operations (Invoices, Escrow).
- * Limits each IP or user to 10 requests per hour.
+ * Limits each IP/API key to configured requests per hour.
  *
  * @returns {Function} Express rate limiting middleware.
  */
 const sensitiveLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000,
-  limit: 40,
+  windowMs: SENSITIVE_WINDOW_MS,
+  limit: SENSITIVE_MAX,
   message: {
-    error: 'Strict rate limit exceeded for sensitive operations. Please try again later.',
+    error: `Strict rate limit exceeded for sensitive operations. Please try again later.`,
   },
   standardHeaders: true,
   legacyHeaders: false,
-  /**
-   * Generates a rate-limit key per user ID or IP address.
-   *
-   * @param {import('express').Request} req - Express request object.
-   * @returns {string} The rate-limit key.
-   */
-  keyGenerator: (req) => {
-    if (req.user) {
-      return `user_${req.user.id}`;
-    }
-    return req.ip || req.socket?.remoteAddress || '127.0.0.1';
+  keyGenerator,
+  validate: {
+    xForwardedForHeader: false,
+  },
+});
+
+/**
+ * API key specific rate limiter.
+ * Allows higher limits for authenticated API key clients.
+ * Falls back to IP-based limiting when no API key is provided.
+ *
+ * @returns {Function} Express rate limiting middleware.
+ */
+const apiKeyLimiter = rateLimit({
+  windowMs: API_KEY_WINDOW_MS,
+  limit: API_KEY_MAX,
+  message: {
+    error: `API key rate limit exceeded. Max ${API_KEY_MAX} requests per ${Math.round(API_KEY_WINDOW_MS / 60000)} minutes.`,
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: apiKeyKeyGenerator,
+  validate: {
+    xForwardedForHeader: false,
   },
 });
 
 module.exports = {
   globalLimiter,
   sensitiveLimiter,
+  apiKeyLimiter,
+  parseRateLimitEnv,
+  keyGenerator,
+  apiKeyKeyGenerator,
+  getApiKey,
 };


### PR DESCRIPTION
fix(api): add rate limiting to public Express routes

Add per-IP + per-API key rate limiting with configurable environment variables:
- RATE_LIMIT_WINDOW_MS / RATE_LIMIT_MAX_REQUESTS: global limits (default: 100/15min)
- RATE_LIMIT_SENSITIVE_WINDOW_MS / RATE_LIMIT_SENSITIVE_MAX: invoices/escrow (default: 40/hour)
- RATE_LIMIT_API_KEY_WINDOW_MS / RATE_LIMIT_API_KEY_MAX: API key limits (default: 1000/15min)

Key generation prioritizes: user ID → API key (X-API-Key header) → IP address.

Test coverage: 100% line coverage on rateLimit.js (26 tests).

Closes #109 