### PR TITLE
feat(kyc): integrate external provider and persist statuses

### DIFF
--- a/src/db/migrations/20260425_add_kyc_status.js
+++ b/src/db/migrations/20260425_add_kyc_status.js
@@ -1,40 +1,21 @@
 /**
- * Database Migration: Add KYC Status to Invoices
- * 
- * Adds kycStatus column to track SME KYC verification state.
- * KYC statuses: pending, verified, rejected, exempted
- * 
- * Usage: knex migrate:latest
+ * Database Migration: Create kyc_records table
+ *
+ * Persists KYC verification results so status survives restarts.
+ * One row per SME; upserted on each provider response.
  */
 
 exports.up = async (knex) => {
-  return knex.schema.table('invoices', (table) => {
-    table
-      .enum('kycStatus', ['pending', 'verified', 'rejected', 'exempted'], {
-        useNative: true,
-        enumName: 'kyc_status_enum',
-      })
-      .defaultTo('pending')
-      .notNullable();
-
-    // Track when KYC status was last updated
-    table.timestamp('kycStatusUpdatedAt').defaultTo(knex.fn.now());
-
-    // Reference to KYC record ID for audit trail
-    table.string('kycRecordId', 128).nullable();
-
-    // Add index for filtering by KYC status
-    table.index('kycStatus');
-    table.index(['kycStatus', 'createdAt']);
+  await knex.schema.createTable('kyc_records', (table) => {
+    table.string('sme_id', 128).primary();
+    table.string('status', 32).notNullable().defaultTo('pending');
+    table.string('provider_record_id', 256).nullable();
+    table.timestamp('verified_at').nullable();
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+    table.index('status');
   });
 };
 
 exports.down = async (knex) => {
-  return knex.schema.table('invoices', (table) => {
-    table.dropIndex(['kycStatus', 'createdAt']);
-    table.dropIndex('kycStatus');
-    table.dropColumn('kycRecordId');
-    table.dropColumn('kycStatusUpdatedAt');
-    table.dropColumn('kycStatus');
-  });
+  await knex.schema.dropTableIfExists('kyc_records');
 };

--- a/src/services/kycService.js
+++ b/src/services/kycService.js
@@ -1,15 +1,19 @@
+'use strict';
+
 /**
  * KYC Service
- * Manages KYC verification workflows and status updates.
- * 
- * Supports optional external KYC provider integration when env keys are present.
- * Defaults to in-memory mock implementation.
- * 
+ *
+ * Verifies SME identity via an external KYC provider and persists results
+ * to the kyc_records table so status survives restarts.
+ *
+ * Fail-closed: any provider error leaves the status as 'pending'.
+ *
  * @module services/kycService
  */
 
 const logger = require('../logger');
 const appConfig = require('../config');
+const db = require('../db/knex');
 
 const KYC_STATUSES = {
   PENDING: 'pending',
@@ -18,19 +22,15 @@ const KYC_STATUSES = {
   EXEMPTED: 'exempted',
 };
 
-// In-memory store for KYC records (used in test/dev environments)
-const mockKycRecords = new Map();
-
 /**
- * Configuration for external KYC provider.
- * Reads from validated config when available, falls back to process.env in test.
+ * Returns KYC provider config from validated app config or process.env fallback
+ * (the fallback keeps unit tests that skip validate() working).
  */
-const getKycProviderConfig = () => {
+function getKycProviderConfig() {
   let cfg;
   try {
     cfg = appConfig.get();
   } catch {
-    // config not yet validated (e.g. unit tests that don't call validate())
     cfg = process.env;
   }
   const apiKey = cfg.KYC_PROVIDER_API_KEY || null;
@@ -41,51 +41,102 @@ const getKycProviderConfig = () => {
     baseUrl,
     apiSecret: cfg.KYC_PROVIDER_SECRET || null,
   };
-};
+}
 
 /**
- * Verifies KYC status from external provider
- * Only called if provider is configured and enabled
- * 
- * @param {string} smeId - The SME identifier
- * @param {Object} smeData - SME data (name, email, etc.)
- * @returns {Promise<{status: string, recordId: string, verifiedAt: string}>}
+ * Calls the external KYC provider to verify an SME.
+ *
+ * POST {baseUrl}/verify
+ * Authorization: Bearer {apiKey}
+ * Body: { smeId, ...smeData }
+ *
+ * Expected response: { status, recordId, verifiedAt }
+ *
+ * @param {string} smeId
+ * @param {Object} smeData
+ * @returns {Promise<{status: string, recordId: string, verifiedAt: string|null}>}
  */
-async function verifyWithExternalProvider(smeId, smeData) {
+async function verifyWithExternalProvider(smeId, smeData = {}) {
   const config = getKycProviderConfig();
-  
+
   if (!config.enabled) {
     throw new Error('KYC provider not configured');
   }
 
-  try {
-    // TODO: Implement actual HTTP call to KYC provider
-    // This is a placeholder - replace with actual provider integration
-    logger.info(
-      { smeId, provider: config.baseUrl },
-      'Calling external KYC provider (stub implementation)'
-    );
+  const url = `${config.baseUrl}/verify`;
 
-    // Mock response structure
-    return {
-      status: KYC_STATUSES.VERIFIED,
-      recordId: `kyc_${smeId}_${Date.now()}`,
-      verifiedAt: new Date().toISOString(),
-    };
-  } catch (error) {
-    logger.error(
-      { smeId, error: error.message },
-      'External KYC provider call failed'
-    );
-    throw error;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${config.apiKey}`,
+      ...(config.apiSecret ? { 'X-KYC-Secret': config.apiSecret } : {}),
+    },
+    body: JSON.stringify({ smeId, ...smeData }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`KYC provider returned ${response.status}`);
+  }
+
+  const body = await response.json();
+
+  return {
+    status: body.status || KYC_STATUSES.PENDING,
+    recordId: body.recordId || null,
+    verifiedAt: body.verifiedAt || null,
+  };
+}
+
+/**
+ * Persists (upserts) a KYC result to the database.
+ *
+ * @param {string} smeId
+ * @param {{status: string, recordId: string|null, verifiedAt: string|null}} result
+ */
+async function persistKycRecord(smeId, result) {
+  const row = {
+    sme_id: smeId,
+    status: result.status,
+    provider_record_id: result.recordId || null,
+    verified_at: result.verifiedAt ? new Date(result.verifiedAt) : null,
+    updated_at: new Date(),
+  };
+
+  const existing = await db('kyc_records').where({ sme_id: smeId }).first();
+
+  if (existing) {
+    await db('kyc_records').where({ sme_id: smeId }).update(row);
+  } else {
+    await db('kyc_records').insert(row);
   }
 }
 
 /**
- * Gets KYC status for an SME
- * Checks external provider if available, falls back to mock data
- * 
- * @param {string} smeId - The SME identifier
+ * Reads a persisted KYC record from the database.
+ *
+ * @param {string} smeId
+ * @returns {Promise<{status: string, recordId: string|null, verifiedAt: string|null}|null>}
+ */
+async function readKycRecord(smeId) {
+  const row = await db('kyc_records').where({ sme_id: smeId }).first();
+  if (!row) return null;
+  return {
+    status: row.status,
+    recordId: row.provider_record_id || null,
+    verifiedAt: row.verified_at ? new Date(row.verified_at).toISOString() : null,
+  };
+}
+
+/**
+ * Returns the current KYC status for an SME.
+ *
+ * Flow:
+ *  1. If provider is configured, call it and persist the result.
+ *  2. On provider error, log and fall back to the last persisted record.
+ *  3. If no record exists, return pending (fail-closed).
+ *
+ * @param {string} smeId
  * @returns {Promise<{status: string, recordId?: string, verifiedAt?: string}>}
  */
 async function getKycStatus(smeId) {
@@ -95,153 +146,45 @@ async function getKycStatus(smeId) {
 
   const config = getKycProviderConfig();
 
-  // Try external provider first if configured
   if (config.enabled) {
     try {
       const result = await verifyWithExternalProvider(smeId, {});
+      await persistKycRecord(smeId, result);
+      logger.info({ smeId, status: result.status }, 'KYC status refreshed from provider');
       return result;
-    } catch (error) {
-      logger.warn({ smeId, error: error.message }, 'KYC provider lookup failed, using mock');
+    } catch (err) {
+      // Log without leaking the API key
+      logger.warn(
+        { smeId, error: err.message, provider: config.baseUrl },
+        'KYC provider call failed — falling back to persisted record'
+      );
     }
   }
 
-  // Fall back to mock/in-memory store
-  const record = mockKycRecords.get(smeId);
-  if (record) {
-    return {
-      status: record.status,
-      recordId: record.recordId,
-      verifiedAt: record.verifiedAt,
-    };
-  }
+  // Fall back to DB
+  const persisted = await readKycRecord(smeId);
+  if (persisted) return persisted;
 
-  // Default: pending status
-  return {
-    status: KYC_STATUSES.PENDING,
-  };
+  return { status: KYC_STATUSES.PENDING };
 }
 
 /**
- * Marks an SME as KYC verified
- * Only available in test/development (mock implementation)
- * Production should integrate with real KYC provider
- * 
- * @param {string} smeId - The SME identifier
- * @param {Object} options - Additional options
- * @returns {Promise<{status: string, recordId: string, verifiedAt: string}>}
- */
-async function verifySmeSafe(smeId, options = {}) {
-  if (!smeId || typeof smeId !== 'string') {
-    throw new Error('Invalid SME ID');
-  }
-
-  const recordId = options.recordId || `kyc_${smeId}_${Date.now()}`;
-  const record = {
-    smeId,
-    status: KYC_STATUSES.VERIFIED,
-    recordId,
-    verifiedAt: new Date().toISOString(),
-    createdAt: new Date().toISOString(),
-  };
-
-  mockKycRecords.set(smeId, record);
-
-  logger.info({ smeId, recordId }, 'SME marked as KYC verified');
-
-  return {
-    status: record.status,
-    recordId: record.recordId,
-    verifiedAt: record.verifiedAt,
-  };
-}
-
-/**
- * Rejects KYC for an SME (mock implementation)
- * 
- * @param {string} smeId - The SME identifier
- * @param {string} reason - Reason for rejection
- * @returns {Promise<{status: string, recordId: string}>}
- */
-async function rejectSmeKyc(smeId, reason = 'Manual rejection') {
-  if (!smeId || typeof smeId !== 'string') {
-    throw new Error('Invalid SME ID');
-  }
-
-  const recordId = `kyc_${smeId}_${Date.now()}`;
-  const record = {
-    smeId,
-    status: KYC_STATUSES.REJECTED,
-    recordId,
-    reason,
-    rejectedAt: new Date().toISOString(),
-    createdAt: new Date().toISOString(),
-  };
-
-  mockKycRecords.set(smeId, record);
-
-  logger.warn({ smeId, recordId, reason }, 'SME KYC rejected');
-
-  return {
-    status: record.status,
-    recordId: record.recordId,
-  };
-}
-
-/**
- * Exempts an SME from KYC requirements
- * Typically used for low-risk vendors or when exemption is policy-approved
- * 
- * @param {string} smeId - The SME identifier
- * @param {string} reason - Reason for exemption
- * @returns {Promise<{status: string, recordId: string}>}
- */
-async function exemptSmeFromKyc(smeId, reason = 'Manual exemption') {
-  if (!smeId || typeof smeId !== 'string') {
-    throw new Error('Invalid SME ID');
-  }
-
-  const recordId = `kyc_${smeId}_${Date.now()}`;
-  const record = {
-    smeId,
-    status: KYC_STATUSES.EXEMPTED,
-    recordId,
-    reason,
-    exemptedAt: new Date().toISOString(),
-    createdAt: new Date().toISOString(),
-  };
-
-  mockKycRecords.set(smeId, record);
-
-  logger.info({ smeId, recordId, reason }, 'SME exempted from KYC');
-
-  return {
-    status: record.status,
-    recordId: record.recordId,
-  };
-}
-
-/**
- * Checks if an SME can proceed with funding operations
- * Returns true only for 'verified' or 'exempted' statuses
- * 
- * @param {string} kycStatus - The KYC status string
- * @returns {boolean} True if KYC status allows funding
+ * Returns true only for statuses that permit capital transfer.
+ *
+ * @param {string} kycStatus
+ * @returns {boolean}
  */
 function canFundWithKycStatus(kycStatus) {
   return kycStatus === KYC_STATUSES.VERIFIED || kycStatus === KYC_STATUSES.EXEMPTED;
 }
 
-function resetMockRecords() {
-  mockKycRecords.clear();
-}
-
 module.exports = {
   KYC_STATUSES,
   getKycStatus,
-  verifySmeSafe,
-  rejectSmeKyc,
-  exemptSmeFromKyc,
   canFundWithKycStatus,
-  resetMockRecords,
   getKycProviderConfig,
+  // Exported for testing
+  verifyWithExternalProvider,
+  persistKycRecord,
+  readKycRecord,
 };

--- a/tests/kyc.provider.test.js
+++ b/tests/kyc.provider.test.js
@@ -1,0 +1,275 @@
+'use strict';
+
+/**
+ * Tests for KYC provider integration and persistence.
+ *
+ * Covers:
+ *  1. Provider success — status persisted and returned
+ *  2. Provider failure — falls back to persisted record (fail-closed)
+ *  3. Persistence read-back — getKycStatus returns DB record when provider is off
+ *  4. Funding denied when status is pending or rejected
+ */
+
+jest.mock('../src/db/knex');
+
+const db = require('../src/db/knex');
+const {
+  KYC_STATUSES,
+  getKycStatus,
+  canFundWithKycStatus,
+  verifyWithExternalProvider,
+  persistKycRecord,
+  readKycRecord,
+} = require('../src/services/kycService');
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.KYC_PROVIDER_URL;
+  delete process.env.KYC_PROVIDER_API_KEY;
+  delete process.env.KYC_PROVIDER_SECRET;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function enableProvider() {
+  process.env.KYC_PROVIDER_URL = 'https://kyc.example.com';
+  process.env.KYC_PROVIDER_API_KEY = 'test-api-key';
+}
+
+function mockFetchOk(body) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockFetchFail(status = 503) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+}
+
+// ── 1. Provider success ───────────────────────────────────────────────────────
+
+describe('provider success', () => {
+  beforeEach(() => {
+    enableProvider();
+    mockFetchOk({
+      status: 'verified',
+      recordId: 'rec_abc123',
+      verifiedAt: '2026-05-27T10:00:00.000Z',
+    });
+    // DB: no existing row → insert path
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue([1]),
+      update: jest.fn().mockResolvedValue(1),
+    }));
+  });
+
+  it('calls the provider with the correct URL and auth header', async () => {
+    await getKycStatus('sme-001');
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe('https://kyc.example.com/verify');
+    expect(opts.headers.Authorization).toBe('Bearer test-api-key');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('returns the provider status', async () => {
+    const result = await getKycStatus('sme-001');
+    expect(result.status).toBe('verified');
+    expect(result.recordId).toBe('rec_abc123');
+  });
+
+  it('does not leak the API key in the returned object', async () => {
+    const result = await getKycStatus('sme-001');
+    expect(JSON.stringify(result)).not.toContain('test-api-key');
+  });
+
+  it('persists the result to the database', async () => {
+    await getKycStatus('sme-001');
+    // db() was called for the upsert (first + insert)
+    expect(db).toHaveBeenCalledWith('kyc_records');
+  });
+});
+
+// ── 2. Provider failure — fail-closed ────────────────────────────────────────
+
+describe('provider failure fallback', () => {
+  it('returns persisted record when provider returns 5xx', async () => {
+    enableProvider();
+    mockFetchFail(503);
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({
+        status: 'verified',
+        provider_record_id: 'rec_old',
+        verified_at: '2026-01-01T00:00:00.000Z',
+      }),
+      insert: jest.fn(),
+      update: jest.fn(),
+    }));
+
+    const result = await getKycStatus('sme-002');
+    expect(result.status).toBe('verified');
+    expect(result.recordId).toBe('rec_old');
+  });
+
+  it('returns pending when provider fails and no DB record exists', async () => {
+    enableProvider();
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+    }));
+
+    const result = await getKycStatus('sme-003');
+    expect(result.status).toBe(KYC_STATUSES.PENDING);
+  });
+
+  it('does not throw — always returns a status object', async () => {
+    enableProvider();
+    global.fetch = jest.fn().mockRejectedValue(new Error('timeout'));
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+    }));
+
+    await expect(getKycStatus('sme-004')).resolves.toMatchObject({ status: expect.any(String) });
+  });
+});
+
+// ── 3. Persistence read-back ──────────────────────────────────────────────────
+
+describe('persistence read-back', () => {
+  it('returns DB record when provider is not configured', async () => {
+    // No KYC_PROVIDER_URL / KYC_PROVIDER_API_KEY set
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({
+        status: 'exempted',
+        provider_record_id: 'rec_exempt',
+        verified_at: null,
+      }),
+    }));
+
+    const result = await getKycStatus('sme-005');
+    expect(result.status).toBe('exempted');
+    expect(result.recordId).toBe('rec_exempt');
+  });
+
+  it('returns pending when provider is off and no DB record', async () => {
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+    }));
+
+    const result = await getKycStatus('sme-006');
+    expect(result.status).toBe(KYC_STATUSES.PENDING);
+  });
+
+  it('readKycRecord maps DB columns to camelCase fields', async () => {
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({
+        status: 'verified',
+        provider_record_id: 'rec_xyz',
+        verified_at: '2026-05-01T00:00:00.000Z',
+      }),
+    }));
+
+    const record = await readKycRecord('sme-007');
+    expect(record.status).toBe('verified');
+    expect(record.recordId).toBe('rec_xyz');
+    expect(record.verifiedAt).toMatch(/2026-05-01/);
+  });
+
+  it('readKycRecord returns null when no row found', async () => {
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+    }));
+
+    const record = await readKycRecord('sme-missing');
+    expect(record).toBeNull();
+  });
+});
+
+// ── 4. Funding gate ───────────────────────────────────────────────────────────
+
+describe('canFundWithKycStatus', () => {
+  it('allows funding for verified', () => {
+    expect(canFundWithKycStatus('verified')).toBe(true);
+  });
+
+  it('allows funding for exempted', () => {
+    expect(canFundWithKycStatus('exempted')).toBe(true);
+  });
+
+  it('denies funding for pending', () => {
+    expect(canFundWithKycStatus('pending')).toBe(false);
+  });
+
+  it('denies funding for rejected', () => {
+    expect(canFundWithKycStatus('rejected')).toBe(false);
+  });
+
+  it('denies funding for unknown/undefined status', () => {
+    expect(canFundWithKycStatus(undefined)).toBe(false);
+    expect(canFundWithKycStatus('')).toBe(false);
+  });
+});
+
+// ── 5. Input validation ───────────────────────────────────────────────────────
+
+describe('input validation', () => {
+  it('throws on missing smeId', async () => {
+    await expect(getKycStatus('')).rejects.toThrow('Invalid SME ID');
+  });
+
+  it('throws on non-string smeId', async () => {
+    await expect(getKycStatus(123)).rejects.toThrow('Invalid SME ID');
+  });
+});
+
+// ── 6. verifyWithExternalProvider — unit ─────────────────────────────────────
+
+describe('verifyWithExternalProvider', () => {
+  it('throws when provider is not configured', async () => {
+    await expect(verifyWithExternalProvider('sme-x', {})).rejects.toThrow(
+      'KYC provider not configured'
+    );
+  });
+
+  it('throws on non-ok response', async () => {
+    enableProvider();
+    mockFetchFail(400);
+    await expect(verifyWithExternalProvider('sme-x', {})).rejects.toThrow('400');
+  });
+
+  it('includes X-KYC-Secret header when secret is set', async () => {
+    enableProvider();
+    process.env.KYC_PROVIDER_SECRET = 'my-secret';
+    mockFetchOk({ status: 'verified', recordId: 'r1', verifiedAt: null });
+
+    await verifyWithExternalProvider('sme-x', {});
+
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.headers['X-KYC-Secret']).toBe('my-secret');
+
+    delete process.env.KYC_PROVIDER_SECRET;
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the in-memory mock KYC implementation with a real external provider
integration and durable DB persistence. Closes #203.

## Changes

**src/db/migrations/20260425_add_kyc_status.js**
- Replaced the invoices column approach with a dedicated kyc_records table
  (sme_id PK, status, provider_record_id, verified_at, updated_at)

**src/services/kycService.js**
- verifyWithExternalProvider — real fetch POST to {KYC_PROVIDER_URL}/verify
  with Authorization: Bearer header and optional X-KYC-Secret
- persistKycRecord — upserts result to kyc_records via knex
- readKycRecord — reads back from DB, maps snake_case to camelCase
- getKycStatus — calls provider → persists → returns; on any error logs without
  leaking the API key and falls back to last persisted record; returns pending
  if no record exists (fail-closed)
- Removed mock helpers (mockKycRecords, verifySmeSafe, rejectSmeKyc,
  exemptSmeFromKyc, resetMockRecords) — nothing in the codebase used them

**tests/kyc.provider.test.js**
- Provider success: correct URL/auth, status returned, API key not leaked, DB persisted
- Provider failure fallback: 5xx → DB record, network error → pending, never throws
- Persistence read-back: no provider → DB, missing row → pending, column mapping
- Funding gate: canFundWithKycStatus for all statuses + edge cases
- Input validation and verifyWithExternalProvider unit cases

## Security
- API key sent only in the Authorization header, never logged or returned
- Fail-closed: provider errors default to pending, blocking funding
- No secrets committed; uses KYC_PROVIDER_URL / KYC_PROVIDER_API_KEY / KYC_PROVIDER_SECRET

## Testing
npm test -- tests/kyc.provider.test.js
 
closed #203 