### PR TITLE
feat(api): mount feature routers into createApp

### DIFF
--- a/docs/API-Examples.md
+++ b/docs/API-Examples.md
@@ -15,6 +15,30 @@ All protected endpoints require a Bearer token:
 export TOKEN="your-jwt-token-here"
 ```
 
+## Mounted Feature Routes
+
+The live Express app factory mounts the feature routers before the 404 handler, so these prefixes are available from the running API:
+
+| Area | Prefix | Example |
+| --- | --- | --- |
+| Invest | `/api/invest` | `GET /api/invest/opportunities` |
+| Marketplace | `/api/marketplace` | `GET /api/marketplace?sortBy=yield_bps&order=desc` |
+| Retention | `/api/retention` | `GET /api/retention/policies` |
+| Invoice state | `/api/invoices` | `GET /api/invoices/inv-001/state` |
+| Admin escrow | `/api/admin/escrow` | `GET /api/admin/escrow/version` |
+| SME | `/api/sme` | `GET /api/sme/metrics` |
+| Versioned API | `/v1` | `GET /v1/health` |
+
+Protected routes continue to require the route-level authentication already defined by each router. Retention operations are tenant-scoped, so service callers should also provide tenant context where applicable:
+
+```bash
+curl "$BASE_URL/api/retention/policies" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-tenant-id: tenant_123"
+```
+
+Invoice state routes are mounted at `/api/invoices` because the router owns its `/:id/state`, `/:id/transition`, `/:id/approve`, `/:id/link-escrow`, `/:id/history`, and `/:id/reject` paths.
+
 ## Error Response Examples
 
 ### 1. Validation Error (400)

--- a/src/app.js
+++ b/src/app.js
@@ -35,6 +35,13 @@ const { performHealthChecks } = require('./services/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
+const investRoutes = require('./routes/invest');
+const marketplaceRoutes = require('./routes/marketplace');
+const retentionRoutes = require('./routes/retention');
+const invoiceStateRoutes = require('./routes/invoiceStateRoutes');
+const adminEscrowRoutes = require('./routes/adminEscrow');
+const smeRoutes = require('./routes/sme');
+const v1Routes = require('./routes/v1');
 
 /**
  * Returns a 403 JSON response only for the dedicated blocked-origin CORS error.
@@ -244,12 +251,21 @@ function createApp() {
   // ── 5. Prometheus metrics ────────────────────────────────────────────────
   app.get('/metrics', metricsAuth, metricsHandler);
 
-  // ── 6. 404 catch-all ─────────────────────────────────────────────────────
+  // ── 6. Feature routers ───────────────────────────────────────────────────
+  app.use('/api/invest', investRoutes);
+  app.use('/api/marketplace', marketplaceRoutes);
+  app.use('/api/retention', retentionRoutes);
+  app.use('/api/invoices', invoiceStateRoutes);
+  app.use('/api/admin/escrow', adminEscrowRoutes);
+  app.use('/api/sme', smeRoutes);
+  app.use('/v1', v1Routes);
+
+  // ── 7. 404 catch-all ─────────────────────────────────────────────────────
   app.use((req, res) => {
     res.status(404).json({ error: 'Not found', path: req.path });
   });
 
-  // ── 6 – 8. Error handlers (order matters) ────────────────────────────────
+  // ── 8 – 10. Error handlers (order matters) ───────────────────────────────
   app.use(handleCorsError);
   app.use(payloadTooLargeHandler);
   app.use(handleInternalError);

--- a/tests/app.routes.test.js
+++ b/tests/app.routes.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+jest.mock('../src/services/health', () => ({
+  performHealthChecks: jest.fn(),
+}));
+
+jest.mock('../src/services/marketplaceService', () => ({
+  getMarketplaceInvoices: jest.fn(),
+}));
+
+jest.mock('../src/config/escrowVersions', () => ({
+  getOnChainSchemaVersion: jest.fn(),
+  compareVersions: jest.fn(),
+}));
+
+jest.mock('../src/db/knex', () => {
+  function createQuery(result) {
+    const query = {
+      where: jest.fn(() => query),
+      whereNull: jest.fn(() => query),
+      orderBy: jest.fn(() => query),
+      select: jest.fn(() => query),
+      insert: jest.fn(() => query),
+      update: jest.fn(() => query),
+      returning: jest.fn(() => Promise.resolve(result)),
+      first: jest.fn(() => Promise.resolve(Array.isArray(result) ? result[0] || null : result)),
+      then: (resolve, reject) => Promise.resolve(result).then(resolve, reject),
+      catch: (reject) => Promise.resolve(result).catch(reject),
+    };
+    return query;
+  }
+
+  return jest.fn(() => createQuery([]));
+});
+
+const { performHealthChecks } = require('../src/services/health');
+const marketplaceService = require('../src/services/marketplaceService');
+const escrowVersions = require('../src/config/escrowVersions');
+const app = require('../src/app');
+
+function authHeader(payload = {}) {
+  const token = jwt.sign(
+    {
+      sub: 'user_1',
+      id: 'user_1',
+      tenantId: 'tenant_test',
+      ...payload,
+    },
+    process.env.JWT_SECRET || 'test-secret'
+  );
+
+  return `Bearer ${token}`;
+}
+
+describe('Mounted feature routers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    performHealthChecks.mockResolvedValue({
+      healthy: true,
+      checks: {
+        database: { healthy: true },
+        soroban: { healthy: true },
+      },
+    });
+    marketplaceService.getMarketplaceInvoices.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    });
+    escrowVersions.getOnChainSchemaVersion.mockResolvedValue(3);
+    escrowVersions.compareVersions.mockReturnValue({
+      status: 'current',
+      knownVersion: '1.2.0',
+    });
+  });
+
+  it('preserves existing health behavior', async () => {
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('ok');
+    expect(res.body.data.service).toBe('liquifact-api');
+  });
+
+  it('preserves existing ready behavior', async () => {
+    const res = await request(app).get('/ready');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ready).toBe(true);
+    expect(performHealthChecks).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves existing metrics auth behavior', async () => {
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('mounts invest routes under /api/invest', async () => {
+    const res = await request(app)
+      .get('/api/invest/opportunities')
+      .set('Authorization', authHeader());
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('mounts marketplace routes under /api/marketplace', async () => {
+    const res = await request(app)
+      .get('/api/marketplace')
+      .set('Authorization', authHeader());
+
+    expect(res.status).not.toBe(404);
+    expect(marketplaceService.getMarketplaceInvoices).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts retention routes under /api/retention', async () => {
+    const res = await request(app)
+      .get('/api/retention/policies')
+      .set('Authorization', authHeader())
+      .set('x-tenant-id', 'tenant_test');
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('mounts invoice state routes under /api/invoices', async () => {
+    const res = await request(app).get('/api/invoices/inv-001/state');
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('mounts admin escrow routes under /api/admin/escrow', async () => {
+    const res = await request(app)
+      .get('/api/admin/escrow/version')
+      .set('Authorization', authHeader());
+
+    expect(res.status).not.toBe(404);
+    expect(escrowVersions.getOnChainSchemaVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts sme routes under /api/sme', async () => {
+    const res = await request(app)
+      .get('/api/sme/metrics')
+      .set('Authorization', authHeader());
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('mounts v1 routes under /v1', async () => {
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).not.toBe(404);
+  });
+});


### PR DESCRIPTION
Ready for review!!

Implemented:

  - Mounted feature routers in src/app.js:
      - /api/invest
      - /api/marketplace
      - /api/retention
      - /api/invoices for /:id/state invoice-state routes
      - /api/admin/escrow
      - /api/sme
      - /v1
  - Added Supertest smoke coverage in tests/app.routes.test.js.
  - Updated docs/API-Examples.md with the live mounted route prefixes.


closes #196 