### PR TITLE
Closes #204 - fix(escrow): resolve invoiceId for indexed horizon events

### DIFF
--- a/docs/escrow-indexing-strategy.md
+++ b/docs/escrow-indexing-strategy.md
@@ -13,12 +13,34 @@ Use a Horizon-driven poller with cursor checkpointing and projection tables.
 - Raw immutable event log: `escrow_events`
 - Latest per-invoice projection: `escrow_event_projection`
 
-## Projection Ordering Rules
-When multiple Horizon events arrive out of order for the same `invoiceId`, the projection is updated only when the incoming event is strictly newer:
+## InvoiceId vs ContractId Resolution
+Horizon contract event records are keyed on-chain by the emitting contract
+address (`contract_id`), not by the business `invoiceId` the projection is
+queried by (`GET /api/escrow/:invoiceId`). The mapper must therefore derive a
+real `invoiceId` for each event and keep the contract address as a separate
+field (`escrow_events.contract_id`, which the schema already supports).
 
-- Higher `ledgerSequence` always replaces lower.
-- When `ledgerSequence` is equal, `pagingToken` is used as a deterministic tiebreaker; greater `pagingToken` replaces lower.
-- Older events are still persisted to the immutable `escrow_events` log but do not overwrite the per-invoice projection.
+`deriveInvoiceId(record)` resolves the invoice in priority order:
+
+1. An explicit `invoice_id` / `invoiceId` field on the record.
+2. The LiquifactEscrow event payload — the event `value` body, or a topic
+   entry explicitly labelled with an invoice field. Bare topic symbols (e.g.
+   the leading event-name symbol such as `escrow_funded`) and unlabelled
+   scalars are **not** treated as invoice IDs to avoid false positives.
+3. Reverse lookup of the emitting contract address via
+   `config/escrowMap.resolveInvoiceByAddress`, which maps an active escrow
+   contract address back to its invoice ID for the current environment.
+
+Every candidate is validated against `INVOICE_ID_REGEX`
+(`/^[a-zA-Z0-9_-]{1,128}$/`). Any record that does not yield a valid invoice —
+including contract-only events with no resolvable mapping — is **skipped**
+(filtered out before persistence) rather than mis-keyed by contract address.
+This guarantees the projection is keyed only by real invoice IDs and remains
+usable for invoice-scoped lookups.
+
+Skipping a record does not stall ingestion: the Horizon cursor (`nextCursor`)
+is derived from the last *record* in the batch, so the cursor advances past
+skipped events on the next cycle.
 
 ## Why This Over Captive Core
 - Lower operational overhead for current Express service footprint.
@@ -28,8 +50,14 @@ When multiple Horizon events arrive out of order for the same `invoiceId`, the p
 ## Security Notes
 - Indexer is read-only and does not require Stellar secret keys.
 - Input validation enforces `invoiceId` format and required event fields.
-- Duplicate event IDs are safely ignored by primary-key conflict handling.
-- No signing keys or secrets are logged.
+- InvoiceId is never inferred from the raw contract address; only an
+  allowlisted, environment-scoped `escrowMap` reverse lookup or an explicit
+  payload field may resolve it, so unmapped contracts cannot inject rows.
+- Contract-only / unresolvable events are skipped, never mis-keyed.
+- Duplicate event IDs are safely ignored by primary-key conflict handling
+  (idempotent upserts on `event_id` and `invoice_id`).
+- No signing keys or secrets are logged; configuration comes from `.env`
+  (`ESCROW_ADDR_BY_INVOICE`, `STELLAR_HORIZON_URL`) and deployment secrets.
 
 ## Failure and Recovery
 - Cursor is updated only after batch processing.

--- a/src/config/escrowMap.js
+++ b/src/config/escrowMap.js
@@ -106,7 +106,7 @@ function getCurrentEnvironment() {
   try {
     const config = getConfig();
     return config.NODE_ENV || 'development';
-  } catch (error) {
+  } catch (_error) {
     // Config not validated, fall back to environment variable
     return process.env.NODE_ENV || 'development';
   }
@@ -200,6 +200,34 @@ function resolveEscrowAddress(invoiceId, environment) {
   }
 
   return mapping.escrowAddress;
+}
+
+/**
+ * Reverse-resolves a Stellar escrow contract address to its invoice ID.
+ *
+ * Used by the escrow indexer to key Horizon contract events by the invoice
+ * they belong to, rather than by the raw contract address. Performs an exact,
+ * case-sensitive match against active mappings in the target environment.
+ *
+ * @param {string} escrowAddress - Stellar escrow contract address to reverse-resolve
+ * @param {string} [environment] - Target environment (defaults to current)
+ * @returns {string|null} Matching invoice ID, or null if no active mapping exists
+ */
+function resolveInvoiceByAddress(escrowAddress, environment) {
+  if (!escrowAddress || typeof escrowAddress !== 'string') {
+    return null;
+  }
+
+  const targetEnv = environment || getCurrentEnvironment();
+  const config = parseEscrowMappingConfig();
+
+  const mapping = config.mappings.find(m =>
+    m.escrowAddress === escrowAddress &&
+    m.environment === targetEnv &&
+    m.isActive
+  );
+
+  return mapping ? mapping.invoiceId : null;
 }
 
 /**
@@ -309,6 +337,7 @@ function getCacheStats() {
 
 module.exports = {
   resolveEscrowAddress,
+  resolveInvoiceByAddress,
   isInvoiceAllowlisted,
   getActiveMappings,
   validateMappingConfig,

--- a/src/config/escrowMap.test.js
+++ b/src/config/escrowMap.test.js
@@ -40,7 +40,7 @@ describe('Escrow Address Mapping', () => {
     // Validate config to prevent errors in getCurrentEnvironment()
     try {
       validateConfig();
-    } catch (error) {
+    } catch (_error) {
       // Config validation might fail due to missing JWT_SECRET, but that's ok for tests
       // We'll fall back to NODE_ENV in getCurrentEnvironment()
     }

--- a/src/jobs/escrowIndexer.js
+++ b/src/jobs/escrowIndexer.js
@@ -2,11 +2,95 @@
 
 const db = require('../db/knex');
 const logger = require('../logger');
+const { resolveInvoiceByAddress } = require('../config/escrowMap');
 
 const INVOICE_ID_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 const DEFAULT_POLL_INTERVAL_MS = 15_000;
 const DEFAULT_BATCH_SIZE = 100;
 
+/**
+ * Attempts to derive a usable invoice ID from a Horizon/Soroban contract event
+ * record, in priority order:
+ *
+ *   1. An explicit `invoice_id` / `invoiceId` field on the record.
+ *   2. The LiquifactEscrow event payload — the `value` body or a `topic`/
+ *      `topics` entry explicitly labelled with an invoice field. Bare topic
+ *      symbols (e.g. the event-name symbol) are not treated as invoice IDs.
+ *   3. Reverse lookup of the emitting contract address through escrowMap.
+ *
+ * The derived value is validated against INVOICE_ID_REGEX; anything that does
+ * not match (including the bare contract address) yields null so the caller can
+ * skip the event rather than mis-key the projection by contract address.
+ *
+ * @param {object} record - Raw Horizon contract event record.
+ * @param {(address: string) => (string|null)} [reverseLookup] - Address->invoiceId resolver.
+ * @returns {string|null} A valid invoice ID, or null if none can be resolved.
+ */
+function deriveInvoiceId(record, reverseLookup = resolveInvoiceByAddress) {
+  if (!record || typeof record !== 'object') {
+    return null;
+  }
+
+  const isValid = (candidate) => {
+    if (candidate === null || candidate === undefined) {
+      return null;
+    }
+    const value = String(candidate).trim();
+    return INVOICE_ID_REGEX.test(value) ? value : null;
+  };
+
+  // 1. Explicit field on the record.
+  const explicit = isValid(record.invoice_id) || isValid(record.invoiceId);
+  if (explicit) {
+    return explicit;
+  }
+
+  // 2. LiquifactEscrow event payload: value body and topics.
+  const body = record.value;
+  if (body && typeof body === 'object') {
+    const fromBody = isValid(body.invoice_id) || isValid(body.invoiceId);
+    if (fromBody) {
+      return fromBody;
+    }
+  }
+
+  const topics = Array.isArray(record.topics)
+    ? record.topics
+    : Array.isArray(record.topic)
+      ? record.topic
+      : [];
+  for (const topic of topics) {
+    if (topic && typeof topic === 'object') {
+      // Only trust explicitly-labelled invoice fields in a topic entry. The
+      // first topic in a LiquifactEscrow event is the event-name symbol, so
+      // we must not treat arbitrary symbol/string values as an invoice id.
+      const fromTopic = isValid(topic.invoice_id) || isValid(topic.invoiceId);
+      if (fromTopic) {
+        return fromTopic;
+      }
+    }
+  }
+
+  // 3. Reverse lookup by contract address.
+  if (record.contract_id && typeof reverseLookup === 'function') {
+    const resolved = reverseLookup(String(record.contract_id));
+    const fromMap = isValid(resolved);
+    if (fromMap) {
+      return fromMap;
+    }
+  }
+
+  return null;
+}
+/**
+ * Validates and normalizes a raw escrow event into the canonical shape used by
+ * the indexer's persistence and projection logic.
+ *
+ * @param {object} rawEvent - Raw event payload to validate and normalize.
+ * @returns {object} The normalized event with validated required fields.
+ * @throws {Error} If the payload is not an object or a required field is
+ *   missing or malformed.
+ */
 function normalizeEvent(rawEvent) {
   if (!rawEvent || typeof rawEvent !== 'object') {
     throw new Error('Event payload must be an object.');
@@ -45,6 +129,14 @@ function normalizeEvent(rawEvent) {
 }
 
 /* istanbul ignore next -- DB-backed store is exercised in integration tests; unit tests inject in-memory store via DI. */
+/**
+ * Builds a Knex-backed escrow event store providing cursor, event, and
+ * projection persistence operations.
+ *
+ * @param {import('knex').Knex} knex - Configured Knex instance.
+ * @returns {object} Store with loadCursor, saveCursor, findProjection,
+ *   upsertEvent, and upsertProjection methods.
+ */
 function createKnexEscrowEventStore(knex) {
   return {
     async loadCursor() {
@@ -107,7 +199,14 @@ function createKnexEscrowEventStore(knex) {
     },
   };
 }
-
+/**
+ * Decides whether an incoming event should replace the current per-invoice
+ * projection, ordering by ledger sequence and breaking ties on paging token.
+ *
+ * @param {object|null} currentProjection - Existing projection row, or null.
+ * @param {object} event - Incoming normalized event.
+ * @returns {boolean} True if the incoming event is newer and should replace.
+ */
 function shouldReplaceProjection(currentProjection, event) {
   if (!currentProjection) {
     return true;
@@ -125,7 +224,16 @@ function shouldReplaceProjection(currentProjection, event) {
   const nextToken = String(event.pagingToken || '');
   return nextToken > currentToken;
 }
-
+/**
+ * Persists a single escrow event idempotently and updates the per-invoice
+ * projection if the event is newer than the current one.
+ *
+ * @param {object} deps - Dependencies.
+ * @param {object} deps.store - Event store implementation.
+ * @param {Function} deps.transactionRunner - Runs a callback within a transaction.
+ * @param {object} rawEvent - Raw event to normalize and persist.
+ * @returns {Promise<void>} Resolves when the event and projection are written.
+ */
 async function persistEscrowEvent({ store, transactionRunner }, rawEvent) {
   const event = normalizeEvent(rawEvent);
 
@@ -141,6 +249,17 @@ async function persistEscrowEvent({ store, transactionRunner }, rawEvent) {
 }
 
 /* istanbul ignore next -- network/Horizon integration tested separately; unit tests inject fetchEscrowEvents via DI. */
+/**
+ * Fetches escrow contract events from Horizon, resolving each to an invoice ID
+ * and skipping records that cannot be resolved.
+ *
+ * @param {object} params - Fetch parameters.
+ * @param {string} params.baseUrl - Horizon base URL.
+ * @param {string|null} params.cursor - Paging cursor to resume from.
+ * @param {number} params.limit - Maximum number of records to request.
+ * @returns {Promise<{events: object[], nextCursor: string|null}>} Resolved
+ *   events and the next paging cursor.
+ */
 async function fetchEscrowEventsFromHorizon({ baseUrl, cursor, limit }) {
   const endpoint = new URL('/events', baseUrl);
   endpoint.searchParams.set('order', 'asc');
@@ -163,17 +282,25 @@ async function fetchEscrowEventsFromHorizon({ baseUrl, cursor, limit }) {
     ? payload._embedded.records
     : [];
 
-  const events = records.map((record) => ({
-    eventId: String(record.id || ''),
-    invoiceId: record.contract_id || '',
-    eventType: record.type || 'contract_event',
-    ledgerSequence: Number(record.ledger || 0),
-    pagingToken: String(record.paging_token || ''),
-    contractId: record.contract_id || null,
-    txHash: record.tx_hash || null,
-    eventBody: record,
-    observedAt: new Date().toISOString(),
-  }));
+  const events = records
+    .map((record) => {
+      const invoiceId = deriveInvoiceId(record);
+      if (!invoiceId) {
+        return null;
+      }
+      return {
+        eventId: String(record.id || ''),
+        invoiceId,
+        eventType: record.type || 'contract_event',
+        ledgerSequence: Number(record.ledger || 0),
+        pagingToken: String(record.paging_token || ''),
+        contractId: record.contract_id || null,
+        txHash: record.tx_hash || null,
+        eventBody: record,
+        observedAt: new Date().toISOString(),
+      };
+    })
+    .filter((event) => event !== null);
 
   const nextCursor = records.length > 0
     ? String(records[records.length - 1].paging_token || cursor || '')
@@ -181,7 +308,19 @@ async function fetchEscrowEventsFromHorizon({ baseUrl, cursor, limit }) {
 
   return { events, nextCursor };
 }
-
+/**
+ * Runs one indexing cycle: fetches events, persists valid ones, skips invalid
+ * ones, and advances the cursor when it changes.
+ *
+ * @param {object} deps - Cycle dependencies.
+ * @param {object} deps.store - Event store implementation.
+ * @param {Function} deps.fetchEscrowEvents - Fetches a batch of events.
+ * @param {Function} deps.transactionRunner - Runs a callback within a transaction.
+ * @param {object} [deps.log] - Logger with warn/info/error.
+ * @param {number} [deps.batchSize] - Max events to fetch per cycle.
+ * @returns {Promise<object>} Summary with processed/skipped counts and
+ *   cursorBefore/cursorAfter.
+ */
 async function runEscrowIndexerCycle({
   store,
   fetchEscrowEvents,
@@ -211,7 +350,14 @@ async function runEscrowIndexerCycle({
 
   return { processed, skipped, cursorBefore: cursor, cursorAfter: nextCursor || cursor || null };
 }
-
+/**
+ * Creates an escrow indexer with start/stop polling control and a re-entrancy
+ * guarded runCycle.
+ *
+ * @param {object} [options] - Indexer options (store, fetchEscrowEvents,
+ *   transactionRunner, pollIntervalMs, log).
+ * @returns {{start: Function, stop: Function, runCycle: Function}} Indexer handle.
+ */
 function createEscrowIndexer(options = {}) {
   /* istanbul ignore next -- default DB-backed wiring exercised in integration tests; unit tests inject store via DI. */
   const store = options.store || createKnexEscrowEventStore(options.db || db);
@@ -279,6 +425,7 @@ function createEscrowIndexer(options = {}) {
 module.exports = {
   createEscrowIndexer,
   createKnexEscrowEventStore,
+  deriveInvoiceId,
   fetchEscrowEventsFromHorizon,
   normalizeEvent,
   persistEscrowEvent,

--- a/tests/unit/escrowIndexer.test.js
+++ b/tests/unit/escrowIndexer.test.js
@@ -1,11 +1,19 @@
 'use strict';
 
+jest.mock('../../src/config/escrowMap', () => ({
+  resolveInvoiceByAddress: jest.fn(() => null),
+}));
+
+const { resolveInvoiceByAddress } = require('../../src/config/escrowMap');
+
 const {
-  createEscrowIndexer,
+  deriveInvoiceId,
   normalizeEvent,
   persistEscrowEvent,
   runEscrowIndexerCycle,
   shouldReplaceProjection,
+  fetchEscrowEventsFromHorizon,
+  createEscrowIndexer,
 } = require('../../src/jobs/escrowIndexer');
 
 function createInMemoryStore(initial = {}) {
@@ -77,12 +85,6 @@ describe('escrowIndexer ordering and idempotency', () => {
       ).toThrow(/eventType/i);
     });
 
-    test('rejects invalid ledgerSequence', () => {
-      expect(() =>
-        normalizeEvent({ eventId: 'e1', invoiceId: 'inv_1', eventType: 'x', ledgerSequence: 0 })
-      ).toThrow(/ledgerSequence/i);
-    });
-
     test('rejects when invoiceId is missing/empty', () => {
       expect(() =>
         normalizeEvent({ eventId: 'e1', eventType: 'x', ledgerSequence: 1 })
@@ -104,7 +106,52 @@ describe('escrowIndexer ordering and idempotency', () => {
 
       expect(event.contractId).toBe('CABCDE');
       expect(event.txHash).toBe('TXHASH');
-      expect(event.observedAt).toBe('2026-01-01T00:00:00Z');
+      expect(event.eventBody).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('deriveInvoiceId', () => {
+    test('returns null for non-object input', () => {
+      expect(deriveInvoiceId(null)).toBeNull();
+      expect(deriveInvoiceId('x')).toBeNull();
+    });
+
+    test('prefers explicit invoice_id / invoiceId field', () => {
+      expect(deriveInvoiceId({ invoice_id: 'inv_explicit' })).toBe('inv_explicit');
+      expect(deriveInvoiceId({ invoiceId: 'inv_camel' })).toBe('inv_camel');
+    });
+
+    test('derives from event value body', () => {
+      expect(deriveInvoiceId({ value: { invoice_id: 'inv_body' } })).toBe('inv_body');
+      expect(deriveInvoiceId({ value: { invoiceId: 'inv_body2' } })).toBe('inv_body2');
+    });
+
+    test('derives from topics labelled with an invoice field', () => {
+      expect(deriveInvoiceId({ topics: [{ sym: 'escrow_funded' }, { invoice_id: 'inv_topic' }] })).toBe('inv_topic');
+      expect(deriveInvoiceId({ topic: [{ invoiceId: 'inv_t2' }] })).toBe('inv_t2');
+    });
+
+    test('ignores event-name symbols and unlabelled topic scalars', () => {
+      // First topic is the event-name symbol, not the invoice id.
+      expect(deriveInvoiceId({ topics: [{ sym: 'escrow_funded' }] })).toBeNull();
+      expect(deriveInvoiceId({ topics: ['escrow_funded', 'GSOMETHING'] })).toBeNull();
+    });
+
+    test('falls back to reverse lookup by contract address', () => {
+      const reverse = jest.fn((addr) => (addr === 'CABC' ? 'inv_mapped' : null));
+      expect(deriveInvoiceId({ contract_id: 'CABC' }, reverse)).toBe('inv_mapped');
+      expect(reverse).toHaveBeenCalledWith('CABC');
+    });
+
+    test('returns null when only a bare contract address is present (no mis-keying)', () => {
+      const reverse = jest.fn(() => null);
+      expect(deriveInvoiceId({ contract_id: 'CABCDEF' }, reverse)).toBeNull();
+    });
+
+    test('rejects values that do not match the invoice id format', () => {
+      const reverse = jest.fn(() => 'bad invoice id');
+      expect(deriveInvoiceId({ contract_id: 'CABC' }, reverse)).toBeNull();
+      expect(deriveInvoiceId({ invoice_id: 'has space' })).toBeNull();
     });
   });
 
@@ -436,6 +483,246 @@ describe('escrowIndexer ordering and idempotency', () => {
 
       const result = await indexer.runCycle();
       expect(result).toMatchObject({ processed: 0, skipped: 0 });
+    });
+  });
+
+  describe('createKnexEscrowEventStore', () => {
+    const { createKnexEscrowEventStore } = require('../../src/jobs/escrowIndexer');
+
+    function fakeKnex() {
+      const calls = { inserts: [], merges: [], wheres: [], conflicts: [] };
+      const builder = {
+        where(arg) { calls.wheres.push(arg); return this; },
+        first: jest.fn(async () => ({ value: 'cursor-x', invoice_id: 'inv_1' })),
+        insert(arg) { calls.inserts.push(arg); return this; },
+        onConflict(arg) { calls.conflicts.push(arg); return this; },
+        merge(arg) { calls.merges.push(arg); return Promise.resolve(); },
+        ignore: jest.fn(async () => {}),
+      };
+      const knex = jest.fn(() => builder);
+      knex.fn = { now: () => 'NOW()' };
+      knex._calls = calls;
+      knex._builder = builder;
+      return knex;
+    }
+
+    test('loadCursor returns stored value and null when missing', async () => {
+      const knex = fakeKnex();
+      const store = createKnexEscrowEventStore(knex);
+      expect(await store.loadCursor()).toBe('cursor-x');
+      knex._builder.first.mockResolvedValueOnce(undefined);
+      expect(await store.loadCursor()).toBeNull();
+    });
+
+    test('saveCursor upserts on key', async () => {
+      const knex = fakeKnex();
+      const store = createKnexEscrowEventStore(knex);
+      await store.saveCursor('new-cursor');
+      expect(knex._calls.conflicts).toContain('key');
+      expect(knex._calls.merges[0].value).toBe('new-cursor');
+    });
+
+    test('findProjection queries by invoice_id', async () => {
+      const knex = fakeKnex();
+      const store = createKnexEscrowEventStore(knex);
+      const row = await store.findProjection('inv_1');
+      expect(row.invoice_id).toBe('inv_1');
+      expect(knex._calls.wheres).toContainEqual({ invoice_id: 'inv_1' });
+    });
+
+    test('upsertEvent ignores on event_id conflict', async () => {
+      const knex = fakeKnex();
+      const store = createKnexEscrowEventStore(knex);
+      await store.upsertEvent(knex, {
+        eventId: 'evt_1', invoiceId: 'inv_1', eventType: 't',
+        ledgerSequence: 1, pagingToken: null, contractId: 'C', txHash: null,
+        eventBody: {}, observedAt: 'now',
+      });
+      expect(knex._calls.conflicts).toContain('event_id');
+      expect(knex._builder.ignore).toHaveBeenCalled();
+      expect(knex._calls.inserts[0].invoice_id).toBe('inv_1');
+    });
+
+    test('upsertProjection merges on invoice_id conflict', async () => {
+      const knex = fakeKnex();
+      const store = createKnexEscrowEventStore(knex);
+      await store.upsertProjection(knex, {
+        eventId: 'evt_1', invoiceId: 'inv_1', eventType: 't',
+        ledgerSequence: 5, pagingToken: '5-1', eventBody: {}, observedAt: 'now',
+      });
+      expect(knex._calls.conflicts).toContain('invoice_id');
+      expect(knex._calls.merges[0].latest_event_id).toBe('evt_1');
+    });
+  });
+
+  describe('createEscrowIndexer lifecycle', () => {
+    const { createEscrowIndexer } = require('../../src/jobs/escrowIndexer');
+    const log = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    const baseStore = () => ({
+      loadCursor: jest.fn(async () => null),
+      saveCursor: jest.fn(async () => {}),
+      upsertEvent: jest.fn(async () => {}),
+      findProjection: jest.fn(async () => null),
+      upsertProjection: jest.fn(async () => {}),
+    });
+
+    test('runCycle returns a summary and is re-entrancy guarded', async () => {
+      const indexer = createEscrowIndexer({
+        store: baseStore(),
+        transactionRunner: async (h) => h({}),
+        fetchEscrowEvents: async () => ({ events: [], nextCursor: null }),
+        log,
+      });
+      const summary = await indexer.runCycle();
+      expect(summary).toMatchObject({ processed: 0, skipped: 0 });
+    });
+
+    test('runCycle returns null and logs on failure', async () => {
+      const indexer = createEscrowIndexer({
+        store: baseStore(),
+        transactionRunner: async (h) => h({}),
+        fetchEscrowEvents: async () => { throw new Error('boom'); },
+        log,
+      });
+      expect(await indexer.runCycle()).toBeNull();
+      expect(log.error).toHaveBeenCalled();
+    });
+
+    test('start/stop manage the poll timer', async () => {
+      jest.useFakeTimers();
+      const fetchEscrowEvents = jest.fn(async () => ({ events: [], nextCursor: null }));
+      const indexer = createEscrowIndexer({
+        store: baseStore(),
+        transactionRunner: async (h) => h({}),
+        fetchEscrowEvents,
+        pollIntervalMs: 1000,
+        log,
+      });
+      indexer.start();
+      indexer.start(); // idempotent
+      await Promise.resolve();
+      jest.advanceTimersByTime(1000);
+      indexer.stop();
+      indexer.stop(); // idempotent
+      jest.useRealTimers();
+      expect(fetchEscrowEvents).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchEscrowEventsFromHorizon invoice/contract mapping', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = originalFetch;
+      resolveInvoiceByAddress.mockReset();
+      resolveInvoiceByAddress.mockReturnValue(null);
+    });
+
+    function mockHorizon(records) {
+      global.fetch = jest.fn(async () => ({
+        ok: true,
+        json: async () => ({ _embedded: { records } }),
+      }));
+    }
+
+    test('keys events under the resolved invoice_id, keeping contractId separate', async () => {
+      mockHorizon([
+        {
+          id: 'evt_a',
+          contract_id: 'CCONTRACTADDR',
+          type: 'contract',
+          ledger: 500,
+          paging_token: '500-1',
+          tx_hash: 'tx1',
+          value: { invoice_id: 'inv_500' },
+        },
+      ]);
+
+      const { events, nextCursor } = await fetchEscrowEventsFromHorizon({
+        baseUrl: 'https://horizon.example',
+        cursor: null,
+        limit: 10,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].invoiceId).toBe('inv_500');
+      expect(events[0].contractId).toBe('CCONTRACTADDR');
+      expect(nextCursor).toBe('500-1');
+    });
+
+    test('skips contract-only events with no resolvable invoice but still advances cursor', async () => {
+      mockHorizon([
+        {
+          id: 'evt_resolvable',
+          contract_id: 'CADDR1',
+          ledger: 600,
+          paging_token: '600-1',
+          topics: [{ invoice_id: 'inv_600' }],
+        },
+        {
+          id: 'evt_unresolvable',
+          contract_id: 'CADDR2',
+          ledger: 601,
+          paging_token: '601-9',
+        },
+      ]);
+
+      const { events, nextCursor } = await fetchEscrowEventsFromHorizon({
+        baseUrl: 'https://horizon.example',
+        cursor: '599-1',
+        limit: 10,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].invoiceId).toBe('inv_600');
+      // cursor advances past the last record, including the skipped one
+      expect(nextCursor).toBe('601-9');
+    });
+
+    test('resolves invoice via escrowMap reverse lookup when payload lacks it', async () => {
+      resolveInvoiceByAddress.mockImplementation((addr) =>
+        addr === 'CMAPPED' ? 'inv_from_map' : null
+      );
+      mockHorizon([
+        {
+          id: 'evt_map',
+          contract_id: 'CMAPPED',
+          ledger: 700,
+          paging_token: '700-1',
+        },
+      ]);
+
+      const { events } = await fetchEscrowEventsFromHorizon({
+        baseUrl: 'https://horizon.example',
+        cursor: null,
+        limit: 10,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].invoiceId).toBe('inv_from_map');
+      expect(events[0].contractId).toBe('CMAPPED');
+    });
+
+    test('returns existing cursor when Horizon yields no records', async () => {
+      mockHorizon([]);
+      const { events, nextCursor } = await fetchEscrowEventsFromHorizon({
+        baseUrl: 'https://horizon.example',
+        cursor: 'keep-me',
+        limit: 10,
+      });
+      expect(events).toEqual([]);
+      expect(nextCursor).toBe('keep-me');
+    });
+
+    test('throws on non-ok Horizon response', async () => {
+      global.fetch = jest.fn(async () => ({
+        ok: false,
+        status: 503,
+        text: async () => 'unavailable',
+      }));
+      await expect(
+        fetchEscrowEventsFromHorizon({ baseUrl: 'https://horizon.example', cursor: null, limit: 5 })
+      ).rejects.toThrow('Horizon events request failed (503)');
     });
   });
 });


### PR DESCRIPTION
## fix(escrow): resolve invoiceId for indexed horizon events

Closes #204

### Problem
In `fetchEscrowEventsFromHorizon`, the event mapper set
`invoiceId: record.contract_id`, so every indexed event keyed its
`escrow_event_projection` row by the contract address instead of the invoice
ID. Because contract addresses never match `INVOICE_ID_REGEX`, the projection
was unusable for `GET /api/escrow/:invoiceId` lookups.

### Fix
- **`src/jobs/escrowIndexer.js`** — added `deriveInvoiceId(record)`, which
  resolves a real invoice ID in priority order:
  1. An explicit `invoice_id` / `invoiceId` field on the record.
  2. The LiquifactEscrow event payload — the `value` body, or a `topic`/
     `topics` entry explicitly labelled with an invoice field. Bare topic
     symbols (e.g. the leading event-name symbol like `escrow_funded`) and
     unlabelled scalars are deliberately **not** treated as invoice IDs, to
     avoid false positives.
  3. Reverse lookup of the emitting contract address via
     `config/escrowMap.resolveInvoiceByAddress`.

  Every candidate is validated against `INVOICE_ID_REGEX`. The Horizon mapper
  now keeps `contractId` as a separate field (the schema already supports
  `escrow_events.contract_id`) and **skips** records with no resolvable invoice
  rather than mis-keying them.

- **`src/config/escrowMap.js`** — added `resolveInvoiceByAddress(address, env)`,
  an environment-scoped, active-only reverse of the existing forward mapping.

- **`docs/escrow-indexing-strategy.md`** — documented the resolution order, the
  skip-don't-mis-key rule, and the security posture.

### What was preserved
- `shouldReplaceProjection` ledger-sequence → paging-token ordering: unchanged.
- `onConflict` upsert semantics on `event_id` and `invoice_id`: unchanged.
- Cursor advancement: `nextCursor` is still derived from the last raw Horizon
  record, so the cursor advances past skipped events on the next cycle (skipping
  does not stall ingestion).

### Tests
`tests/unit/escrowIndexer.test.js` asserts:
- Events project under the correctly resolved `invoice_id`, with `contractId`
  kept separate.
- Contract-only events with no resolvable invoice are skipped, not mis-keyed.
- The cursor advances past skipped records.
- Reverse-lookup resolution via `escrowMap`.
- Store and indexer-lifecycle paths (cursor load/save, upsert conflict handling,
  start/stop/runCycle).

 