### PR TITLE
fix(security): use constant-time comparison for API key verification (#283)

### DIFF
--- a/src/middleware/apiKeyAuth.js
+++ b/src/middleware/apiKeyAuth.js
@@ -11,10 +11,46 @@
  * @module middleware/apiKeyAuth
  */
 
+const crypto = require('crypto');
 const { loadApiKeyRegistry } = require('../config/apiKeys');
 
 /** Name of the HTTP request header that carries the API key. */
 const API_KEY_HEADER = 'x-api-key';
+
+/**
+ * Compares two strings in constant time to prevent timing attacks.
+ *
+ * Both strings are hashed with SHA-256 before comparison so that
+ * `crypto.timingSafeEqual` always receives equal-length buffers, regardless
+ * of the input lengths.
+ *
+ * @param {string} a - First string (e.g. the candidate key from the request).
+ * @param {string} b - Second string (e.g. a key from the registry).
+ * @returns {boolean} `true` when both strings are identical.
+ */
+function timingSafeStringEqual(a, b) {
+  const hashA = crypto.createHash('sha256').update(a).digest();
+  const hashB = crypto.createHash('sha256').update(b).digest();
+  return crypto.timingSafeEqual(hashA, hashB);
+}
+
+/**
+ * Looks up a key in the registry using constant-time comparison for every
+ * candidate, preventing timing-based enumeration of valid keys.
+ *
+ * @param {Map<string, import('../config/apiKeys').ApiKeyEntry>} registry
+ * @param {string} candidate - The trimmed key from the request header.
+ * @returns {import('../config/apiKeys').ApiKeyEntry | undefined}
+ */
+function findEntry(registry, candidate) {
+  let matched;
+  for (const [registryKey, entry] of registry) {
+    if (timingSafeStringEqual(candidate, registryKey)) {
+      matched = entry;
+    }
+  }
+  return matched;
+}
 
 /**
  * @typedef {Object} ApiClient
@@ -29,7 +65,8 @@ const API_KEY_HEADER = 'x-api-key';
  * The middleware operates in three stages:
  * 1. **Presence check** — rejects with `401` when the header is missing.
  * 2. **Registry lookup + revocation check** — rejects with `401` when the key
- *    is unknown or has been revoked.
+ *    is unknown or has been revoked. The lookup uses constant-time comparison
+ *    to prevent timing-based side-channel attacks.
  * 3. **Scope check** (optional) — when `requiredScope` is supplied the key must
  *    include that scope, otherwise the request is rejected with `403`.
  *
@@ -44,7 +81,6 @@ function authenticateApiKey(options = {}) {
   const { requiredScope, env = process.env } = options;
 
   return (req, res, next) => {
-     
     const rawKey = req.headers[API_KEY_HEADER];
 
     if (!rawKey || typeof rawKey !== 'string' || rawKey.trim() === '') {
@@ -55,7 +91,7 @@ function authenticateApiKey(options = {}) {
 
     // Load registry fresh on each call so env changes in tests are respected.
     const registry = loadApiKeyRegistry(env);
-    const entry = registry.get(rawKey.trim());
+    const entry = findEntry(registry, rawKey.trim());
 
     if (!entry) {
       return res.status(401).json({ error: 'Invalid API key.' });
@@ -84,4 +120,5 @@ function authenticateApiKey(options = {}) {
 module.exports = {
   authenticateApiKey,
   API_KEY_HEADER,
+  timingSafeStringEqual,
 };

--- a/tests/unit/apiKeyAuth.test.js
+++ b/tests/unit/apiKeyAuth.test.js
@@ -26,6 +26,7 @@ const {
 const {
   authenticateApiKey,
   API_KEY_HEADER,
+  timingSafeStringEqual,
 } = require('../../src/middleware/apiKeyAuth');
 
 // ---------------------------------------------------------------------------
@@ -364,5 +365,88 @@ describe('middleware/apiKeyAuth — malformed API_KEYS env propagates error', ()
     const res = await request(app).get('/test').set('X-API-Key', 'lf_anything000');
     // The registry load throws; Express default error handler returns 500
     expect(res.status).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timingSafeStringEqual — unit tests
+// ---------------------------------------------------------------------------
+
+describe('timingSafeStringEqual — constant-time comparison helper', () => {
+  it('returns true when both strings are identical', () => {
+    expect(timingSafeStringEqual('lf_validkey001', 'lf_validkey001')).toBe(true);
+  });
+
+  it('returns false when strings differ by one character', () => {
+    expect(timingSafeStringEqual('lf_validkey001', 'lf_validkey002')).toBe(false);
+  });
+
+  it('returns false for completely different strings', () => {
+    expect(timingSafeStringEqual('lf_aaaaaaaaaa', 'lf_bbbbbbbbbb')).toBe(false);
+  });
+
+  it('returns false when strings have different lengths', () => {
+    expect(timingSafeStringEqual('lf_short', 'lf_muchlongerkey')).toBe(false);
+  });
+
+  it('returns false for empty string vs non-empty string', () => {
+    expect(timingSafeStringEqual('', 'lf_validkey001')).toBe(false);
+  });
+
+  it('returns true for two empty strings', () => {
+    expect(timingSafeStringEqual('', '')).toBe(true);
+  });
+
+  it('is case-sensitive', () => {
+    expect(timingSafeStringEqual('lf_ValidKey001', 'lf_validkey001')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// middleware/apiKeyAuth — constant-time lookup via findEntry (via middleware)
+// ---------------------------------------------------------------------------
+
+describe('middleware/apiKeyAuth — constant-time lookup', () => {
+  it('always evaluates every registry entry (does not short-circuit on first match)', async () => {
+    // Build a registry with multiple entries; the valid key is the first entry.
+    // If lookup short-circuits, the timing for a matching first key would differ
+    // from a matching last key. We assert correct behaviour for all positions.
+    const multiEnv = {
+      API_KEYS: [
+        JSON.stringify({ key: 'lf_firstkey0001', clientId: 'svc-first', scopes: ['invoices:read'] }),
+        JSON.stringify({ key: 'lf_middlekey001', clientId: 'svc-mid', scopes: ['invoices:read'] }),
+        JSON.stringify({ key: 'lf_lastkey00001', clientId: 'svc-last', scopes: ['invoices:read'] }),
+      ].join(';'),
+    };
+
+    const app = makeApp(authenticateApiKey({ env: multiEnv }));
+
+    // First entry resolves correctly
+    const res1 = await request(app).get('/test').set('X-API-Key', 'lf_firstkey0001');
+    expect(res1.status).toBe(200);
+    expect(res1.body.apiClient.clientId).toBe('svc-first');
+
+    // Middle entry resolves correctly
+    const res2 = await request(app).get('/test').set('X-API-Key', 'lf_middlekey001');
+    expect(res2.status).toBe(200);
+    expect(res2.body.apiClient.clientId).toBe('svc-mid');
+
+    // Last entry resolves correctly
+    const res3 = await request(app).get('/test').set('X-API-Key', 'lf_lastkey00001');
+    expect(res3.status).toBe(200);
+    expect(res3.body.apiClient.clientId).toBe('svc-last');
+  });
+
+  it('returns 401 for a key that is a prefix of a valid key', async () => {
+    const app = makeApp(authenticateApiKey({ env: REGISTRY_ENV }));
+    // VALID_KEY = 'lf_validkey001'; send a prefix of it
+    const res = await request(app).get('/test').set('X-API-Key', 'lf_validkey00');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a key that is a superset of a valid key', async () => {
+    const app = makeApp(authenticateApiKey({ env: REGISTRY_ENV }));
+    const res = await request(app).get('/test').set('X-API-Key', `${VALID_KEY}extra`);
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #283 — replaces `Map.get()` with a constant-time comparison for every registry entry, closing a timing side-channel that could allow an attacker to enumerate valid key prefixes.

## Problem

`registry.get(rawKey.trim())` uses strict equality (`===`) internally, which short-circuits on the first differing character. An attacker sending many slightly-varying keys could measure response-time differences to deduce valid key prefixes byte-by-byte.

## Solution

- **`timingSafeStringEqual(a, b)`** — hashes both strings to SHA-256 with `crypto.createHash` before calling `crypto.timingSafeEqual`. Fixed-length buffers avoid the `RangeError` on unequal-length inputs; comparison is always constant-time.
- **`findEntry(registry, candidate)`** — iterates *all* registry entries on every call (no early exit on match), applying `timingSafeStringEqual` at each step. Response time is `O(n)` in registry size, independent of match position.

No new dependencies — `crypto` is a Node.js built-in.

## Files changed

| File | Change |
|------|--------|
| `src/middleware/apiKeyAuth.js` | Add `crypto` import; `timingSafeStringEqual` + `findEntry` helpers; replace `Map.get` with `findEntry`; export helper for tests |
| `tests/unit/apiKeyAuth.test.js` | Import helper; 7 unit tests for `timingSafeStringEqual`; 3 integration tests for constant-time lookup |

## Test results

```
PASS tests/unit/apiKeyAuth.test.js  (52 tests, 0 failures)
```

Pre-existing failures in unrelated suites are unchanged (confirmed via git stash comparison).
closes #283 