### PR TITLE
test(escrow-map): cover address resolution, allowlist, and cache behavior

### DIFF
--- a/tests/escrowMap.test.js
+++ b/tests/escrowMap.test.js
@@ -1,0 +1,390 @@
+'use strict';
+
+const {
+  resolveEscrowAddress,
+  EscrowNotFoundError,
+  EscrowMapConfigError,
+  _resetCache,
+} = require('../src/config/escrowMap');
+
+// Valid Stellar contract address (C + 55 base-32 chars)
+const ADDR_A = 'C' + 'A'.repeat(55);
+const ADDR_B = 'C' + 'B'.repeat(55);
+
+// Helpers -------------------------------------------------------------------
+
+/**
+ * Set ESCROW_ADDR_BY_INVOICE to a serialised config object and reset the
+ * module cache so the next resolveEscrowAddress call re-parses from env.
+ */
+function setConfig(cfg) {
+  process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify(cfg);
+  _resetCache();
+}
+
+function clearConfig() {
+  delete process.env.ESCROW_ADDR_BY_INVOICE;
+  _resetCache();
+}
+
+// ---------------------------------------------------------------------------
+
+describe('escrowMap – resolveEscrowAddress', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    clearConfig();
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    clearConfig();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  // ── active mapping resolves ───────────────────────────────────────────────
+
+  it('resolves a known active mapping to its address', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+  });
+
+  // ── unknown invoiceId throws, no silent default ───────────────────────────
+
+  it('throws EscrowNotFoundError for an unknown invoiceId', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    expect(() => resolveEscrowAddress('inv_UNKNOWN')).toThrow(EscrowNotFoundError);
+  });
+
+  it('error message includes the invoiceId', () => {
+    setConfig({ mappings: [], defaultEnvironment: 'test', allowlistEnabled: false });
+
+    try {
+      resolveEscrowAddress('inv_MISSING');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EscrowNotFoundError);
+      expect(err.message).toContain('inv_MISSING');
+      expect(err.invoiceId).toBe('inv_MISSING');
+    }
+  });
+
+  // ── inactive mapping is rejected ─────────────────────────────────────────
+
+  it('throws EscrowNotFoundError for an inactive mapping (isActive: false)', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: false },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowNotFoundError);
+  });
+
+  it('treats missing isActive field as active (truthy default)', () => {
+    // isActive is only checked as !== false, so omitting it counts as active
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test' },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+  });
+
+  // ── environment filtering ─────────────────────────────────────────────────
+
+  it('resolves only the mapping whose environment matches NODE_ENV', () => {
+    process.env.NODE_ENV = 'production';
+    _resetCache();
+
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+        { invoiceId: 'inv_001', escrowAddress: ADDR_B, environment: 'production', isActive: true },
+      ],
+      defaultEnvironment: 'production',
+      allowlistEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_B);
+  });
+
+  it('throws when the mapping exists but for a different environment', () => {
+    process.env.NODE_ENV = 'staging';
+    _resetCache();
+
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'staging',
+      allowlistEnabled: false,
+    });
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowNotFoundError);
+  });
+
+  it('falls back to defaultEnvironment when NODE_ENV is not set', () => {
+    delete process.env.NODE_ENV;
+    _resetCache();
+
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'production', isActive: true },
+      ],
+      defaultEnvironment: 'production',
+      allowlistEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  // ── allowlistEnabled behavior ─────────────────────────────────────────────
+
+  it('resolves normally when allowlistEnabled is true and address is in the mappings', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: true,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+  });
+
+  it('throws EscrowNotFoundError when allowlistEnabled is true and invoiceId is not in mappings', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: true,
+    });
+
+    // inv_002 is not in the allowlist
+    expect(() => resolveEscrowAddress('inv_002')).toThrow(EscrowNotFoundError);
+  });
+
+  it('still throws for an inactive mapping even when allowlistEnabled is true', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: false },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: true,
+    });
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowNotFoundError);
+  });
+
+  // ── empty / missing config ────────────────────────────────────────────────
+
+  it('throws EscrowNotFoundError when ESCROW_ADDR_BY_INVOICE is not set', () => {
+    // clearConfig() already unsets it in beforeEach; confirm no silent default
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowNotFoundError);
+  });
+
+  it('throws EscrowNotFoundError when mappings array is empty', () => {
+    setConfig({ mappings: [], defaultEnvironment: 'test', allowlistEnabled: false });
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowNotFoundError);
+  });
+
+  // ── multiple mappings — picks correct one ─────────────────────────────────
+
+  it('picks the correct address when multiple active mappings are present', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+        { invoiceId: 'inv_002', escrowAddress: ADDR_B, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+    expect(resolveEscrowAddress('inv_002')).toBe(ADDR_B);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('escrowMap – config validation (EscrowMapConfigError)', () => {
+  beforeEach(() => {
+    clearConfig();
+  });
+
+  afterEach(() => {
+    clearConfig();
+  });
+
+  it('throws EscrowMapConfigError for malformed JSON', () => {
+    process.env.ESCROW_ADDR_BY_INVOICE = '{not valid json';
+    _resetCache();
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowMapConfigError);
+  });
+
+  it('error message mentions JSON when config is malformed', () => {
+    process.env.ESCROW_ADDR_BY_INVOICE = 'definitely-not-json';
+    _resetCache();
+
+    try {
+      resolveEscrowAddress('inv_001');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EscrowMapConfigError);
+      expect(err.message.toLowerCase()).toContain('json');
+    }
+  });
+
+  it('throws EscrowMapConfigError when mappings is not an array', () => {
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: 'not-an-array',
+      defaultEnvironment: 'test',
+    });
+    _resetCache();
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowMapConfigError);
+  });
+
+  it('throws EscrowMapConfigError when a mapping is missing invoiceId', () => {
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: [{ escrowAddress: ADDR_A, environment: 'test', isActive: true }],
+      defaultEnvironment: 'test',
+    });
+    _resetCache();
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowMapConfigError);
+  });
+
+  it('throws EscrowMapConfigError for an invalid Stellar escrowAddress', () => {
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: 'not-a-stellar-address', environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+    });
+    _resetCache();
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowMapConfigError);
+  });
+
+  it('throws EscrowMapConfigError for a G... address (only C... allowed for contracts)', () => {
+    // G-addresses are account keys, not contract IDs — the regex requires C or G but
+    // length + charset must also pass. A 56-char G address is valid per the regex.
+    // This test just confirms a short/malformed address is caught.
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: 'GSHORT', environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+    });
+    _resetCache();
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowMapConfigError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('escrowMap – module-level cache', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    clearConfig();
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    clearConfig();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('returns the same address on repeated calls without re-reading env (cache hit)', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    const first = resolveEscrowAddress('inv_001');
+
+    // Mutate env — should NOT affect result because cache is still warm
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_B, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+    // Note: no _resetCache() call here
+
+    const second = resolveEscrowAddress('inv_001');
+    expect(first).toBe(ADDR_A);
+    expect(second).toBe(ADDR_A); // still cached
+  });
+
+  it('picks up the new config after _resetCache()', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    resolveEscrowAddress('inv_001'); // warms cache
+
+    // Swap config and reset
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_B, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_B);
+  });
+
+  it('fails closed after cache reset when new config is malformed JSON', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+    });
+
+    resolveEscrowAddress('inv_001'); // warms cache
+
+    // Now corrupt the env and reset
+    process.env.ESCROW_ADDR_BY_INVOICE = '{broken';
+    _resetCache();
+
+    expect(() => resolveEscrowAddress('inv_001')).toThrow(EscrowMapConfigError);
+  });
+});


### PR DESCRIPTION
closes #311 

## Summary

Adds `tests/escrowMap.test.js` — dedicated coverage for `src/config/escrowMap.js`, the resolver on the capital-movement path used by `src/routes/invest.js`. A resolution mistake routes funds to the wrong contract, so this is high-value coverage.

## Resolution rules (from the source)

`resolveEscrowAddress(invoiceId)` looks up a mapping where all three conditions hold:
1. `m.invoiceId === invoiceId`
2. `m.isActive !== false` (omitted `isActive` counts as active)
3. `m.environment === (process.env.NODE_ENV || defaultEnvironment)`

If no match → `EscrowNotFoundError`. If the config JSON is unparseable or structurally invalid → `EscrowMapConfigError`. There is no fallback address — ever.

## Config schema

```json
{
  "mappings": [
    {
      "invoiceId": "inv_001",
      "escrowAddress": "CAAA...AAA",
      "environment": "production",
      "isActive": true
    }
  ],
  "defaultEnvironment": "production",
  "allowlistEnabled": true,
  "cacheEnabled": true,
  "cacheTtlSeconds": 300
}
```

## Test coverage

| Scenario | Assertion |
|---|---|
| Active mapping | resolves to correct address |
| Unknown invoiceId | throws `EscrowNotFoundError` with id in message |
| `isActive: false` | throws `EscrowNotFoundError` |
| Missing `isActive` field | treated as active (`!== false` semantics) |
| Correct environment | resolves when `NODE_ENV` matches |
| Wrong environment | throws `EscrowNotFoundError` |
| `defaultEnvironment` fallback | used when `NODE_ENV` is unset |
| `allowlistEnabled: true` + address present | resolves normally |
| `allowlistEnabled: true` + address absent | throws `EscrowNotFoundError` |
| Empty mappings array | throws `EscrowNotFoundError` |
| No env var set | throws `EscrowNotFoundError` |
| Malformed JSON | throws `EscrowMapConfigError` (fails closed) |
| Non-array `mappings` | throws `EscrowMapConfigError` |
| Missing `invoiceId` in entry | throws `EscrowMapConfigError` |
| Invalid `escrowAddress` | throws `EscrowMapConfigError` |
| Cache hit | env mutation ignored while cache is warm |
| Cache reset | re-parses config; picks up new address |
| Cache reset + broken config | fails closed with `EscrowMapConfigError` |

## Security notes
- No default-address fallback: an unmapped or inactive invoiceId always throws — funds cannot be silently routed to a wrong contract.
- Allowlist cannot be bypassed: `allowlistEnabled: true` with an unlisted invoiceId still throws `EscrowNotFoundError`.
- Malformed config fails closed: invalid JSON or structural errors throw `EscrowMapConfigError` rather than silently using an empty mapping set.
- Cache security: `_resetCache()` is exported for tests only; production code has no path to inject arbitrary keys.