### PR TITLE
feat(security): append-only audit log for admin actions and webhook deliveries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ REDIS_ESCROW_LEDGER_GAP_THRESHOLD=3
 
 # DB (when added)
 # DATABASE_URL=postgresql://user:pass@localhost:5432/liquifact
+# AUDIT_LOG_ENABLED=true
+# AUDIT_LOG_FAIL_CLOSED=false
 
 # --------------------
 # JWT Authentication |

--- a/README.md
+++ b/README.md
@@ -308,6 +308,48 @@ Unexpected error:
 
 ---
 
+## Security audit log (Issue #116)
+
+The backend now supports a database-backed append-only audit log for:
+
+- admin actions (for example, KYC state transitions or key-rotation operations)
+- webhook dispatch outcomes (success/failure with redacted payload fields)
+
+### Database migrations
+
+Run SQL migrations in order:
+
+- `migrations/202604260001_create_audit_log_events.sql`
+- `migrations/202604260002_enforce_audit_log_append_only.sql`
+
+`audit_log_events` is enforced as append-only at the database layer via triggers that reject `UPDATE` and `DELETE`.
+
+### Runtime behavior
+
+- `src/middleware/auditLog.js` attaches `req.audit` helpers:
+  - `req.audit.logAdminAction(...)`
+  - `req.audit.logWebhookDelivery(...)`
+- successful `POST|PUT|PATCH|DELETE` requests under `/api/admin/*` are auto-logged
+- sensitive fields are redacted before persistence (`password`, `token`, `secret`, `apiKey`, `privateKey`, etc.)
+
+### Example API usage
+
+Admin action example:
+
+```bash
+curl -X POST http://localhost:3001/api/admin/kyc/cus_42/approve \
+  -H "Authorization: Bearer <admin-jwt>" \
+  -H "x-admin-action: kyc.approve" \
+  -H "x-audit-target-type: kyc_profile" \
+  -H "x-audit-target-id: cus_42" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"manual review","privateKey":"redacted-at-write-time"}'
+```
+
+Webhook delivery logging is typically called internally from delivery workers/routes via `req.audit.logWebhookDelivery(...)`.
+
+---
+
 ## Load baseline suite
 
 The repo includes a focused load baseline suite for representative core endpoint reads:

--- a/migrations/202604260001_create_audit_log_events.sql
+++ b/migrations/202604260001_create_audit_log_events.sql
@@ -1,0 +1,24 @@
+-- Append-only audit ledger for admin actions and webhook deliveries.
+CREATE TABLE IF NOT EXISTS audit_log_events (
+  id BIGSERIAL PRIMARY KEY,
+  event_type VARCHAR(64) NOT NULL CHECK (event_type IN ('admin_action', 'webhook_delivery')),
+  action VARCHAR(128) NOT NULL,
+  actor_type VARCHAR(64) NOT NULL,
+  actor_id VARCHAR(255) NOT NULL,
+  target_type VARCHAR(128),
+  target_id VARCHAR(255),
+  request_id VARCHAR(128),
+  route TEXT,
+  method VARCHAR(16),
+  status_code INTEGER,
+  ip_address VARCHAR(64),
+  user_agent TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_events_event_type_created_at
+  ON audit_log_events (event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_events_actor
+  ON audit_log_events (actor_type, actor_id, created_at DESC);

--- a/migrations/202604260002_enforce_audit_log_append_only.sql
+++ b/migrations/202604260002_enforce_audit_log_append_only.sql
@@ -1,0 +1,20 @@
+-- Hard-enforce append-only semantics at the DB layer.
+CREATE OR REPLACE FUNCTION prevent_audit_log_update_or_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_log_events is append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_audit_log_no_update ON audit_log_events;
+DROP TRIGGER IF EXISTS trg_audit_log_no_delete ON audit_log_events;
+
+CREATE TRIGGER trg_audit_log_no_update
+BEFORE UPDATE ON audit_log_events
+FOR EACH ROW
+EXECUTE FUNCTION prevent_audit_log_update_or_delete();
+
+CREATE TRIGGER trg_audit_log_no_delete
+BEFORE DELETE ON audit_log_events
+FOR EACH ROW
+EXECUTE FUNCTION prevent_audit_log_update_or_delete();

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const { createCorsOptions } = require('./config/cors');
 const { correlationIdMiddleware } = require('./middleware/correlationId');
 const { jsonBodyLimit, urlencodedBodyLimit, payloadTooLargeHandler } = require('./middleware/bodySizeLimits');
 const { auditMiddleware } = require('./middleware/audit');
+const { auditLogMiddleware } = require('./middleware/auditLog');
 const { globalLimiter, sensitiveLimiter } = require('./middleware/rateLimit');
 const { authenticateToken } = require('./middleware/auth');
 const smeRouter = require('./routes/sme');
@@ -88,6 +89,7 @@ function createApp(options = {}) {
   app.use(jsonBodyLimit());
   app.use(urlencodedBodyLimit());
   app.use(globalLimiter);
+  app.use(auditLogMiddleware);
   app.use(auditMiddleware);
 
   app.use('/api/sme', smeRouter);

--- a/src/middleware/auditLog.js
+++ b/src/middleware/auditLog.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const { appendAuditEvent, redactValue } = require('../services/auditLogStore');
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function getActor(req) {
+  if (req.user && typeof req.user === 'object') {
+    if (req.user.id) {
+      return { actorType: 'user', actorId: String(req.user.id) };
+    }
+    if (req.user.sub) {
+      return { actorType: 'user', actorId: String(req.user.sub) };
+    }
+  }
+
+  if (req.apiClient && req.apiClient.clientId) {
+    return { actorType: 'api_client', actorId: String(req.apiClient.clientId) };
+  }
+
+  return { actorType: 'system', actorId: req.ip || 'unknown' };
+}
+
+function isAdminAction(req) {
+  return req.path.startsWith('/api/admin/');
+}
+
+function buildBaseEvent(req) {
+  const actor = getActor(req);
+  return {
+    ...actor,
+    requestId: req.id || req.headers['x-correlation-id'],
+    route: req.originalUrl || req.path,
+    method: req.method,
+    ipAddress: req.ip,
+    userAgent: req.get('user-agent') || null,
+  };
+}
+
+function createAuditContext(req) {
+  const baseEvent = buildBaseEvent(req);
+
+  return {
+    async logAdminAction(action, options = {}) {
+      await appendAuditEvent({
+        ...baseEvent,
+        eventType: 'admin_action',
+        action,
+        targetType: options.targetType || null,
+        targetId: options.targetId || null,
+        statusCode: options.statusCode,
+        metadata: {
+          before: redactValue(options.before || null),
+          after: redactValue(options.after || null),
+          ...options.metadata,
+        },
+      });
+    },
+    async logWebhookDelivery(options = {}) {
+      await appendAuditEvent({
+        ...baseEvent,
+        eventType: 'webhook_delivery',
+        action: options.action || 'webhook.dispatch',
+        targetType: 'webhook_endpoint',
+        targetId: options.endpointId || options.endpoint || null,
+        statusCode: options.statusCode,
+        metadata: redactValue({
+          endpoint: options.endpoint,
+          deliveryId: options.deliveryId,
+          outcome: options.outcome,
+          requestPayload: options.requestPayload,
+          responseBody: options.responseBody,
+          errorCode: options.errorCode,
+          errorMessage: options.errorMessage,
+          ...options.metadata,
+        }),
+      });
+    },
+  };
+}
+
+function auditLogMiddleware(req, res, next) {
+  req.audit = createAuditContext(req);
+
+  if (!MUTATION_METHODS.has(req.method.toUpperCase()) || !isAdminAction(req)) {
+    return next();
+  }
+
+  const action = req.headers['x-admin-action'] || `${req.method.toLowerCase()}.admin`;
+  const targetType = req.headers['x-audit-target-type'] || 'admin_resource';
+  const targetId = req.headers['x-audit-target-id'] || req.params.id || null;
+  const beforeSnapshot = req.body ? redactValue(req.body) : null;
+
+  res.on('finish', () => {
+    const statusCode = res.statusCode;
+    if (statusCode < 200 || statusCode >= 300) {
+      return;
+    }
+
+    req.audit
+      .logAdminAction(action, {
+        targetType,
+        targetId,
+        statusCode,
+        before: beforeSnapshot,
+        metadata: {
+          source: 'http',
+          autoLogged: true,
+        },
+      })
+      .catch((error) => {
+        req.log?.warn?.({ err: error }, 'failed to persist admin audit event');
+      });
+  });
+
+  return next();
+}
+
+module.exports = {
+  auditLogMiddleware,
+};

--- a/src/services/auditLogStore.js
+++ b/src/services/auditLogStore.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const db = require('../db/knex');
+
+const REDACTED = '***REDACTED***';
+const SENSITIVE_KEY_PATTERNS = [
+  /password/i,
+  /secret/i,
+  /token/i,
+  /api[-_]?key/i,
+  /authorization/i,
+  /private[-_]?key/i,
+  /seed/i,
+  /mnemonic/i,
+];
+
+function redactValue(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  const sanitized = {};
+  for (const [key, currentValue] of Object.entries(value)) {
+    if (SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key))) {
+      sanitized[key] = REDACTED;
+      continue;
+    }
+    sanitized[key] = redactValue(currentValue);
+  }
+  return sanitized;
+}
+
+function normalizeMetadata(metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return {};
+  }
+  return redactValue(metadata);
+}
+
+async function appendAuditEvent(event) {
+  const record = {
+    event_type: event.eventType,
+    action: event.action,
+    actor_type: event.actorType,
+    actor_id: event.actorId,
+    target_type: event.targetType || null,
+    target_id: event.targetId || null,
+    request_id: event.requestId || null,
+    route: event.route || null,
+    method: event.method || null,
+    status_code: Number.isInteger(event.statusCode) ? event.statusCode : null,
+    ip_address: event.ipAddress || null,
+    user_agent: event.userAgent || null,
+    metadata: JSON.stringify(normalizeMetadata(event.metadata)),
+  };
+
+  await db('audit_log_events').insert(record);
+}
+
+module.exports = {
+  appendAuditEvent,
+  redactValue,
+  REDACTED,
+};

--- a/tests/auditLog.test.js
+++ b/tests/auditLog.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+jest.mock('../src/db/knex');
+
+const express = require('express');
+const request = require('supertest');
+const db = require('../src/db/knex');
+const { auditLogMiddleware } = require('../src/middleware/auditLog');
+const { REDACTED } = require('../src/services/auditLogStore');
+
+describe('audit log middleware', () => {
+  let insertMock;
+  let app;
+
+  beforeEach(() => {
+    insertMock = jest.fn().mockResolvedValue([1]);
+    db.mockImplementation((tableName) => {
+      if (tableName !== 'audit_log_events') {
+        throw new Error(`unexpected table: ${tableName}`);
+      }
+      return { insert: insertMock };
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = { id: 'admin-user-1' };
+      next();
+    });
+    app.use(auditLogMiddleware);
+
+    app.post('/api/admin/kyc/:id/approve', (_req, res) => {
+      return res.status(200).json({ ok: true });
+    });
+
+    app.post('/api/webhooks/test', async (req, res, next) => {
+      try {
+        await req.audit.logWebhookDelivery({
+          endpoint: 'https://example.com/hooks/kyc',
+          endpointId: 'wh_123',
+          deliveryId: 'del_001',
+          outcome: 'failed',
+          statusCode: 500,
+          requestPayload: {
+            customerId: 'cus_123',
+            apiKey: 'super-secret-key',
+          },
+          responseBody: {
+            message: 'invalid signature',
+            token: 'response-token',
+          },
+          errorMessage: 'timeout',
+        });
+        return res.status(202).json({ accepted: true });
+      } catch (error) {
+        return next(error);
+      }
+    });
+  });
+
+  it('auto-logs successful admin actions as append-only inserts', async () => {
+    const response = await request(app)
+      .post('/api/admin/kyc/cus_42/approve')
+      .set('x-admin-action', 'kyc.approve')
+      .set('x-audit-target-type', 'kyc_profile')
+      .set('x-audit-target-id', 'cus_42')
+      .send({
+        reason: 'manual review completed',
+        privateKey: 'stellar-secret',
+      });
+
+    expect(response.status).toBe(200);
+
+    // finish handlers are async; flush microtasks before assertions.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    const inserted = insertMock.mock.calls[0][0];
+    expect(inserted.event_type).toBe('admin_action');
+    expect(inserted.action).toBe('kyc.approve');
+    expect(inserted.target_type).toBe('kyc_profile');
+    expect(inserted.target_id).toBe('cus_42');
+
+    const metadata = JSON.parse(inserted.metadata);
+    expect(metadata.before.privateKey).toBe(REDACTED);
+    expect(metadata.autoLogged).toBe(true);
+  });
+
+  it('supports explicit webhook delivery logging with redaction', async () => {
+    const response = await request(app)
+      .post('/api/webhooks/test')
+      .set('user-agent', 'jest-agent')
+      .send({ ok: true });
+
+    expect(response.status).toBe(202);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+
+    const inserted = insertMock.mock.calls[0][0];
+    expect(inserted.event_type).toBe('webhook_delivery');
+    expect(inserted.action).toBe('webhook.dispatch');
+    expect(inserted.target_id).toBe('wh_123');
+    expect(inserted.status_code).toBe(500);
+
+    const metadata = JSON.parse(inserted.metadata);
+    expect(metadata.requestPayload.apiKey).toBe(REDACTED);
+    expect(metadata.responseBody.token).toBe(REDACTED);
+    expect(metadata.endpoint).toBe('https://example.com/hooks/kyc');
+    expect(metadata.deliveryId).toBe('del_001');
+  });
+});


### PR DESCRIPTION
Closes #116
## Summary
- Adds DB-backed append-only audit logging for admin actions and webhook deliveries.
- Creates `audit_log_events` table and DB triggers that block UPDATE/DELETE.
- Adds middleware/helpers for admin mutation auto-logging and webhook delivery outcome logging.
- Redacts sensitive fields before persistence (`password`, `token`, `secret`, `apiKey`, `privateKey`, etc.).
- Adds tests and documentation updates.

## Security notes
- Append-only enforcement is at database layer (trigger-protected).
- Sensitive fields are redacted before write.
- No secrets committed; env-driven config remains in `.env`.

## Test plan
- [ ] Run migration `202604260001_create_audit_log_events.sql`
- [ ] Run migration `202604260002_enforce_audit_log_append_only.sql`
- [ ] `npm test -- tests/auditLog.test.js`
- [ ] `npm run test:coverage`
- [ ] Verify >=95% coverage on changed/new backend code

## API examples
```bash
curl -X POST http://localhost:3001/api/admin/kyc/cus_42/approve \
  -H "Authorization: Bearer <admin-jwt>" \
  -H "x-admin-action: kyc.approve" \
  -H "x-audit-target-type: kyc_profile" \
  -H "x-audit-target-id: cus_42" \
  -H "Content-Type: application/json" \
  -d '{"reason":"manual review","privateKey":"will-be-redacted"}'