### PR TITLE
[codex] Harden input sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,11 @@ All API failures return a structured error payload:
 - Internal stack traces and raw exception details are never returned to clients.
 - Correlation IDs are sanitized.
 - Retry hints are generic and do not leak infrastructure details.
+- Request body, query, and route-param sanitization recursively drops
+  `__proto__`, `constructor`, and `prototype` keys, returns sanitized plain
+  objects with no prototype, and caps nested payload traversal to reduce
+  prototype-pollution and oversized-input risk before handlers build Knex
+  filters or spread request data.
 
 ---
 

--- a/src/middleware/sanitizeInput.test.js
+++ b/src/middleware/sanitizeInput.test.js
@@ -60,4 +60,34 @@ describe('sanitizeInput middleware', () => {
       customer: 'Test',
     });
   });
+
+  it('strips nested prototype-pollution keys from body and query payloads', async () => {
+    const response = await request(app)
+      .post('/echo/inv-002?constructor=drop&prototype=drop&safe=%20ok%20')
+      .send(JSON.parse(`{
+        "customer": "Test",
+        "metadata": {
+          "__proto__": { "polluted": true },
+          "safe": "  keep  "
+        },
+        "items": [
+          { "prototype": "drop", "name": "  first  " }
+        ]
+      }`));
+
+    expect(response.status).toBe(200);
+    expect(response.body.body).toEqual({
+      customer: 'Test',
+      metadata: {
+        safe: 'keep',
+      },
+      items: [
+        { name: 'first' },
+      ],
+    });
+    expect(response.body.query).toEqual({
+      safe: 'ok',
+    });
+    expect(Object.prototype.polluted).toBeUndefined();
+  });
 });

--- a/src/utils/sanitization.js
+++ b/src/utils/sanitization.js
@@ -10,6 +10,8 @@
 const DANGEROUS_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
 const DEFAULT_MAX_DEPTH = 20;
 const DEFAULT_MAX_STRING_LENGTH = 4096;
+const DEFAULT_MAX_ARRAY_LENGTH = 1000;
+const DEFAULT_MAX_OBJECT_KEYS = 1000;
 
 /**
  * Sanitizes and normalizes a user-supplied string.
@@ -45,6 +47,8 @@ function sanitizeUserString(value, options = {}) {
  * @param {object} [options] Tree sanitization options.
  * @param {number} [options.maxDepth=20] Maximum recursion depth.
  * @param {number} [options.maxStringLength=4096] Maximum string length.
+ * @param {number} [options.maxArrayLength=1000] Maximum array items to keep.
+ * @param {number} [options.maxObjectKeys=1000] Maximum object keys to keep.
  * @returns {*} Sanitized value tree.
  */
 function sanitizeValue(input, options = {}) {
@@ -52,8 +56,19 @@ function sanitizeValue(input, options = {}) {
   const maxStringLength = Number.isInteger(options.maxStringLength)
     ? options.maxStringLength
     : DEFAULT_MAX_STRING_LENGTH;
+  const maxArrayLength = Number.isInteger(options.maxArrayLength)
+    ? options.maxArrayLength
+    : DEFAULT_MAX_ARRAY_LENGTH;
+  const maxObjectKeys = Number.isInteger(options.maxObjectKeys)
+    ? options.maxObjectKeys
+    : DEFAULT_MAX_OBJECT_KEYS;
 
-  return sanitizeValueAtDepth(input, 0, { maxDepth, maxStringLength });
+  return sanitizeValueAtDepth(input, 0, {
+    maxArrayLength,
+    maxDepth,
+    maxObjectKeys,
+    maxStringLength,
+  });
 }
 
 /**
@@ -61,7 +76,12 @@ function sanitizeValue(input, options = {}) {
  *
  * @param {*} input Value to sanitize.
  * @param {number} depth Current recursion depth.
- * @param {{ maxDepth: number, maxStringLength: number }} options Sanitization options.
+ * @param {{
+ *   maxArrayLength: number,
+ *   maxDepth: number,
+ *   maxObjectKeys: number,
+ *   maxStringLength: number
+ * }} options Sanitization options.
  * @returns {*} Sanitized value.
  */
 function sanitizeValueAtDepth(input, depth, options) {
@@ -74,13 +94,14 @@ function sanitizeValueAtDepth(input, depth, options) {
   }
 
   if (Array.isArray(input)) {
-    return input
+    return input.slice(0, options.maxArrayLength)
       .map((item) => sanitizeValueAtDepth(item, depth + 1, options))
       .filter((item) => item !== undefined);
   }
 
   if (input && typeof input === 'object') {
-    const sanitizedObject = {};
+    const sanitizedObject = Object.create(null);
+    let copiedKeys = 0;
 
     for (const [key, value] of Object.entries(input)) {
       if (DANGEROUS_KEYS.has(key)) {
@@ -90,6 +111,11 @@ function sanitizeValueAtDepth(input, depth, options) {
       const sanitizedValue = sanitizeValueAtDepth(value, depth + 1, options);
       if (sanitizedValue !== undefined) {
         sanitizedObject[key] = sanitizedValue;
+        copiedKeys += 1;
+      }
+
+      if (copiedKeys >= options.maxObjectKeys) {
+        break;
       }
     }
 

--- a/src/utils/sanitization.test.js
+++ b/src/utils/sanitization.test.js
@@ -44,8 +44,68 @@ describe('sanitizeValue', () => {
     expect(sanitizeValue(input)).toEqual({ safe: 'ok' });
   });
 
+  it('removes JSON-parsed prototype-pollution keys at every nesting level', () => {
+    const input = JSON.parse(`{
+      "safe": "ok",
+      "__proto__": { "polluted": true },
+      "nested": {
+        "constructor": { "prototype": { "polluted": true } },
+        "keep": "  value  "
+      },
+      "items": [
+        { "__proto__": { "polluted": true }, "name": "  first  " },
+        { "prototype": "drop", "name": "second" }
+      ]
+    }`);
+
+    const output = sanitizeValue(input);
+
+    expect(output).toEqual({
+      safe: 'ok',
+      nested: {
+        keep: 'value',
+      },
+      items: [
+        { name: 'first' },
+        { name: 'second' },
+      ],
+    });
+    expect(Object.prototype.polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(output)).toBeNull();
+    expect(Object.getPrototypeOf(output.nested)).toBeNull();
+  });
+
+  it('does not let sanitized output mutate Object prototype', () => {
+    const input = JSON.parse('{"__proto__":{"polluted":"yes"},"safe":"ok"}');
+    const output = sanitizeValue(input);
+
+    Object.assign({}, output);
+
+    expect(Object.prototype.polluted).toBeUndefined();
+    expect({}.polluted).toBeUndefined();
+  });
+
   it('drops branches that exceed max depth', () => {
     const input = { level1: { level2: { level3: { keep: 'nope' } } } };
     expect(sanitizeValue(input, { maxDepth: 2 })).toEqual({ level1: { level2: {} } });
+  });
+
+  it('caps array and object traversal for oversized payloads', () => {
+    const input = {
+      entries: ['one', 'two', 'three'],
+      keyed: {
+        a: 'one',
+        b: 'two',
+        c: 'three',
+      },
+    };
+
+    expect(sanitizeValue(input, { maxArrayLength: 2, maxObjectKeys: 2 })).toEqual({
+      entries: ['one', 'two'],
+      keyed: {
+        a: 'one',
+        b: 'two',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Harden `sanitizeValue()` against nested prototype-pollution payloads by dropping `__proto__`, `constructor`, and `prototype` keys recursively.
- Return sanitized objects with a null prototype so downstream object spreads and Knex filter construction cannot inherit polluted properties.
- Bound recursive traversal for large arrays and objects while preserving existing string normalization behavior.
- Add focused utility and middleware coverage for JSON-parsed malicious keys, nested array payloads, query sanitization, global prototype safety, and traversal caps.
- Document the request sanitization behavior in the README security notes.

## Why

Issue #284 asks for deeper prototype-pollution protection in request sanitization before downstream handlers build filters or spread request data. The previous sanitizer removed some dangerous keys, but it still returned regular objects and did not cap array/object traversal.

## Validation

- `npx jest src/utils/sanitization.test.js src/middleware/sanitizeInput.test.js --runInBand --forceExit`
- `npx eslint src/utils/sanitization.js src/utils/sanitization.test.js src/middleware/sanitizeInput.js src/middleware/sanitizeInput.test.js`
- `git diff --check HEAD~1..HEAD`

## Baseline note

Full `npm test` and full `npm run lint` currently fail on unrelated pre-existing repository baseline issues outside this patch. The focused sanitizer tests and focused ESLint checks above pass.
