### PR TITLE
fix(security): scope presigned S3 keys to tenant and clamp URL expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,137 @@ curl -H "Authorization: Bearer <token>" \
 
 ---
 
+## Invoice Upload Security
+
+LiquiFact uses tenant-scoped object storage and strict validation controls for invoice uploads.
+
+### Storage Key Scoping
+
+Invoice files are stored using tenant and invoice scoped object keys:
+
+```text
+tenants/{tenantId}/invoices/{invoiceId}/{uuid}-{filename}
+```
+
+Example:
+
+```text
+tenants/tenant-123/invoices/inv-456/550e8400-e29b-41d4-a716-446655440000-invoice.pdf
+```
+
+Security benefits:
+
+- Tenant isolation
+- Invoice isolation
+- UUID-based object naming
+- Protection against object enumeration
+- Prevention of cross-tenant object access
+
+### Filename Validation
+
+Uploaded filenames are sanitized before storage.
+
+The storage layer:
+
+- Rejects path traversal attempts (`../`)
+- Rejects invalid filenames
+- Removes null bytes
+- Sanitizes special characters
+- Truncates excessively long filenames
+
+Examples:
+
+```text
+../../etc/passwd        -> rejected
+..\..\windows\system32 -> rejected
+invoice.pdf            -> accepted
+```
+
+### Tenant and Invoice Validation
+
+Tenant IDs and invoice IDs are validated before key generation.
+
+Allowed characters:
+
+```text
+a-z
+A-Z
+0-9
+_
+-
+```
+
+Rejected examples:
+
+```text
+../../admin
+tenant/admin
+inv/123
+```
+
+### MIME Type Validation
+
+Supported invoice file types:
+
+- application/pdf
+- image/jpeg
+- image/png
+- image/tiff
+
+Validation occurs during:
+
+- Direct uploads
+- Presigned URL generation
+
+Unsupported MIME types are rejected before any storage operation occurs.
+
+### File Size Limits
+
+Invoice uploads are limited by:
+
+```bash
+BODY_LIMIT_INVOICE
+```
+
+Default:
+
+```text
+512 KB
+```
+
+Files exceeding the configured limit are rejected.
+
+### Presigned URL Expiry Limits
+
+Upload URLs:
+
+```text
+15 minutes
+```
+
+Download URLs:
+
+```text
+Default: 1 hour
+Maximum: 24 hours
+```
+
+Requests outside the allowed expiry range are rejected.
+
+### Security Controls
+
+The invoice upload subsystem includes:
+
+- Path traversal protection
+- MIME type allow-listing
+- File size enforcement
+- Tenant isolation
+- Invoice isolation
+- UUID object naming
+- Presigned URL expiry limits
+- AWS credential non-disclosure
+- Server-side validation before S3 operations
+
 Core routes currently covered:
 
 - Health: `GET /health`

--- a/src/routes/invoiceFile.js
+++ b/src/routes/invoiceFile.js
@@ -63,13 +63,25 @@ router.post('/:id/presigned-upload', express.json(), async (req, res) => {
       message: 'Presigned upload URL generated',
     });
   } catch (error) {
-    if (error.code === 'INVALID_MIME_TYPE' || error.code === 'FILE_TOO_LARGE') {
+     if (
+      error.code === 'INVALID_MIME_TYPE' ||
+      error.code === 'FILE_TOO_LARGE' ||
+      error.code === 'INVALID_FILENAME' ||
+      error.code === 'INVALID_TENANT_ID' ||
+      error.code === 'INVALID_INVOICE_ID' ||
+      error.code === 'INVALID_EXPIRY'
+    ) {
       return res.status(400).json({
         error: 'Bad Request',
         message: error.message,
       });
     }
-    console.error('Presigned upload error:', error);
+   const logger = require('../logger');
+
+   logger.error(
+    { err: error, invoiceId: id },
+    'Failed to generate presigned upload URL'
+  );
     return res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to generate presigned upload URL',

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -73,18 +73,34 @@ class StorageService {
    * @param {string} filename - Raw filename from user input.
    * @returns {string} Sanitized filename safe for S3 key generation.
    */
+ 
   _sanitizeFilename(filename) {
-    if (!filename || typeof filename !== 'string') {
-      return 'unnamed';
-    }
-    let name = filename.replace(/\\/g, '/');
-    name = path.basename(name);
-    name = name.replace(/\0/g, '');
-    name = name.replace(/\.\./g, '');
-    name = name.replace(/[<>:"|?*\\/]/g, '_');
-    return name.slice(0, 255) || 'unnamed';
+  if (!filename || typeof filename !== 'string') {
+    const err = new Error('Invalid filename');
+    err.code = 'INVALID_FILENAME';
+    throw err;
   }
 
+  const normalized = path.posix.normalize(filename);
+
+  if (
+    normalized.includes('..') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('\\')
+  ) {
+    const err = new Error('Path traversal detected');
+    err.code = 'INVALID_FILENAME';
+    throw err;
+  }
+
+  let name = path.basename(normalized);
+
+  name = name.replace(/\0/g, '');
+
+  name = name.replace(/[<>:"|?*\\/]/g, '_');
+
+  return name.slice(0, 255);
+  }
   /**
    * Validates that the MIME type is in the allowed list.
    *
@@ -96,6 +112,38 @@ class StorageService {
   }
 
   /**
+ * Validates tenant identifiers.
+ * Only alphanumeric characters, underscores, and hyphens are allowed.
+ *
+ * @param {string} tenantId
+ * @returns {boolean}
+ */
+
+
+  _validateTenantId(tenantId) {
+    return (
+      typeof tenantId === 'string' &&
+      /^[a-zA-Z0-9_-]+$/.test(tenantId)
+    );
+  }
+
+
+  /**
+ * Validates invoice identifiers.
+ * Prevents path traversal and cross-tenant key manipulation.
+ *
+ * @param {string} invoiceId
+ * @returns {boolean}
+ */
+
+
+  _validateInvoiceId(invoiceId) {
+    return (
+      typeof invoiceId === 'string' &&
+      /^[a-zA-Z0-9_-]+$/.test(invoiceId)
+    );
+  }
+  /**
    * Generates a tenant/invoice-scoped S3 object key.
    * Format: tenants/{tenantId}/invoices/{invoiceId}/{uuid}-{safeName}
    *
@@ -104,10 +152,25 @@ class StorageService {
    * @param {string} safeName - Sanitized filename.
    * @returns {string} S3 object key.
    */
+
   _generateKey(tenantId, invoiceId, safeName) {
-    const uuid = crypto.randomUUID();
-    return `tenants/${tenantId}/invoices/${invoiceId}/${uuid}-${safeName}`;
+
+  if (!this._validateTenantId(tenantId)) {
+    const err = new Error('Invalid tenant ID');
+    err.code = 'INVALID_TENANT_ID';
+    throw err;
   }
+
+  if (!this._validateInvoiceId(invoiceId)) {
+    const err = new Error('Invalid invoice ID');
+    err.code = 'INVALID_INVOICE_ID';
+    throw err;
+  }
+
+  const uuid = crypto.randomUUID();
+
+  return `tenants/${tenantId}/invoices/${invoiceId}/${uuid}-${safeName}`;
+}
 
   /**
    * Uploads a file buffer to S3 with MIME type and size validation.
@@ -122,6 +185,20 @@ class StorageService {
    * @throws {Error} With code INVALID_MIME_TYPE if MIME type is rejected.
    */
   async uploadFile(fileBuffer, fileName, mimeType, tenantId = 'unknown', invoiceId = 'unknown') {
+    
+    
+    if (!this._validateTenantId(tenantId)) {
+      const err = new Error('Invalid tenant ID');
+      err.code = 'INVALID_TENANT_ID';
+      throw err;
+    }
+
+    if (!this._validateInvoiceId(invoiceId)) {
+      const err = new Error('Invalid invoice ID');
+      err.code = 'INVALID_INVOICE_ID';
+      throw err;
+    }
+
     if (fileBuffer.length > this.maxFileSize) {
       const err = new Error(`File size ${fileBuffer.length} exceeds maximum of ${this.maxFileSize} bytes`);
       err.code = 'FILE_TOO_LARGE';
@@ -160,6 +237,19 @@ class StorageService {
    * @throws {Error} With code FILE_TOO_LARGE if file size exceeds limit.
    */
   async getPresignedUploadUrl({ tenantId, invoiceId, fileName, mimeType, fileSize }) {
+    
+    if (!this._validateTenantId(tenantId)) {
+      const err = new Error('Invalid tenant ID');
+      err.code = 'INVALID_TENANT_ID';
+      throw err;
+    }
+
+if (!this._validateInvoiceId(invoiceId)) {
+      const err = new Error('Invalid invoice ID');
+      err.code = 'INVALID_INVOICE_ID';
+      throw err;
+    }
+        
     if (!this._validateMimeType(mimeType)) {
       const err = new Error(`Invalid MIME type: "${mimeType}". Allowed: ${ALLOWED_MIME_TYPES.join(', ')}`);
       err.code = 'INVALID_MIME_TYPE';
@@ -195,12 +285,26 @@ class StorageService {
    * @returns {Promise<string>} Presigned download URL.
    */
   async getSignedUrl(key, expiresIn = DEFAULT_DOWNLOAD_URL_EXPIRY_SEC) {
-    const safeExpiry = Math.min(Math.max(Math.floor(expiresIn), 1), MAX_DOWNLOAD_URL_EXPIRY_SEC);
+
+    const expiry = Math.floor(expiresIn);
+
+    if (
+      expiry < 1 ||
+      expiry > MAX_DOWNLOAD_URL_EXPIRY_SEC
+    ) {
+      const err = new Error(
+        `Expiry must be between 1 and ${MAX_DOWNLOAD_URL_EXPIRY_SEC} seconds`
+      );
+
+      err.code = 'INVALID_EXPIRY';
+
+      throw err;
+    }
     const command = new GetObjectCommand({
       Bucket: this.bucket,
       Key: key,
     });
-    return await getSignedUrl(s3Client, command, { expiresIn: safeExpiry });
+    return await getSignedUrl(s3Client, command, { expiresIn: expiry });
   }
 }
 

--- a/tests/sme.upload.test.js
+++ b/tests/sme.upload.test.js
@@ -225,8 +225,10 @@ describe('StorageService Unit - File Validation', () => {
   describe('_sanitizeFilename', () => {
     const svc = new StorageService();
 
-    it('should strip directory traversal attempts', () => {
-      expect(svc._sanitizeFilename('../../etc/passwd')).toBe('passwd');
+    it('should reject directory traversal attempts', () => {
+      expect(() =>
+        svc._sanitizeFilename('../../etc/passwd')
+      ).toThrow('Path traversal detected');
     });
 
     it('should handle simple filename', () => {
@@ -242,13 +244,13 @@ describe('StorageService Unit - File Validation', () => {
       expect(result).toBe('bad_chars_here_.pdf');
     });
 
-    it('should return "unnamed" for empty input', () => {
-      expect(svc._sanitizeFilename('')).toBe('unnamed');
+    it('should reject empty input', () => {
+      expect(() => svc._sanitizeFilename('')).toThrow('Invalid filename');
     });
 
-    it('should return "unnamed" for non-string input', () => {
-      expect(svc._sanitizeFilename(null)).toBe('unnamed');
-      expect(svc._sanitizeFilename(undefined)).toBe('unnamed');
+    it('should reject non-string input', () => {
+      expect(() => svc._sanitizeFilename(null)).toThrow('Invalid filename');
+      expect(() => svc._sanitizeFilename(undefined)).toThrow('Invalid filename');
     });
 
     it('should truncate long filenames', () => {
@@ -257,9 +259,11 @@ describe('StorageService Unit - File Validation', () => {
       expect(result.length).toBeLessThanOrEqual(255);
     });
 
-    it('should handle Windows backslash traversal', () => {
-      expect(svc._sanitizeFilename('..\\..\\windows\\system32')).toBe('system32');
-    });
+  it('should reject Windows traversal attempts', () => {
+    expect(() =>
+      svc._sanitizeFilename('..\\..\\windows\\system32')
+    ).toThrow();
+  });
 
     it('should handle angle brackets in filename', () => {
       const result = svc._sanitizeFilename('<script>alert(1)</script>.pdf');
@@ -297,6 +301,46 @@ describe('StorageService Unit - File Validation', () => {
 
     it('should reject empty string', () => {
       expect(svc._validateMimeType('')).toBe(false);
+    });
+  });
+
+  describe('_validateTenantId', () => {
+    const svc = new StorageService();
+
+    it('accepts valid tenant ids', () => {
+      expect(svc._validateTenantId('tenant-123')).toBe(true);
+    });
+
+    it('rejects path traversal', () => {
+      expect(svc._validateTenantId('../../admin')).toBe(false);
+    });
+
+    it('rejects slashes', () => {
+      expect(svc._validateTenantId('tenant/admin')).toBe(false);
+    });
+
+    it('rejects empty values', () => {
+      expect(svc._validateTenantId('')).toBe(false);
+    });
+  });
+
+  describe('_validateInvoiceId', () => {
+    const svc = new StorageService();
+
+    it('accepts valid invoice ids', () => {
+      expect(svc._validateInvoiceId('inv-123')).toBe(true);
+    });
+
+    it('rejects traversal attempts', () => {
+      expect(svc._validateInvoiceId('../../invoice')).toBe(false);
+    });
+
+    it('rejects slashes', () => {
+      expect(svc._validateInvoiceId('inv/123')).toBe(false);
+    });
+
+    it('rejects empty values', () => {
+      expect(svc._validateInvoiceId('')).toBe(false);
     });
   });
 
@@ -343,6 +387,30 @@ describe('StorageService Unit - File Validation', () => {
 
   describe('getPresignedUploadUrl validation', () => {
     const svc = new StorageService();
+
+    it('rejects invalid tenant ids', async () => {
+      await expect(
+        svc.getPresignedUploadUrl({
+          tenantId: '../../admin',
+          invoiceId: 'inv1',
+          fileName: 'file.pdf',
+          mimeType: 'application/pdf',
+          fileSize: 100,
+        })
+      ).rejects.toThrow();
+    });
+
+    it('rejects invalid invoice ids', async () => {
+      await expect(
+        svc.getPresignedUploadUrl({
+          tenantId: 'tenant1',
+          invoiceId: '../../invoice',
+          fileName: 'file.pdf',
+          mimeType: 'application/pdf',
+          fileSize: 100,
+        })
+      ).rejects.toThrow();
+    });
 
     it('should reject oversized file sizes', async () => {
       await expect(
@@ -445,5 +513,21 @@ describe('InvoiceFile Route - Presigned Upload (POST /api/invoices/:id/presigned
     expect(bodyString).not.toContain('AKIA');
     expect(bodyString).not.toContain('secretAccessKey');
     expect(bodyString).not.toContain('AWS');
+  });
+});
+
+describe('getSignedUrl expiry validation', () => {
+  const svc = new StorageService();
+
+  it('rejects expiry less than 1 second', async () => {
+    await expect(
+      svc.getSignedUrl('test-key', 0)
+    ).rejects.toThrow('Expiry must be between');
+  });
+
+  it('rejects expiry greater than max allowed', async () => {
+    await expect(
+      svc.getSignedUrl('test-key', 999999)
+    ).rejects.toThrow('Expiry must be between');
   });
 });


### PR DESCRIPTION
Closes #286

---

## Summary

Hardens S3 presigned URL generation and invoice file uploads by enforcing tenant-scoped object keys, path traversal protection, MIME allowlisting, and bounded URL expiry validation.

### Changes

* Enforced tenant/invoice-scoped S3 key generation
* Added validation against path traversal and cross-tenant access attempts
* Added expiry bounds validation for presigned URLs
* Re-validated MIME types server-side using the allowlist
* Added security-focused unit and route tests
* Documented key scoping and expiry limits in the README
* Added JSDoc for key construction and validation methods

### Security Impact

Prevents path traversal, cross-tenant key access, MIME spoofing, and excessive presigned URL lifetimes while ensuring presigned URLs are not exposed through application logs.
