### PR TITLE
docs(escrow): add custodial fund signing design stub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,19 @@ JWT_SECRET=your-super-secure-jwt-secret-key-at-least-32-chars-long-here
 # Cache
 ESCROW_CACHE_TTL_SECONDS=30
 
+# Soroban escrow funding submission stub
+# Defaults to delegated mode; live signing/submission is disabled in code.
+ESCROW_SIGNING_MODE=delegated
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+# LIQUIFACT_ESCROW_CONTRACT_ID=C...
+
+# Custodial signing references only. Never store raw Stellar secret keys here.
+ESCROW_CUSTODIAL_SIGNING_ENABLED=false
+# ESCROW_CUSTODIAL_KMS_PROVIDER=aws-kms
+# ESCROW_CUSTODIAL_KEY_ID=liquifact/escrow/fund/v1
+# ESCROW_DOCUMENT_CUSTODIAL_KEY_ID=liquifact/docs/custody/v1
+
 # DB (when added)
 # DATABASE_URL=postgresql://user:pass@localhost:5432/liquifact
 # REDIS_URL=redis://localhost:6379

--- a/docs/ops-signing.md
+++ b/docs/ops-signing.md
@@ -1,0 +1,171 @@
+# LiquiFact Ops Signing Design
+
+This document defines the server-orchestrated signing interface for Soroban
+escrow funding and document custody. The current backend implementation is a
+design stub: it validates funding requests and returns a funding intent, but it
+does not build, sign, or submit a live Stellar/Soroban transaction.
+
+## Goals
+
+- Keep private signing material out of the repository, logs, request bodies, and
+  API responses.
+- Support delegated signing first, where the funder signs with their own
+  Stellar wallet and the server only orchestrates validation and submission.
+- Support a future custodial path only through explicit environment gates and a
+  managed KMS/HSM signer.
+- Separate escrow fund-signing keys from document custody or attestation keys.
+- Preserve idempotency and auditability for funding operations.
+
+## Runtime Modes
+
+`ESCROW_SIGNING_MODE=delegated` is the recommended default.
+
+| Mode | Current behavior | Future live behavior |
+| --- | --- | --- |
+| `delegated` | Validates the request and reports that a client signature is required unless `signedTransactionXdr` is supplied. It still does not submit. | Server builds a Soroban transaction for the LiquifactEscrow `fund_escrow` operation, returns unsigned XDR, receives signed XDR from the client, simulates and submits through Soroban RPC. |
+| `custodial` | Validates the request and reports missing configuration unless every custodial env gate is present. It still does not sign or submit. | Server asks KMS/HSM to sign the transaction with an approved custodial fund key, then simulates and submits through Soroban RPC. |
+
+## Environment Variables
+
+These variables are intentionally configuration references, not secrets. Raw
+Stellar secret keys or mnemonic material must never be stored in `.env`.
+
+| Variable | Required for live delegated | Required for live custodial | Notes |
+| --- | --- | --- | --- |
+| `ESCROW_SIGNING_MODE` | Yes | Yes | `delegated` or `custodial`. Defaults to `delegated` in the stub. |
+| `SOROBAN_RPC_URL` | Yes | Yes | Soroban RPC endpoint for simulation and submission. |
+| `STELLAR_NETWORK_PASSPHRASE` | Yes | Yes | Network passphrase, for example testnet or public network. |
+| `LIQUIFACT_ESCROW_CONTRACT_ID` | Yes | Yes | Soroban `C...` contract ID for LiquifactEscrow. |
+| `ESCROW_CUSTODIAL_SIGNING_ENABLED` | No | Yes | Must be exactly `true` before custodial signing can be considered. |
+| `ESCROW_CUSTODIAL_KMS_PROVIDER` | No | Yes | Provider identifier such as `aws-kms`, `gcp-kms`, `azure-key-vault`, or `hsm`. |
+| `ESCROW_CUSTODIAL_KEY_ID` | No | Yes | KMS/HSM key alias or ARN for escrow funding. Do not store raw secret keys. |
+| `ESCROW_DOCUMENT_CUSTODIAL_KEY_ID` | No | Optional | Separate KMS/HSM key alias or ARN for document custody and attestation. |
+
+## Key Management Interface
+
+Fund and document keys must be separate trust domains.
+
+| Key class | Purpose | Allowed operations | Rotation name example |
+| --- | --- | --- | --- |
+| Escrow fund key | Sign Soroban funding transactions for server-custodial flows. | `signTransactionHash`, never export private key material. | `liquifact/escrow/fund/v1` |
+| Document custody key | Sign document hashes, receipt attestations, or encrypted document metadata. | `signDigest`, `encrypt`, `decrypt` as approved by the document pipeline. | `liquifact/docs/custody/v1` |
+
+Operational requirements:
+
+- Use KMS/HSM key handles only. No Stellar secret seeds in source, `.env`, CI
+  logs, test fixtures, or API payloads.
+- Require dual control for custodial fund key creation, policy edits, and
+  deletion scheduling.
+- Allow the application role to sign only with the escrow fund key, not with the
+  document custody key.
+- Emit an audit event for every signing request containing request ID,
+  authenticated user/client, invoice ID, public key, asset, amount,
+  idempotency key, key alias, and Soroban transaction hash when available.
+- Rotate keys by adding a new alias version, deploying the new key ID, waiting
+  for pending requests to drain, and disabling the old key. Never overwrite
+  historical audit records.
+- Keep break-glass access outside the application role and require incident
+  review after use.
+
+## Funding API
+
+Authenticated route:
+
+```http
+POST /api/escrow
+Authorization: Bearer <jwt>
+Idempotency-Key: fund-inv-123-0001
+Content-Type: application/json
+```
+
+Delegated signing request:
+
+```bash
+curl -X POST http://localhost:3001/api/escrow \
+  -H "Authorization: Bearer $JWT" \
+  -H "Idempotency-Key: fund-inv-123-0001" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "invoiceId": "inv_123",
+    "funderPublicKey": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "amount": "100.0000000",
+    "asset": { "code": "XLM" },
+    "signingMode": "delegated",
+    "memo": "inv_123"
+  }'
+```
+
+Stub response:
+
+```json
+{
+  "data": {
+    "status": "requires_signature",
+    "submitted": false,
+    "signingMode": "delegated",
+    "transaction": {
+      "unsignedXdr": null,
+      "signedXdrAccepted": false,
+      "hash": null
+    },
+    "controls": {
+      "liveSubmissionEnabled": false
+    }
+  },
+  "message": "Escrow funding transaction prepared; no live transaction was signed or submitted."
+}
+```
+
+Custodial request shape:
+
+```bash
+curl -X POST http://localhost:3001/api/escrow \
+  -H "Authorization: Bearer $JWT" \
+  -H "Idempotency-Key: fund-inv-123-0002" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "invoiceId": "inv_123",
+    "funderPublicKey": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "amount": "100.0000000",
+    "asset": {
+      "code": "USDC",
+      "issuer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "signingMode": "custodial"
+  }'
+```
+
+The stub returns `requires_configuration` unless all custodial env gates are
+present, and it still never signs or submits a transaction.
+
+## Validation And Security Notes
+
+- `invoiceId` is limited to URL-safe invoice identifiers.
+- `funderPublicKey` and asset issuers must be Stellar `G...` public keys.
+- `amount` must be positive and use at most seven decimal places, matching
+  Stellar amount precision.
+- Native XLM must not include an issuer. Issued assets require an issuer.
+- `signedTransactionXdr` is accepted only as bounded base64 text and is not
+  submitted by the stub.
+- `Idempotency-Key` is accepted from the header or body and should be required
+  by the live implementation before transaction submission.
+- The authenticated caller is taken from the existing JWT middleware on
+  `src/index.js`.
+- Sensitive operations remain behind the existing sensitive rate limiter.
+
+## Future Live Submission Checklist
+
+Before replacing the stub with live submission:
+
+1. Add Stellar SDK/Soroban transaction building with deterministic operation
+   parameters for LiquifactEscrow.
+2. Simulate every transaction before signing or submission.
+3. Bind idempotency keys to invoice ID, amount, asset, funder, and transaction
+   hash.
+4. Add replay protection for already-funded invoice states.
+5. Add audit logging around build, signature request, simulation, submission,
+   and final ledger status.
+6. Add KMS/HSM signer integration tests with a fake signer and contract tests
+   for delegated signed-XDR submission.
+7. Keep `liveSubmissionEnabled` false until the production signer and network
+   controls are reviewed.

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const logger = require('./logger');
 const requestId = require('./middleware/requestId');
 const pinoHttp = require('pino-http');
 const investRoutes = require('./routes/invest');
+const { submitEscrowFunding } = require('./services/escrowSubmit');
 
 const PORT = process.env.PORT || 3001;
 
@@ -51,8 +52,12 @@ function createApp(options = {}) {
     logger,
     genReqId: (req) => req.id,
     customLogLevel: (req, res, err) => {
-      if (res.statusCode >= 500 || err) return 'error';
-      if (res.statusCode >= 400) return 'warn';
+      if (res.statusCode >= 500 || err) {
+        return 'error';
+      }
+      if (res.statusCode >= 400) {
+        return 'warn';
+      }
       return 'info';
     },
     serializers: {
@@ -207,11 +212,22 @@ function createApp(options = {}) {
     }
   });
 
-  app.post('/api/escrow', authenticateToken, sensitiveLimiter, (req, res) => {
-    return res.json({
-      data: { status: 'funded' },
-      message: 'Escrow operation simulated.',
-    });
+  app.post('/api/escrow', authenticateToken, sensitiveLimiter, async (req, res, next) => {
+    try {
+      const data = await submitEscrowFunding(req.body, {
+        env: process.env,
+        idempotencyKey: req.get('Idempotency-Key'),
+        now: new Date(),
+        userId: req.user && req.user.id,
+      });
+
+      return res.status(202).json({
+        data,
+        message: 'Escrow funding transaction prepared; no live transaction was signed or submitted.',
+      });
+    } catch (error) {
+      return next(error);
+    }
   });
 
   app.get('/error-test-trigger', (req, res, next) => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -181,11 +181,25 @@ describe('LiquiFact API', () => {
       expect(response.body.data).toHaveProperty('invoiceId', '123');
     });
 
-    it('POST /api/escrow - returns simulated escrow payload', async () => {
-      const response = await request(app).post('/api/escrow').set(authHeader()).send({ invoiceId: '  abc-123 \n', fundedAmount: 10 });
+    it('POST /api/escrow - returns no-submit funding intent', async () => {
+      const publicKey = `G${'A'.repeat(55)}`;
+      const response = await request(app)
+        .post('/api/escrow')
+        .set(authHeader())
+        .set('Idempotency-Key', 'fund-abc-123')
+        .send({
+          invoiceId: 'abc-123',
+          funderPublicKey: publicKey,
+          fundedAmount: 10,
+          asset: { code: 'XLM' },
+        });
 
-      expect(response.status).toBe(200);
-      expect(response.body.data).toMatchObject({ status: 'funded' });
+      expect(response.status).toBe(202);
+      expect(response.body.data).toMatchObject({
+        status: 'requires_signature',
+        submitted: false,
+        signingMode: 'delegated',
+      });
     });
   });
 

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -52,7 +52,7 @@ function errorHandler(error, req, res, _next) {
  * Log the error with correlation context without exposing internals to clients.
  *
  * @param {unknown} error Thrown error value.
- * @param {string} correlationId Request correlation ID.
+ * @param {string} requestId Request correlation ID.
  * @returns {void}
  */
 function logError(error, requestId) {

--- a/src/routes/sme/metrics.js
+++ b/src/routes/sme/metrics.js
@@ -28,10 +28,18 @@ function mapStatusToCategory(status) {
   const SETTLED_STATUSES = ['settled', 'paid'];
   const DEFAULTED_STATUSES = ['defaulted'];
 
-  if (OPEN_STATUSES.includes(status)) return 'open';
-  if (FUNDED_STATUSES.includes(status)) return 'funded';
-  if (SETTLED_STATUSES.includes(status)) return 'settled';
-  if (DEFAULTED_STATUSES.includes(status)) return 'defaulted';
+  if (OPEN_STATUSES.includes(status)) {
+    return 'open';
+  }
+  if (FUNDED_STATUSES.includes(status)) {
+    return 'funded';
+  }
+  if (SETTLED_STATUSES.includes(status)) {
+    return 'settled';
+  }
+  if (DEFAULTED_STATUSES.includes(status)) {
+    return 'defaulted';
+  }
   
   return null; // Exclude 'withdrawn' and others
 }

--- a/src/services/escrowSubmit.js
+++ b/src/services/escrowSubmit.js
@@ -1,0 +1,569 @@
+'use strict';
+
+const AppError = require('../errors/AppError');
+
+const SIGNING_MODES = Object.freeze({
+  CUSTODIAL: 'custodial',
+  DELEGATED: 'delegated',
+});
+
+const SUBMISSION_STATUSES = Object.freeze({
+  REQUIRES_SIGNATURE: 'requires_signature',
+  REQUIRES_CONFIGURATION: 'requires_configuration',
+  STUBBED: 'stubbed',
+});
+
+const DEFAULT_SIGNING_MODE = SIGNING_MODES.DELEGATED;
+const FUND_OPERATION = 'fund_escrow';
+const MAX_METADATA_BYTES = 2048;
+const MAX_MEMO_LENGTH = 64;
+
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const STELLAR_PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/;
+const SOROBAN_CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
+const ASSET_CODE_PATTERN = /^[A-Z0-9]{1,12}$/;
+const AMOUNT_PATTERN = /^(?:0|[1-9]\d{0,14})(?:\.\d{1,7})?$/;
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/;
+const XDR_PATTERN = /^[A-Za-z0-9+/=]+$/;
+
+/**
+ * Checks whether a value is a non-array JSON object.
+ *
+ * @param {unknown} value - Candidate value.
+ * @returns {boolean} True when the value is a plain object.
+ */
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+/**
+ * Converts a value to a trimmed string, preserving undefined.
+ *
+ * @param {unknown} value - Candidate value.
+ * @returns {string | undefined} Trimmed string or undefined.
+ */
+function optionalString(value) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return String(value).trim();
+}
+
+/**
+ * Adds a validation error to the shared list.
+ *
+ * @param {string[]} errors - Validation error accumulator.
+ * @param {string} message - Error message to add.
+ * @returns {void}
+ */
+function addError(errors, message) {
+  errors.push(message);
+}
+
+/**
+ * Creates a stable application validation error.
+ *
+ * @param {string[]} errors - Validation errors to expose.
+ * @returns {AppError} Structured validation error.
+ */
+function createValidationError(errors) {
+  return new AppError({
+    type: 'https://liquifact.com/probs/validation-error',
+    title: 'Validation Error',
+    status: 400,
+    detail: errors.join(' '),
+    code: 'VALIDATION_ERROR',
+    retryable: false,
+    retryHint: 'Fix the escrow funding payload and try again.',
+  });
+}
+
+/**
+ * Creates a stable server configuration error.
+ *
+ * @param {string} detail - Configuration problem to expose.
+ * @returns {AppError} Structured configuration error.
+ */
+function createConfigurationError(detail) {
+  return new AppError({
+    type: 'https://liquifact.com/probs/escrow-signing-configuration',
+    title: 'Escrow Signing Configuration Error',
+    status: 500,
+    detail,
+    code: 'CONFIGURATION_ERROR',
+    retryable: false,
+    retryHint: 'Correct the escrow signing environment and redeploy.',
+  });
+}
+
+/**
+ * Normalizes and validates a LiquiFact invoice identifier.
+ *
+ * @param {unknown} value - Raw invoice identifier.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized invoice identifier.
+ */
+function normalizeInvoiceId(value, errors) {
+  const invoiceId = optionalString(value);
+  if (!invoiceId) {
+    addError(errors, 'invoiceId is required.');
+    return undefined;
+  }
+  if (!IDENTIFIER_PATTERN.test(invoiceId)) {
+    addError(errors, 'invoiceId contains unsupported characters.');
+    return undefined;
+  }
+  return invoiceId;
+}
+
+/**
+ * Normalizes and validates a Stellar public key.
+ *
+ * @param {unknown} value - Raw public key value.
+ * @param {string} field - Field name for validation messages.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized public key.
+ */
+function normalizePublicKey(value, field, errors) {
+  const publicKey = optionalString(value);
+  if (!publicKey) {
+    addError(errors, `${field} is required.`);
+    return undefined;
+  }
+  if (!STELLAR_PUBLIC_KEY_PATTERN.test(publicKey)) {
+    addError(errors, `${field} must be a Stellar G... public key.`);
+    return undefined;
+  }
+  return publicKey;
+}
+
+/**
+ * Normalizes and validates a Stellar amount string.
+ *
+ * @param {unknown} amountValue - Raw amount value.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized amount.
+ */
+function normalizeAmount(amountValue, errors) {
+  const amount = optionalString(amountValue);
+  if (!amount) {
+    addError(errors, 'amount is required.');
+    return undefined;
+  }
+  if (!AMOUNT_PATTERN.test(amount)) {
+    addError(errors, 'amount must be a positive decimal with up to 7 decimal places.');
+    return undefined;
+  }
+  if (/^0(?:\.0{1,7})?$/.test(amount)) {
+    addError(errors, 'amount must be greater than zero.');
+    return undefined;
+  }
+  return amount;
+}
+
+/**
+ * Normalizes and validates the funding asset descriptor.
+ *
+ * @param {Object} payload - Request payload.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {{code: string, issuer: string | null, type: string} | undefined} Asset descriptor.
+ */
+function normalizeAsset(payload, errors) {
+  const assetSource = isPlainObject(payload.asset) ? payload.asset : payload;
+  const code = optionalString(assetSource.code || assetSource.assetCode || payload.assetCode);
+  const issuer = optionalString(assetSource.issuer || assetSource.assetIssuer || payload.assetIssuer);
+
+  if (!code) {
+    addError(errors, 'asset.code is required.');
+    return undefined;
+  }
+
+  const normalizedCode = code.toUpperCase();
+  if (!ASSET_CODE_PATTERN.test(normalizedCode)) {
+    addError(errors, 'asset.code must be 1-12 uppercase alphanumeric characters.');
+    return undefined;
+  }
+
+  if (normalizedCode === 'XLM') {
+    if (issuer) {
+      addError(errors, 'asset.issuer must be omitted for native XLM.');
+      return undefined;
+    }
+    return { code: normalizedCode, issuer: null, type: 'native' };
+  }
+
+  const normalizedIssuer = normalizePublicKey(issuer, 'asset.issuer', errors);
+  if (!normalizedIssuer) {
+    return undefined;
+  }
+
+  return { code: normalizedCode, issuer: normalizedIssuer, type: 'credit_alphanum' };
+}
+
+/**
+ * Normalizes and validates a signing mode value.
+ *
+ * @param {unknown} value - Raw signing mode.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized signing mode.
+ */
+function normalizeRequestedSigningMode(value, errors) {
+  const signingMode = optionalString(value);
+  if (!signingMode) {
+    return undefined;
+  }
+
+  const normalizedMode = signingMode.toLowerCase();
+  if (!Object.values(SIGNING_MODES).includes(normalizedMode)) {
+    addError(errors, 'signingMode must be "custodial" or "delegated".');
+    return undefined;
+  }
+
+  return normalizedMode;
+}
+
+/**
+ * Normalizes and validates an optional idempotency key.
+ *
+ * @param {unknown} value - Raw idempotency key.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized idempotency key.
+ */
+function normalizeIdempotencyKey(value, errors) {
+  const idempotencyKey = optionalString(value);
+  if (!idempotencyKey) {
+    return undefined;
+  }
+  if (!IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey)) {
+    addError(errors, 'idempotencyKey must be 8-128 URL-safe characters.');
+    return undefined;
+  }
+  return idempotencyKey;
+}
+
+/**
+ * Normalizes an optional short memo value.
+ *
+ * @param {unknown} value - Raw memo value.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized memo.
+ */
+function normalizeMemo(value, errors) {
+  const memo = optionalString(value);
+  if (!memo) {
+    return undefined;
+  }
+  if (memo.length > MAX_MEMO_LENGTH) {
+    addError(errors, `memo must be ${MAX_MEMO_LENGTH} characters or fewer.`);
+    return undefined;
+  }
+  return memo;
+}
+
+/**
+ * Normalizes optional metadata without allowing oversized audit payloads.
+ *
+ * @param {unknown} value - Raw metadata value.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {Object | undefined} Metadata object.
+ */
+function normalizeMetadata(value, errors) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(value)) {
+    addError(errors, 'metadata must be a JSON object when provided.');
+    return undefined;
+  }
+
+  const byteLength = Buffer.byteLength(JSON.stringify(value), 'utf8');
+  if (byteLength > MAX_METADATA_BYTES) {
+    addError(errors, `metadata must be ${MAX_METADATA_BYTES} bytes or fewer.`);
+    return undefined;
+  }
+
+  return value;
+}
+
+/**
+ * Normalizes an optional signed transaction envelope placeholder.
+ *
+ * @param {unknown} value - Raw signed XDR value.
+ * @param {string[]} errors - Validation error accumulator.
+ * @returns {string | undefined} Normalized XDR value.
+ */
+function normalizeSignedTransactionXdr(value, errors) {
+  const signedTransactionXdr = optionalString(value);
+  if (!signedTransactionXdr) {
+    return undefined;
+  }
+  if (signedTransactionXdr.length > 8192 || !XDR_PATTERN.test(signedTransactionXdr)) {
+    addError(errors, 'signedTransactionXdr must be base64 text no larger than 8192 characters.');
+    return undefined;
+  }
+  return signedTransactionXdr;
+}
+
+/**
+ * Validates and normalizes a funding request body.
+ *
+ * @param {unknown} payload - Raw request body.
+ * @param {Object} [options={}] - Request context.
+ * @param {string} [options.idempotencyKey] - Idempotency key from an HTTP header.
+ * @returns {Object} Normalized funding request.
+ */
+function validateFundingRequest(payload, options = {}) {
+  const errors = [];
+
+  if (!isPlainObject(payload)) {
+    throw createValidationError(['Escrow funding payload must be a JSON object.']);
+  }
+
+  const amountValue = payload.amount !== undefined && payload.amount !== null
+    ? payload.amount
+    : payload.fundedAmount;
+
+  const request = {
+    invoiceId: normalizeInvoiceId(payload.invoiceId, errors),
+    funderPublicKey: normalizePublicKey(payload.funderPublicKey, 'funderPublicKey', errors),
+    amount: normalizeAmount(amountValue, errors),
+    asset: normalizeAsset(payload, errors),
+    signingMode: normalizeRequestedSigningMode(payload.signingMode, errors),
+    idempotencyKey: normalizeIdempotencyKey(payload.idempotencyKey || options.idempotencyKey, errors),
+    memo: normalizeMemo(payload.memo, errors),
+    metadata: normalizeMetadata(payload.metadata, errors),
+    signedTransactionXdr: normalizeSignedTransactionXdr(payload.signedTransactionXdr, errors),
+    clientReference: normalizeIdempotencyKey(payload.clientReference, errors),
+  };
+
+  if (errors.length > 0) {
+    throw createValidationError(errors);
+  }
+
+  return request;
+}
+
+/**
+ * Reads and validates the configured signing mode.
+ *
+ * @param {NodeJS.ProcessEnv} env - Environment variable source.
+ * @returns {string} Configured signing mode.
+ */
+function normalizeConfiguredSigningMode(env) {
+  const rawMode = optionalString(env.ESCROW_SIGNING_MODE);
+  if (!rawMode) {
+    return DEFAULT_SIGNING_MODE;
+  }
+
+  const configuredMode = rawMode.toLowerCase();
+  if (!Object.values(SIGNING_MODES).includes(configuredMode)) {
+    throw createConfigurationError('ESCROW_SIGNING_MODE must be "custodial" or "delegated".');
+  }
+
+  return configuredMode;
+}
+
+/**
+ * Validates a configured Soroban RPC URL when present.
+ *
+ * @param {unknown} value - Raw URL value.
+ * @returns {string | null} Normalized URL or null.
+ */
+function normalizeConfiguredRpcUrl(value) {
+  const rpcUrl = optionalString(value);
+  if (!rpcUrl) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(rpcUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('Unsupported protocol');
+    }
+    return parsed.toString();
+  } catch {
+    throw createConfigurationError('SOROBAN_RPC_URL must be a valid HTTP(S) URL.');
+  }
+}
+
+/**
+ * Validates a configured Soroban contract ID when present.
+ *
+ * @param {unknown} value - Raw contract ID.
+ * @returns {string | null} Normalized contract ID or null.
+ */
+function normalizeConfiguredContractId(value) {
+  const contractId = optionalString(value);
+  if (!contractId) {
+    return null;
+  }
+  if (!SOROBAN_CONTRACT_ID_PATTERN.test(contractId)) {
+    throw createConfigurationError('LIQUIFACT_ESCROW_CONTRACT_ID must be a Soroban C... contract ID.');
+  }
+  return contractId;
+}
+
+/**
+ * Resolves env-driven signing configuration without exposing key material.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env] - Environment variable source.
+ * @param {string} [requestedMode] - Request-level signing mode override.
+ * @returns {Object} Redacted signing configuration.
+ */
+function resolveSigningConfig(env = process.env, requestedMode) {
+  const mode = requestedMode || normalizeConfiguredSigningMode(env);
+  const rpcUrl = normalizeConfiguredRpcUrl(env.SOROBAN_RPC_URL);
+  const networkPassphrase = optionalString(env.STELLAR_NETWORK_PASSPHRASE) || null;
+  const escrowContractId = normalizeConfiguredContractId(env.LIQUIFACT_ESCROW_CONTRACT_ID);
+  const custodialSigningEnabled = optionalString(env.ESCROW_CUSTODIAL_SIGNING_ENABLED) === 'true';
+  const custodialKeyId = optionalString(env.ESCROW_CUSTODIAL_KEY_ID) || null;
+  const custodialKmsProvider = optionalString(env.ESCROW_CUSTODIAL_KMS_PROVIDER) || null;
+
+  const networkReady = Boolean(rpcUrl && networkPassphrase && escrowContractId);
+  const custodialReady = Boolean(
+    custodialSigningEnabled &&
+      custodialKeyId &&
+      custodialKmsProvider &&
+      networkReady,
+  );
+
+  return {
+    mode,
+    network: {
+      ready: networkReady,
+      rpcUrlConfigured: Boolean(rpcUrl),
+      networkPassphrase,
+      escrowContractId,
+    },
+    custodial: {
+      ready: custodialReady,
+      enabled: custodialSigningEnabled,
+      keyConfigured: Boolean(custodialKeyId),
+      kmsProviderConfigured: Boolean(custodialKmsProvider),
+    },
+    delegated: {
+      ready: networkReady,
+    },
+  };
+}
+
+/**
+ * Builds the Soroban fund operation intent represented by this stub.
+ *
+ * @param {Object} request - Normalized funding request.
+ * @param {Object} config - Redacted signing configuration.
+ * @param {Object} options - Request context.
+ * @returns {Object} Funding operation intent.
+ */
+function buildFundingIntent(request, config, options) {
+  return {
+    operation: FUND_OPERATION,
+    invoiceId: request.invoiceId,
+    funderPublicKey: request.funderPublicKey,
+    amount: request.amount,
+    asset: request.asset,
+    contractId: config.network.escrowContractId,
+    networkPassphrase: config.network.networkPassphrase,
+    idempotencyKey: request.idempotencyKey || null,
+    memo: request.memo || null,
+    clientReference: request.clientReference || null,
+    metadata: request.metadata || null,
+    requestedAt: options.now.toISOString(),
+    requestedBy: options.userId ? String(options.userId) : null,
+  };
+}
+
+/**
+ * Determines the safe non-submission outcome for the current request.
+ *
+ * @param {Object} request - Normalized funding request.
+ * @param {Object} config - Redacted signing configuration.
+ * @returns {{status: string, reason: string, nextAction: string}} Stub outcome.
+ */
+function determineStubOutcome(request, config) {
+  if (config.mode === SIGNING_MODES.DELEGATED && !request.signedTransactionXdr) {
+    return {
+      status: SUBMISSION_STATUSES.REQUIRES_SIGNATURE,
+      reason: 'Delegated signing requires a client-signed transaction envelope before submission.',
+      nextAction: 'return_unsigned_transaction_xdr_when_soroban_builder_is_implemented',
+    };
+  }
+
+  if (config.mode === SIGNING_MODES.DELEGATED && !config.delegated.ready) {
+    return {
+      status: SUBMISSION_STATUSES.REQUIRES_CONFIGURATION,
+      reason: 'Delegated submission requires Soroban RPC, network passphrase, and escrow contract configuration.',
+      nextAction: 'configure_soroban_network_before_accepting_signed_xdr',
+    };
+  }
+
+  if (config.mode === SIGNING_MODES.CUSTODIAL && !config.custodial.ready) {
+    return {
+      status: SUBMISSION_STATUSES.REQUIRES_CONFIGURATION,
+      reason: 'Custodial signing requires explicit enablement plus KMS key, Soroban RPC, network passphrase, and contract configuration.',
+      nextAction: 'configure_custodial_signing_or_use_delegated_signing',
+    };
+  }
+
+  return {
+    status: SUBMISSION_STATUSES.STUBBED,
+    reason: 'Funding request validated, but this design stub never signs or submits a live Soroban transaction.',
+    nextAction: 'implement_soroban_transaction_build_sign_and_submit_pipeline',
+  };
+}
+
+/**
+ * Validates an escrow funding request and returns a no-submit Soroban intent.
+ *
+ * This service intentionally never signs with a custodial key and never sends
+ * a transaction to Soroban. Future live submission code must replace this
+ * stub behind explicit env gates and tests.
+ *
+ * @param {unknown} payload - Raw funding request payload.
+ * @param {Object} [options={}] - Request context.
+ * @param {NodeJS.ProcessEnv} [options.env=process.env] - Environment source.
+ * @param {Date} [options.now=new Date()] - Request timestamp.
+ * @param {string} [options.idempotencyKey] - Idempotency key from a header.
+ * @param {string | number} [options.userId] - Authenticated user identifier.
+ * @returns {Promise<Object>} Non-submitted funding intent result.
+ */
+async function submitEscrowFunding(payload, options = {}) {
+  const normalizedOptions = {
+    env: options.env || process.env,
+    now: options.now || new Date(),
+    idempotencyKey: options.idempotencyKey,
+    userId: options.userId,
+  };
+  const request = validateFundingRequest(payload, normalizedOptions);
+  const config = resolveSigningConfig(normalizedOptions.env, request.signingMode);
+  const outcome = determineStubOutcome(request, config);
+
+  return {
+    status: outcome.status,
+    submitted: false,
+    signingMode: config.mode,
+    reason: outcome.reason,
+    nextAction: outcome.nextAction,
+    intent: buildFundingIntent(request, config, normalizedOptions),
+    transaction: {
+      unsignedXdr: null,
+      signedXdrAccepted: Boolean(request.signedTransactionXdr),
+      hash: null,
+    },
+    controls: {
+      liveSubmissionEnabled: false,
+      custodialSigningReady: config.custodial.ready,
+      delegatedSubmissionReady: config.delegated.ready,
+      custodialKeyConfigured: config.custodial.keyConfigured,
+    },
+  };
+}
+
+module.exports = {
+  submitEscrowFunding,
+  validateFundingRequest,
+  resolveSigningConfig,
+  determineStubOutcome,
+  SIGNING_MODES,
+  SUBMISSION_STATUSES,
+};

--- a/tests/escrowSubmit.stub.test.js
+++ b/tests/escrowSubmit.stub.test.js
@@ -1,0 +1,270 @@
+'use strict';
+
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+
+const { createApp } = require('../src/index');
+const {
+  SIGNING_MODES,
+  SUBMISSION_STATUSES,
+  resolveSigningConfig,
+  submitEscrowFunding,
+} = require('../src/services/escrowSubmit');
+
+const PUBLIC_KEY = `G${'A'.repeat(55)}`;
+const CONTRACT_ID = `C${'A'.repeat(55)}`;
+const NOW = new Date('2026-04-25T12:00:00.000Z');
+
+function basePayload(overrides = {}) {
+  return {
+    invoiceId: 'inv_123',
+    funderPublicKey: PUBLIC_KEY,
+    amount: '100.0000000',
+    asset: { code: 'XLM' },
+    memo: 'inv_123',
+    ...overrides,
+  };
+}
+
+function networkEnv(overrides = {}) {
+  return {
+    SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+    STELLAR_NETWORK_PASSPHRASE: 'Test SDF Network ; September 2015',
+    LIQUIFACT_ESCROW_CONTRACT_ID: CONTRACT_ID,
+    ...overrides,
+  };
+}
+
+function authHeader() {
+  const token = jwt.sign({ id: 'user_123', role: 'user' }, process.env.JWT_SECRET || 'test-secret');
+  return { Authorization: `Bearer ${token}` };
+}
+
+describe('escrowSubmit design stub', () => {
+  it('prepares a delegated funding intent without signing or submitting', async () => {
+    const result = await submitEscrowFunding(basePayload({
+      idempotencyKey: 'fund-inv-123',
+      clientReference: 'client-ref-123',
+      metadata: { source: 'unit-test' },
+    }), {
+      env: {},
+      now: NOW,
+      userId: 'user_123',
+    });
+
+    expect(result.status).toBe(SUBMISSION_STATUSES.REQUIRES_SIGNATURE);
+    expect(result.submitted).toBe(false);
+    expect(result.signingMode).toBe(SIGNING_MODES.DELEGATED);
+    expect(result.controls.liveSubmissionEnabled).toBe(false);
+    expect(result.transaction).toEqual({
+      unsignedXdr: null,
+      signedXdrAccepted: false,
+      hash: null,
+    });
+    expect(result.intent).toMatchObject({
+      operation: 'fund_escrow',
+      invoiceId: 'inv_123',
+      funderPublicKey: PUBLIC_KEY,
+      amount: '100.0000000',
+      asset: { code: 'XLM', issuer: null, type: 'native' },
+      idempotencyKey: 'fund-inv-123',
+      clientReference: 'client-ref-123',
+      metadata: { source: 'unit-test' },
+      requestedAt: '2026-04-25T12:00:00.000Z',
+      requestedBy: 'user_123',
+    });
+  });
+
+  it('accepts fundedAmount and idempotency header aliases for the gateway stub', async () => {
+    const result = await submitEscrowFunding(basePayload({
+      amount: undefined,
+      fundedAmount: 25,
+      idempotencyKey: undefined,
+    }), {
+      env: {},
+      idempotencyKey: 'header-key-0001',
+      now: NOW,
+    });
+
+    expect(result.intent.amount).toBe('25');
+    expect(result.intent.idempotencyKey).toBe('header-key-0001');
+    expect(result.status).toBe(SUBMISSION_STATUSES.REQUIRES_SIGNATURE);
+  });
+
+  it('returns requires_configuration for custodial mode without KMS and network env', async () => {
+    const result = await submitEscrowFunding(basePayload({
+      signingMode: 'custodial',
+      asset: { code: 'USDC', issuer: PUBLIC_KEY },
+    }), {
+      env: { ESCROW_SIGNING_MODE: 'custodial' },
+      now: NOW,
+    });
+
+    expect(result.status).toBe(SUBMISSION_STATUSES.REQUIRES_CONFIGURATION);
+    expect(result.signingMode).toBe(SIGNING_MODES.CUSTODIAL);
+    expect(result.controls.custodialSigningReady).toBe(false);
+    expect(result.controls.custodialKeyConfigured).toBe(false);
+  });
+
+  it('accepts delegated signed XDR only as a non-submitted design stub', async () => {
+    const result = await submitEscrowFunding(basePayload({
+      signingMode: 'delegated',
+      signedTransactionXdr: 'AAAA',
+    }), {
+      env: networkEnv(),
+      now: NOW,
+    });
+
+    expect(result.status).toBe(SUBMISSION_STATUSES.STUBBED);
+    expect(result.submitted).toBe(false);
+    expect(result.transaction.signedXdrAccepted).toBe(true);
+    expect(result.controls.delegatedSubmissionReady).toBe(true);
+  });
+
+  it('requires network configuration before accepting delegated signed XDR for submission', async () => {
+    const result = await submitEscrowFunding(basePayload({
+      signedTransactionXdr: 'AAAA',
+    }), {
+      env: {},
+      now: NOW,
+    });
+
+    expect(result.status).toBe(SUBMISSION_STATUSES.REQUIRES_CONFIGURATION);
+    expect(result.nextAction).toBe('configure_soroban_network_before_accepting_signed_xdr');
+  });
+
+  it('does not expose custodial key identifiers when custodial env is configured', async () => {
+    const result = await submitEscrowFunding(basePayload({
+      signingMode: 'custodial',
+    }), {
+      env: networkEnv({
+        ESCROW_CUSTODIAL_SIGNING_ENABLED: 'true',
+        ESCROW_CUSTODIAL_KMS_PROVIDER: 'aws-kms',
+        ESCROW_CUSTODIAL_KEY_ID: 'liquifact/escrow/fund/v1',
+      }),
+      now: NOW,
+    });
+
+    expect(result.status).toBe(SUBMISSION_STATUSES.STUBBED);
+    expect(result.controls.custodialSigningReady).toBe(true);
+    expect(JSON.stringify(result)).not.toContain('liquifact/escrow/fund/v1');
+  });
+
+  it('rejects invalid funding payloads with collected validation details', async () => {
+    await expect(submitEscrowFunding({
+      invoiceId: '$bad',
+      funderPublicKey: 'bad-key',
+      amount: '0.00000000',
+      asset: { code: 'USDC' },
+      signingMode: 'offline',
+      idempotencyKey: 'bad key',
+      memo: 'x'.repeat(65),
+      metadata: 'not-an-object',
+      signedTransactionXdr: '*',
+      clientReference: 'short',
+    }, {
+      env: {},
+      now: NOW,
+    })).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      detail: expect.stringContaining('invoiceId contains unsupported characters.'),
+    });
+  });
+
+  it('rejects non-object payloads and oversize metadata', async () => {
+    await expect(submitEscrowFunding(null, { env: {}, now: NOW })).rejects.toMatchObject({
+      status: 400,
+      detail: 'Escrow funding payload must be a JSON object.',
+    });
+
+    await expect(submitEscrowFunding(basePayload({
+      invoiceId: undefined,
+      amount: '0',
+      asset: { code: 'TOO-LONG-ASSET-CODE' },
+    }), {
+      env: {},
+      now: NOW,
+    })).rejects.toMatchObject({
+      status: 400,
+      detail: expect.stringContaining('invoiceId is required.'),
+    });
+
+    await expect(submitEscrowFunding(basePayload({
+      asset: { code: 'XLM', issuer: PUBLIC_KEY },
+    }), {
+      env: {},
+      now: NOW,
+    })).rejects.toMatchObject({
+      status: 400,
+      detail: 'asset.issuer must be omitted for native XLM.',
+    });
+
+    await expect(submitEscrowFunding(basePayload({
+      metadata: { big: 'x'.repeat(2050) },
+    }), {
+      env: {},
+      now: NOW,
+    })).rejects.toMatchObject({
+      status: 400,
+      detail: expect.stringContaining('metadata must be 2048 bytes or fewer.'),
+    });
+  });
+
+  it('fails closed on invalid signing environment values', () => {
+    expect(resolveSigningConfig({ ESCROW_SIGNING_MODE: 'custodial' }).mode).toBe(
+      SIGNING_MODES.CUSTODIAL,
+    );
+    expect(() => resolveSigningConfig({ ESCROW_SIGNING_MODE: 'server' })).toThrow(
+      'Escrow Signing Configuration Error',
+    );
+    expect(() => resolveSigningConfig({ SOROBAN_RPC_URL: 'ftp://example.test' })).toThrow(
+      'Escrow Signing Configuration Error',
+    );
+    expect(() => resolveSigningConfig({ LIQUIFACT_ESCROW_CONTRACT_ID: 'bad-contract' })).toThrow(
+      'Escrow Signing Configuration Error',
+    );
+  });
+});
+
+describe('POST /api/escrow funding stub', () => {
+  it('returns a 202 no-submit funding intent for authenticated callers', async () => {
+    const response = await request(createApp())
+      .post('/api/escrow')
+      .set(authHeader())
+      .set('Idempotency-Key', 'fund-inv-123')
+      .send(basePayload());
+
+    expect(response.status).toBe(202);
+    expect(response.body.message).toBe(
+      'Escrow funding transaction prepared; no live transaction was signed or submitted.',
+    );
+    expect(response.body.data).toMatchObject({
+      status: SUBMISSION_STATUSES.REQUIRES_SIGNATURE,
+      submitted: false,
+      signingMode: SIGNING_MODES.DELEGATED,
+      controls: {
+        liveSubmissionEnabled: false,
+      },
+      intent: {
+        invoiceId: 'inv_123',
+        idempotencyKey: '***REDACTED***',
+      },
+    });
+  });
+
+  it('returns structured validation errors for invalid funding requests', async () => {
+    const response = await request(createApp())
+      .post('/api/escrow')
+      .set(authHeader())
+      .send({ invoiceId: '$' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      retryable: false,
+      retry_hint: 'Fix the escrow funding payload and try again.',
+    });
+    expect(response.body.error.message).toContain('invoiceId contains unsupported characters.');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #113.

- Added `src/services/escrowSubmit.js` as a secure no-live-signing Soroban escrow funding stub.
- Wired `POST /api/escrow` to return a validated `202` funding intent.
- Added delegated and custodial signing/key-management docs in `docs/ops-signing.md`.
- Added env docs for Soroban RPC, contract ID, signing mode, and KMS key references.
- Added focused Jest coverage for validation, custodial/delegated modes, route behavior, and no-submit guarantees.

## Validation

Passing:

- `npm run lint`
- `npm test -- tests/escrowSubmit.stub.test.js src/index.test.js`
- Focused coverage for `src/services/escrowSubmit.js`: 100% line coverage

Known existing full-suite issues unrelated to this PR:

- CORS tests currently fail on allowlist expectations.
- `tests/maturityReminders.test.js` fails because `nodemailer` is missing.
- `tests/security.middleware.test.js` has no tests.

## Security Notes

- No live Soroban signing or submission is performed.
- No raw Stellar secret keys are accepted or documented.
- Custodial mode requires explicit env gates and KMS/HSM key references.
- Delegated mode requires client signing before any future submission flow.
- Funding payloads validate Stellar public keys, asset shape, positive 7-decimal amounts, idempotency keys, metadata size, and bounded XDR input.
