### PR TITLE
feat: add Soroban tx submitter worker with retry logic

### DIFF
--- a/src/workers/txSubmitter.js
+++ b/src/workers/txSubmitter.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const JobQueue = require('./jobQueue');
+const BackgroundWorker = require('./worker');
+const logger = require('../logger');
+
+const DEFAULT_CONFIG = {
+  maxRetries: Math.min(parseInt(process.env.SOROBAN_TX_SUBMIT_MAX_RETRIES || '3', 10), 10),
+  baseDelayMs: Math.min(parseInt(process.env.SOROBAN_TX_SUBMIT_BASE_DELAY_MS || '500', 10), 10000),
+  maxDelayMs: Math.min(parseInt(process.env.SOROBAN_TX_SUBMIT_MAX_DELAY_MS || '20000', 10), 60000),
+  feeBumpMultiplier: Math.min(parseFloat(process.env.SOROBAN_TX_FEE_BUMP_MULTIPLIER || '2'), 10),
+};
+
+function isRetryableSubmitError(err) {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+
+  const code = String(err.code || '').toLowerCase();
+  if (['etimedout', 'econnreset', 'eai_again', 'enotfound'].includes(code)) {
+    return true;
+  }
+
+  const message = String(err.message || err).toLowerCase();
+  if (message.includes('tx_bad_seq') || message.includes('timeout') || message.includes('timed out') || message.includes('transaction_timeout')) {
+    return true;
+  }
+
+  const resultCode = err.result?.code || err.result?.result?.code;
+  if (typeof resultCode === 'string' && resultCode.toLowerCase().includes('tx_bad_seq')) {
+    return true;
+  }
+
+  return false;
+}
+
+function computeTxBackoff(attempt, baseDelay, maxDelay) {
+  const delay = Math.min(baseDelay * 2 ** attempt, maxDelay);
+  return Math.max(0, delay);
+}
+
+async function submitWithRetry(operation, config = {}) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  let lastError;
+
+  for (let attempt = 0; attempt <= cfg.maxRetries; attempt += 1) {
+    try {
+      return await operation({ attempt, feeBumpMultiplier: cfg.feeBumpMultiplier });
+    } catch (err) {
+      lastError = err;
+      const isLastAttempt = attempt === cfg.maxRetries;
+      if (isLastAttempt || !isRetryableSubmitError(err)) {
+        throw err;
+      }
+      const delayMs = computeTxBackoff(attempt, cfg.baseDelayMs, cfg.maxDelayMs);
+      logger.warn({ attempt, delayMs, error: err.message || err, retryable: true }, 'Retrying Soroban transaction submission after transient failure');
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}
+
+async function handleTxSubmitJob(job, submitTransactionFn, config = {}) {
+  if (!job || typeof job.payload !== 'object' || job.payload === null) {
+    throw new Error('Invalid tx submit job payload');
+  }
+  if (typeof submitTransactionFn !== 'function') {
+    throw new Error('submitTransactionFn must be supplied');
+  }
+
+  const payload = job.payload;
+  if (typeof payload.signedTransactionXdr !== 'string' || payload.signedTransactionXdr.trim() === '') {
+    throw new Error('signedTransactionXdr is required for transaction submission');
+  }
+
+  return submitWithRetry(async (context) => {
+    return submitTransactionFn(payload, context);
+  }, config);
+}
+
+function createTxSubmitterWorker(submitTransactionFn, options = {}) {
+  const txQueue = new JobQueue({ maxRetries: 0 });
+  const txWorker = new BackgroundWorker({ jobQueue: txQueue, pollIntervalMs: options.pollIntervalMs ?? 100, maxConcurrency: options.maxConcurrency ?? 1 });
+
+  txWorker.registerHandler('submit_soroban_tx', async (job) => {
+    return handleTxSubmitJob(job, submitTransactionFn, options.retryConfig);
+  });
+
+  return {
+    txQueue,
+    txWorker,
+    enqueueTxSubmission: (payload, enqueueOptions = {}) => txQueue.enqueue('submit_soroban_tx', payload, enqueueOptions),
+  };
+}
+
+module.exports = {
+  createTxSubmitterWorker,
+  submitWithRetry,
+  isRetryableSubmitError,
+  computeTxBackoff,
+  handleTxSubmitJob,
+  DEFAULT_CONFIG,
+};

--- a/tests/txSubmitter.test.js
+++ b/tests/txSubmitter.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const {
+  createTxSubmitterWorker,
+  submitWithRetry,
+  isRetryableSubmitError,
+  computeTxBackoff,
+  handleTxSubmitJob,
+} = require('../src/workers/txSubmitter');
+
+// Mock the logger to avoid dependency issues
+jest.mock('../src/logger', () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+
+describe('txSubmitter worker utilities', () => {
+  it('marks tx_bad_seq and timeout errors as retryable', () => {
+    expect(isRetryableSubmitError(new Error('tx_bad_seq'))).toBe(true);
+    expect(isRetryableSubmitError(new Error('transaction timed out'))).toBe(true);
+    expect(isRetryableSubmitError({ code: 'ETIMEDOUT' })).toBe(true);
+    expect(isRetryableSubmitError(new Error('bad signature'))).toBe(false);
+  });
+
+  it('computes exponential backoff correctly', () => {
+    expect(computeTxBackoff(0, 100, 1000)).toBe(100);
+    expect(computeTxBackoff(1, 100, 1000)).toBe(200);
+    expect(computeTxBackoff(4, 100, 500)).toBe(500);
+  });
+
+  it('retries transient failures and succeeds', async () => {
+    let attempts = 0;
+    const operation = jest.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        const error = new Error('tx_bad_seq');
+        error.code = 'TX_BAD_SEQ';
+        throw error;
+      }
+      return 'submitted';
+    });
+
+    await expect(submitWithRetry(operation, { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 })).resolves.toBe('submitted');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails immediately on non-retryable errors', async () => {
+    const operation = jest.fn(async () => {
+      throw new Error('invalid transaction');
+    });
+
+    await expect(submitWithRetry(operation, { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 })).rejects.toThrow('invalid transaction');
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles a worker job through the tx submitter worker', async () => {
+    let submitAttempts = 0;
+    const submitTransactionFn = jest.fn(async (payload, context) => {
+      submitAttempts += 1;
+      if (submitAttempts === 1) {
+        const err = new Error('tx_bad_seq');
+        err.code = 'TX_BAD_SEQ';
+        throw err;
+      }
+      return { status: 'ok', payload };
+    });
+
+    const { txQueue, txWorker, enqueueTxSubmission } = createTxSubmitterWorker(submitTransactionFn, {
+      pollIntervalMs: 10,
+      maxConcurrency: 1,
+      retryConfig: { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    txWorker.start();
+
+    const jobId = enqueueTxSubmission({ signedTransactionXdr: 'abcdef123' });
+    expect(jobId).toEqual(expect.stringContaining('job-'));
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const job = txQueue.getJob(jobId);
+    expect(job.status).toBe('completed');
+    expect(submitTransactionFn).toHaveBeenCalledTimes(2);
+
+    await txWorker.stop();
+  });
+
+  it('rejects invalid job payloads', async () => {
+    const submitTransactionFn = jest.fn();
+    await expect(handleTxSubmitJob({ payload: {} }, submitTransactionFn)).rejects.toThrow('signedTransactionXdr is required');
+  });
+});


### PR DESCRIPTION
- Add txSubmitter.js worker module with exponential backoff retry
- Support configurable retry attempts, delays, and fee bump multiplier
- Handle tx_bad_seq and timeout errors as retryable
- Add comprehensive Jest tests with mocked logger
- Integrate with existing JobQueue and BackgroundWorker patterns

Closes #121