### PR TITLE
feat(webhooks): add timestamped replay-resistant signatures

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -49,11 +49,80 @@ Webhooks are configured per tenant in the `tenants.settings` JSONB field:
 
 ## Security
 
-Each webhook request includes an `X-Signature` header containing the HMAC-SHA256 signature of the JSON payload using the configured secret.
+Each webhook request includes an `X-Signature` header containing a timestamped HMAC-SHA256 signature using the configured secret.
 
-To verify:
-1. Compute HMAC-SHA256 of the raw JSON payload using the secret.
-2. Compare with the `X-Signature` header.
+### Signature Format
+
+The signature header uses the format `X-Signature: t=<timestamp>,v1=<signature>` where:
+- `t` is a Unix timestamp (seconds) of when the webhook was signed
+- `v1` is the signature version identifier
+- Both are required for proper verification
+
+### Signature Construction
+
+1. Generate a Unix timestamp (seconds since epoch).
+2. Create the signed payload string: `"<timestamp>.<raw_json_body>"` (e.g., `"1704110400.{...}"`)
+3. Compute HMAC-SHA256 of the signed payload using your webhook secret.
+4. Include in the request header: `X-Signature: t=<timestamp>,v1=<hex_signature>`
+
+### Verifying Webhook Signatures (Receiver)
+
+To verify a webhook signature on the receiver side:
+
+**Security Best Practices:**
+1. **Use constant-time comparison** - Use `crypto.timingSafeEqual()` or equivalent to prevent timing attacks when comparing signatures.
+2. **Validate the timestamp** - Reject webhooks with timestamps older than 5 minutes (recommended tolerance window) to prevent replay attacks.
+3. **Keep the secret secure** - Never log or expose your webhook secret. Store it in environment variables or a secure secrets manager.
+4. **Parse carefully** - Extract `t=` and `v1=` parameters from the signature header before verification.
+
+**Verification Steps (Node.js example):**
+```javascript
+const crypto = require('crypto');
+
+function verifyWebhook(rawBody, signatureHeader, secret, toleranceMs = 5 * 60 * 1000) {
+  const parts = signatureHeader.split(',');
+  let timestamp = null;
+  let signature = null;
+
+  for (const part of parts) {
+    if (part.startsWith('t=')) {
+      timestamp = parseInt(part.slice(2), 10);
+    } else if (part.startsWith('v1=')) {
+      signature = part.slice(3);
+    }
+  }
+
+  if (!timestamp || !signature) {
+    throw new Error('Invalid signature header format');
+  }
+
+  // Check for replay attacks
+  const now = Date.now();
+  if (Math.abs(now - timestamp * 1000) > toleranceMs) {
+    throw new Error('Timestamp outside tolerance window');
+  }
+
+  // Compute expected signature
+  const signedPayload = `${timestamp}.${rawBody}`;
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(signedPayload)
+    .digest('hex');
+
+  // Use constant-time comparison
+  if (!crypto.timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expectedSignature, 'hex'))) {
+    throw new Error('Invalid signature');
+  }
+
+  return true;
+}
+```
+
+**Replay Protection:**
+The timestamp in the signature allows receivers to detect and reject replayed webhooks. We recommend a tolerance window of 5 minutes (300,000 ms), which can be configured. Any webhook with a timestamp outside this window should be rejected.
+
+**Idempotency Recommendation:**
+While signatures prevent tampering and replay, consider implementing idempotency on the receiver side to handle duplicate legitimate webhook deliveries gracefully. The `invoiceId` in the payload can be used as an idempotency key.
 
 ## Delivery
 

--- a/src/services/webhooks.js
+++ b/src/services/webhooks.js
@@ -5,6 +5,35 @@ const axios = require('axios');
 const db = require('../db/knex');
 const logger = require('../logger');
 
+const SIGNATURE_VERSION = 'v1';
+const TOLERANCE_MS = 5 * 60 * 1000;
+
+/**
+ * Creates an HMAC-SHA256 signature for the given payload and timestamp.
+ *
+ * @param {string} secret - The webhook secret.
+ * @param {string} rawBody - The raw JSON payload string.
+ * @param {number} timestamp - Unix timestamp in seconds.
+ * @returns {string} The hex-encoded signature.
+ */
+function createSignature(secret, rawBody, timestamp) {
+  const signedPayload = `${timestamp}.${rawBody}`;
+  return crypto.createHmac('sha256', secret).update(signedPayload).digest('hex');
+}
+
+/**
+ * Creates a signature header in the format t=<timestamp>,v1=<signature>.
+ *
+ * @param {string} secret - The webhook secret.
+ * @param {string} rawBody - The raw JSON payload string.
+ * @returns {string} The signature header string.
+ */
+function createSignatureHeader(secret, rawBody) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = createSignature(secret, rawBody, timestamp);
+  return `t=${timestamp},v1=${signature}`;
+}
+
 /**
  * Emits a webhook for escrow events.
  *
@@ -15,7 +44,6 @@ const logger = require('../logger');
  */
 async function emitWebhook(event, invoiceId, additionalData = {}) {
   try {
-    // Get tenant_id from invoice
     const invoice = await db('invoices').select('tenant_id').where('id', invoiceId).first();
     if (!invoice) {
       logger.warn({ invoiceId }, 'Invoice not found for webhook emission');
@@ -24,7 +52,6 @@ async function emitWebhook(event, invoiceId, additionalData = {}) {
 
     const { tenant_id } = invoice;
 
-    // Get tenant settings
     const tenant = await db('tenants').select('settings').where('id', tenant_id).first();
     if (!tenant || !tenant.settings) {
       logger.warn({ tenant_id, invoiceId }, 'Tenant settings not found for webhook');
@@ -37,7 +64,6 @@ async function emitWebhook(event, invoiceId, additionalData = {}) {
       return;
     }
 
-    // Create payload
     const payload = {
       event,
       timestamp: new Date().toISOString(),
@@ -45,25 +71,69 @@ async function emitWebhook(event, invoiceId, additionalData = {}) {
       ...additionalData,
     };
 
-    // Sign payload
-    const signature = crypto.createHmac('sha256', webhook_secret).update(JSON.stringify(payload)).digest('hex');
+    const rawBody = JSON.stringify(payload);
+    const signatureHeader = createSignatureHeader(webhook_secret, rawBody);
 
-    // Send webhook
     await axios.post(webhook_url, payload, {
       headers: {
         'Content-Type': 'application/json',
-        'X-Signature': signature,
+        'X-Signature': signatureHeader,
       },
-      timeout: 5000, // 5 second timeout
+      timeout: 5000,
     });
 
     logger.info({ event, invoiceId, tenant_id }, 'Webhook emitted successfully');
   } catch (error) {
     logger.error({ event, invoiceId, error: error.message }, 'Failed to emit webhook');
-    // For now, log error; retries not implemented yet
   }
+}
+
+/**
+ * Verifies a webhook signature with timestamp tolerance.
+ *
+ * @param {string} secret - The webhook secret.
+ * @param {string} rawBody - The raw JSON payload string.
+ * @param {string} signatureHeader - The X-Signature header value.
+ * @param {number} [toleranceMs=TOLERANCE_MS] - Tolerance window in milliseconds.
+ * @returns {Object} Result object with valid boolean and optional error message.
+ */
+function verifySignature(secret, rawBody, signatureHeader, toleranceMs = TOLERANCE_MS) {
+  const parts = signatureHeader.split(',');
+  let timestamp = null;
+  let signature = null;
+
+  for (const part of parts) {
+    if (part.startsWith('t=')) {
+      timestamp = parseInt(part.slice(2), 10);
+    } else if (part.startsWith('v1=')) {
+      signature = part.slice(3);
+    }
+  }
+
+  if (!timestamp || !signature) {
+    return { valid: false, error: 'Invalid signature header format' };
+  }
+
+  const now = Date.now();
+  const timestampMs = timestamp * 1000;
+  if (Math.abs(now - timestampMs) > toleranceMs) {
+    return { valid: false, error: 'Timestamp outside tolerance window' };
+  }
+
+  const expectedSignature = createSignature(secret, rawBody, timestamp);
+  const valid = crypto.timingSafeEqual(
+    Buffer.from(signature, 'hex'),
+    Buffer.from(expectedSignature, 'hex')
+  );
+
+  return { valid, error: valid ? null : 'Signature mismatch' };
 }
 
 module.exports = {
   emitWebhook,
+  verifySignature,
+  createSignature,
+  createSignatureHeader,
+  SIGNATURE_VERSION,
+  TOLERANCE_MS,
 };

--- a/tests/webhooks.signing.test.js
+++ b/tests/webhooks.signing.test.js
@@ -2,7 +2,6 @@
 
 process.env.NODE_ENV = 'test';
 
-// Mock dependencies
 jest.mock('axios');
 jest.mock('../src/db/knex', () => jest.fn());
 jest.mock('../src/logger', () => ({
@@ -14,7 +13,14 @@ jest.mock('../src/logger', () => ({
 const axios = require('axios');
 const db = require('../src/db/knex');
 const logger = require('../src/logger');
-const { emitWebhook } = require('../src/services/webhooks');
+const {
+  emitWebhook,
+  verifySignature,
+  createSignature,
+  createSignatureHeader,
+  SIGNATURE_VERSION,
+  TOLERANCE_MS,
+} = require('../src/services/webhooks');
 
 describe('webhooks service', () => {
   beforeEach(() => {
@@ -23,7 +29,6 @@ describe('webhooks service', () => {
 
   describe('emitWebhook', () => {
     it('emits webhook successfully for valid tenant and settings', async () => {
-      // Mock DB queries
       const mockDb = jest.fn();
       const mockSelect = jest.fn().mockReturnThis();
       const mockWhere = jest.fn().mockReturnThis();
@@ -35,13 +40,11 @@ describe('webhooks service', () => {
         },
       });
 
-      // Mock knex chain for invoices
       mockDb.mockReturnValueOnce({
         select: mockSelect,
         where: jest.fn().mockReturnThis(),
         first: mockFirstInvoice,
       });
-      // Mock knex chain for tenants
       mockDb.mockReturnValueOnce({
         select: mockSelect,
         where: jest.fn().mockReturnThis(),
@@ -50,7 +53,6 @@ describe('webhooks service', () => {
 
       db.mockImplementation(mockDb);
 
-      // Mock axios
       axios.post.mockResolvedValue({ status: 200 });
 
       const event = 'escrow_funded';
@@ -59,11 +61,9 @@ describe('webhooks service', () => {
 
       await emitWebhook(event, invoiceId, additionalData);
 
-      // Verify DB queries
       expect(db).toHaveBeenCalledWith('invoices');
       expect(db).toHaveBeenCalledWith('tenants');
 
-      // Verify axios call
       expect(axios.post).toHaveBeenCalledWith(
         'https://example.com/webhook',
         expect.objectContaining({
@@ -74,13 +74,12 @@ describe('webhooks service', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
-            'X-Signature': expect.any(String),
+            'X-Signature': expect.stringMatching(/^t=\d+,v1=[a-f0-9]{64}$/),
           }),
           timeout: 5000,
         })
       );
 
-      // Verify logger
       expect(logger.info).toHaveBeenCalledWith(
         { event, invoiceId, tenant_id: 'tenant_123' },
         'Webhook emitted successfully'
@@ -162,39 +161,164 @@ describe('webhooks service', () => {
         'Failed to emit webhook'
       );
     });
+  });
 
-    it('verifies HMAC signature', async () => {
-      const webhookSecret = 'secret123';
-      db.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        first: jest.fn()
-          .mockResolvedValueOnce({ tenant_id: 'tenant_123' })
-          .mockResolvedValueOnce({
-            settings: {
-              webhook_url: 'https://example.com/webhook',
-              webhook_secret: webhookSecret,
-            },
-          }),
-      });
+  describe('signature construction', () => {
+    it('creates signature with t=v1 format', () => {
+      const secret = 'secret123';
+      const rawBody = JSON.stringify({ event: 'escrow_funded', invoiceId: 'inv_123' });
+      const signatureHeader = createSignatureHeader(secret, rawBody);
 
-      axios.post.mockResolvedValue({ status: 200 });
+      expect(signatureHeader).toMatch(/^t=\d+,v1=[a-f0-9]{64}$/);
+      const parts = signatureHeader.split(',');
+      expect(parts[0]).toMatch(/^t=\d+$/);
+      expect(parts[1]).toMatch(/^v1=[a-f0-9]{64}$/);
+    });
 
-      const event = 'escrow_funded';
-      const invoiceId = 'inv_123';
-      const additionalData = { amount: 1000 };
+    it('creates consistent signature for same inputs', () => {
+      const secret = 'secret123';
+      const rawBody = JSON.stringify({ event: 'escrow_funded', invoiceId: 'inv_123' });
+      const timestamp = Math.floor(Date.now() / 1000);
 
-      await emitWebhook(event, invoiceId, additionalData);
+      const sig1 = createSignature(secret, rawBody, timestamp);
+      const sig2 = createSignature(secret, rawBody, timestamp);
 
-      const callArgs = axios.post.mock.calls[0];
-      const payload = callArgs[1];
-      const signature = callArgs[2].headers['X-Signature'];
+      expect(sig1).toBe(sig2);
+    });
 
-      // Verify signature
-      const crypto = require('crypto');
-      const expectedSignature = crypto.createHmac('sha256', webhookSecret).update(JSON.stringify(payload)).digest('hex');
+    it('creates different signatures for different payloads', () => {
+      const secret = 'secret123';
+      const rawBody1 = JSON.stringify({ event: 'escrow_funded', invoiceId: 'inv_123' });
+      const rawBody2 = JSON.stringify({ event: 'escrow_settled', invoiceId: 'inv_123' });
+      const timestamp = Math.floor(Date.now() / 1000);
 
-      expect(signature).toBe(expectedSignature);
+      const sig1 = createSignature(secret, rawBody1, timestamp);
+      const sig2 = createSignature(secret, rawBody2, timestamp);
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('creates different signatures for different secrets', () => {
+      const secret1 = 'secret123';
+      const secret2 = 'different_secret';
+      const rawBody = JSON.stringify({ event: 'escrow_funded', invoiceId: 'inv_123' });
+      const timestamp = Math.floor(Date.now() / 1000);
+
+      const sig1 = createSignature(secret1, rawBody, timestamp);
+      const sig2 = createSignature(secret2, rawBody, timestamp);
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('creates different signatures for different timestamps', () => {
+      const secret = 'secret123';
+      const rawBody = JSON.stringify({ event: 'escrow_funded', invoiceId: 'inv_123' });
+
+      const sig1 = createSignature(secret, rawBody, 1000000);
+      const sig2 = createSignature(secret, rawBody, 2000000);
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('exports SIGNATURE_VERSION as v1', () => {
+      expect(SIGNATURE_VERSION).toBe('v1');
+    });
+
+    it('exports TOLERANCE_MS as 5 minutes', () => {
+      expect(TOLERANCE_MS).toBe(5 * 60 * 1000);
+    });
+  });
+
+  describe('verifySignature', () => {
+    const secret = 'test_secret';
+    const rawBody = JSON.stringify({ event: 'escrow_funded', invoiceId: 'inv_123' });
+
+    it('returns valid for correct signature', () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signatureHeader = `t=${timestamp},v1=${createSignature(secret, rawBody, timestamp)}`;
+
+      const result = verifySignature(secret, rawBody, signatureHeader);
+
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it('returns invalid for tampered payload', () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const originalSignature = createSignature(secret, rawBody, timestamp);
+      const signatureHeader = `t=${timestamp},v1=${originalSignature}`;
+      const tamperedBody = JSON.stringify({ event: 'escrow_settled', invoiceId: 'inv_123' });
+
+      const result = verifySignature(secret, tamperedBody, signatureHeader);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Signature mismatch');
+    });
+
+    it('returns invalid for tampered timestamp in header', () => {
+      const originalTimestamp = Math.floor(Date.now() / 1000);
+      const tamperedTimestamp = originalTimestamp + 100;
+      const originalSignature = createSignature(secret, rawBody, originalTimestamp);
+      const signatureHeader = `t=${tamperedTimestamp},v1=${originalSignature}`;
+
+      const result = verifySignature(secret, rawBody, signatureHeader);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Signature mismatch');
+    });
+
+    it('returns invalid for incorrect secret', () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signatureHeader = `t=${timestamp},v1=${createSignature(secret, rawBody, timestamp)}`;
+
+      const result = verifySignature('wrong_secret', rawBody, signatureHeader);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Signature mismatch');
+    });
+
+    it('returns invalid for timestamp outside tolerance window', () => {
+      const oldTimestamp = Math.floor(Date.now() / 1000) - 10 * 60;
+      const signatureHeader = `t=${oldTimestamp},v1=${createSignature(secret, rawBody, oldTimestamp)}`;
+
+      const result = verifySignature(secret, rawBody, signatureHeader, 5 * 60 * 1000);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Timestamp outside tolerance window');
+    });
+
+    it('accepts timestamp within tolerance window', () => {
+      const recentTimestamp = Math.floor(Date.now() / 1000) - 2 * 60;
+      const signatureHeader = `t=${recentTimestamp},v1=${createSignature(secret, rawBody, recentTimestamp)}`;
+
+      const result = verifySignature(secret, rawBody, signatureHeader, 5 * 60 * 1000);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns invalid for missing timestamp in signature header', () => {
+      const signatureHeader = `v1=abc123`;
+
+      const result = verifySignature(secret, rawBody, signatureHeader);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid signature header format');
+    });
+
+    it('returns invalid for missing signature in header', () => {
+      const signatureHeader = `t=1234567890`;
+
+      const result = verifySignature(secret, rawBody, signatureHeader);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid signature header format');
+    });
+
+    it('returns invalid for malformed signature header', () => {
+      const result = verifySignature(secret, rawBody, 'invalid-format');
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid signature header format');
     });
   });
 });


### PR DESCRIPTION
## Closes #221 
## Summary
This PR implements timestamped HMAC-SHA256 webhook signatures with replay protection to address security vulnerability 

## Changes

### src/services/webhooks.js
- Added `SIGNATURE_VERSION` ('v1') and `TOLERANCE_MS` (5 minutes) constants
- Added `createSignature(secret, rawBody, timestamp)` - signs `timestamp.rawBody` with HMAC-SHA256
- Added `createSignatureHeader(secret, rawBody)` - returns `t=<timestamp>,v1=<signature>` format
- Added `verifySignature(secret, rawBody, signatureHeader, toleranceMs)` - validates signatures with:
  - Format validation (parsing t= and v1= parameters)
  - Timestamp tolerance window check (default 5 minutes)
  - Constant-time comparison via `crypto.timingSafeEqual()`
- Updated `emitWebhook` to use new signature scheme
- Exported all new functions and constants

### tests/webhooks.signing.test.js
- 21 tests with 100% line coverage:
  - Signature header format validation (t=, v1= format)
  - Consistent signatures for same inputs
  - Different signatures for different payloads/secrets/timestamps
  - Correct signature construction verification
  - Tampered payload detection
  - Tampered timestamp detection
  - Incorrect secret detection
  - Out-of-window timestamp rejection
  - Invalid header format handling

### docs/webhooks.md
- Added Signature Format section explaining `t=<timestamp>,v1=<signature>` structure
- Added Signature Construction section for webhook senders
- Added Verifying Webhook Signatures section with:
  - Node.js verification code example
  - Security best practices (constant-time comparison, timestamp validation, secret handling)
  - Replay protection guidance (5-minute tolerance window)
  - Idempotency recommendations

## Security Notes

1. **Replay Protection**: The timestamp allows receivers to reject webhooks older than the tolerance window
2. **Timing Attack Prevention**: `crypto.timingSafeEqual()` used for constant-time signature comparison
3. **Secret Handling**: Secrets are never logged; passed only to HMAC computation
4. **Versioned Scheme**: v1 identifier allows future signature algorithm rotation

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
-------------|---------|----------|---------|---------|
File         | % Stmts | % Branch | % Funcs | % Lines |
webhooks.js  |     100 |      100 |     100 |     100 |
```

## Acceptance Criteria
- [x] Tests verify signature construction
- [x] Tests verify out-of-window timestamp is detectable
- [x] Tests verify tampering with payload or timestamp invalidates signature
- [x] Minimum 95% line coverage on new/changed backend code (achieved 100%)
- [x] No secrets in repo (uses existing tenant.settings.webhook_secret)
- [x] Clear documentation with receiver verification guidance