### PR TITLE
feat(security): tighten HTTP security headers and CSP, and fix test s…

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -23,21 +23,26 @@ module.exports = {
     // Note: Prefer creating migrations for `node-pg-migrate` (Postgres) and
     // testing them against a Postgres instance. The SQLite configs here are
     // provided for convenience in local development only.
-    directory: './migrations',
+    client: 'sqlite3',
+    connection: {
+      filename: ':memory:',
+    },
+    migrations: {
+      directory: './migrations',
+    },
+    seeds: {
+      directory: './seeds',
+    },
+    useNullAsDefault: true,
   },
-  seeds: {
-    directory: './seeds',
-  },
-  useNullAsDefault: true,
-},
   production: {
-  client: 'pg',
+    client: 'pg',
     connection: process.env.DATABASE_URL,
-      migrations: {
-    directory: './migrations',
+    migrations: {
+      directory: './migrations',
     },
-  seeds: {
-    directory: './seeds',
+    seeds: {
+      directory: './seeds',
     },
-},
+  },
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     ]
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.665.0",
+    "@aws-sdk/s3-request-presigner": "^3.665.0",
     "@sentry/node": "^8.0.0",
+    "@stellar/stellar-sdk": "^16.0.1",
     "axios": "^1.16.1",
     "chessify-protocol": "^0.1.0",
     "cors": "^2.8.6",
@@ -53,14 +56,12 @@
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "multer": "^1.4.5-lts.1",
-    "@aws-sdk/client-s3": "^3.665.0",
-    "@aws-sdk/s3-request-presigner": "^3.665.0",
+    "nanoid": "^5.1.9",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
     "pino-pretty": "^13.1.3",
     "prom-client": "^15.1.3",
     "sqlite3": "^5.1.6",
-    "nanoid": "^5.1.9",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,8 @@ require('dotenv').config();
 
 const express = require('express');
 const cors = require('cors');
-const { callSorobanContract } = require('./services/soroban');
+const { createSecurityMiddleware } = require('./middleware/security');
+const { auditMiddleware } = require('./middleware/audit');
 const invoiceService = require('./services/invoiceService');
 const { resolveEscrowAddress } = require('./config/escrowMap');
 const { getEscrowStateWithProjection } = require('./services/escrowRead');
@@ -117,6 +118,10 @@ function createApp() {
   // ── 2 & 3. Body-size guardrails ──────────────────────────────────────────
   app.use(...jsonBodyLimit());
   app.use(...urlencodedBodyLimit());
+
+// Apply security headers middleware
+  app.use(createSecurityMiddleware());
+  app.use(auditMiddleware);
 
   // ── 4. Routes ────────────────────────────────────────────────────────────
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -30,7 +30,7 @@ const ConfigSchema = z
     KYC_PROVIDER_SECRET: z.string().min(1).optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.NODE_ENV === 'test') return;
+    if (data.NODE_ENV === 'test') { return; }
     const hasUrl = Boolean(data.KYC_PROVIDER_URL);
     const hasKey = Boolean(data.KYC_PROVIDER_API_KEY);
     if (hasUrl !== hasKey) {
@@ -76,8 +76,45 @@ function get() {
   return config;
 }
 
+const securityHeaders = {
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'"],
+      imgSrc: ["'self'", "data:"],
+      connectSrc: ["'self'"],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      mediaSrc: ["'self'"],
+      frameSrc: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"]
+    }
+  },
+  referrerPolicy: { policy: 'no-referrer' },
+  hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+  // Less restrictive CSP for Swagger UI docs
+  docsContentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:"],
+      connectSrc: ["'self'"],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      mediaSrc: ["'self'"],
+      frameSrc: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"]
+    }
+  }
+};
+
 module.exports = {
   validate,
   get,
   ConfigSchema,
+  securityHeaders,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -33,14 +33,17 @@ function resetStore() {
   // intentional no-op
 }
 
+const originalCreateApp = app.createApp;
+
 /**
  * Returns the underlying Express app factory.
  *
  * @returns {import('express').Express} Configured Express app.
  */
 function createApp() {
-  return typeof app.createApp === 'function' ? app.createApp() : app;
+  return typeof originalCreateApp === 'function' ? originalCreateApp() : app;
 }
+
 
 if (process.env.NODE_ENV !== 'test' && require.main === module) {
   startServer();

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -1,45 +1,69 @@
 'use strict';
 
 const helmet = require('helmet');
+const { securityHeaders } = require('../config');
 
 /**
- * Creates and returns configured Helmet security middleware.
- * @returns {Function} Express middleware that sets secure HTTP response headers.
+ * Security middleware factory.
+ * Applies Helmet with the appropriate Content‑Security‑Policy based on the request path.
+ * For Swagger/OpenAPI docs routes (`/api-docs` or `/docs`) a relaxed CSP is used to allow
+ * inline scripts/styles required by the UI. All other routes receive the strict default CSP.
+ * All other security headers are sourced from `securityHeaders` defined in the config module.
+ *
+ * @returns {import('express').RequestHandler}
  */
 function createSecurityMiddleware() {
-  return helmet({
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"],
-        scriptSrc: ["'self'"],
-        styleSrc: ["'self'"],
-        imgSrc: ["'self'", 'data:'],
-        connectSrc: ["'self'"],
-        fontSrc: ["'self'"],
-        objectSrc: ["'none'"],
-        mediaSrc: ["'self'"],
-        frameSrc: ["'none'"],
-        baseUri: ["'self'"],
-        formAction: ["'self'"],
-      },
-    },
-    crossOriginEmbedderPolicy: { policy: 'require-corp' },
-    crossOriginOpenerPolicy: { policy: 'same-origin' },
-    crossOriginResourcePolicy: { policy: 'same-origin' },
-    dnsPrefetchControl: { allow: false },
-    frameguard: { action: 'deny' },
-    hidePoweredBy: true,
-    hsts: {
-      maxAge: 31536000,
-      includeSubDomains: true,
-      preload: true,
-    },
-    ieNoOpen: true,
-    noSniff: true,
-    originAgentCluster: true,
-    permittedCrossDomainPolicies: { permittedPolicies: 'none' },
-    referrerPolicy: { policy: 'no-referrer' },
-  });
+  return (req, res, next) => {
+    const isDocs = req.path && (/^\/api-docs|\/docs/.test(req.path));
+
+    const csp = isDocs ? securityHeaders.docsContentSecurityPolicy : securityHeaders.contentSecurityPolicy;
+
+    // Helmet expects an options object; we spread the common options and inject the chosen CSP.
+    const helmetOptions = {
+      contentSecurityPolicy: csp,
+      referrerPolicy: securityHeaders.referrerPolicy,
+      hsts: securityHeaders.hsts,
+      crossOriginEmbedderPolicy: { policy: 'require-corp' },
+      crossOriginOpenerPolicy: { policy: 'same-origin' },
+      crossOriginResourcePolicy: { policy: 'same-origin' },
+      dnsPrefetchControl: { allow: false },
+      frameguard: { action: 'deny' },
+      hidePoweredBy: true,
+      ieNoOpen: true,
+      noSniff: true,
+      originAgentCluster: true,
+      permittedCrossDomainPolicies: { permittedPolicies: 'none' },
+    };
+
+    return helmet(helmetOptions)(req, res, next);
+  };
 }
 
-module.exports = { createSecurityMiddleware };
+/**
+ * Explicit middleware for the documentation route.
+ * This is kept for backward compatibility – it applies the docs‑specific CSP directly.
+ *
+ * @returns {import('express').RequestHandler}
+ */
+function createDocsSecurityMiddleware() {
+  return (req, res, next) => {
+    const helmetOptions = {
+      contentSecurityPolicy: securityHeaders.docsContentSecurityPolicy,
+      referrerPolicy: securityHeaders.referrerPolicy,
+      hsts: securityHeaders.hsts,
+      crossOriginEmbedderPolicy: { policy: 'require-corp' },
+      crossOriginOpenerPolicy: { policy: 'same-origin' },
+      crossOriginResourcePolicy: { policy: 'same-origin' },
+      dnsPrefetchControl: { allow: false },
+      frameguard: { action: 'deny' },
+      hidePoweredBy: true,
+      ieNoOpen: true,
+      noSniff: true,
+      originAgentCluster: true,
+      permittedCrossDomainPolicies: { permittedPolicies: 'none' },
+    };
+    return helmet(helmetOptions)(req, res, next);
+  };
+}
+
+module.exports = { createSecurityMiddleware, createDocsSecurityMiddleware };

--- a/src/services/escrowRead.js
+++ b/src/services/escrowRead.js
@@ -333,6 +333,73 @@ async function readFundedAmount(invoiceId, options = {}) {
   return Number.isFinite(amount) ? amount : 0;
 }
 
+/**
+ * Retrieves the escrow state from the projection or cache,
+ * falling back to live read if necessary.
+ *
+ * @param {string} invoiceId - Invoice identifier
+ * @returns {Promise<Object>} The escrow state
+ */
+async function getEscrowStateWithProjection(invoiceId) {
+  const safeId = invoiceId.trim();
+
+  // Try cache first if enabled
+  if (cache) {
+    const cacheResult = await cache.getSummary(safeId);
+    if (cacheResult.hit) {
+      return cacheResult.value;
+    }
+  }
+
+  // Try projection table
+  const projection = await db('escrow_event_projection')
+    .where('invoice_id', safeId)
+    .first();
+
+  if (projection) {
+    let eventBody = {};
+    try {
+      eventBody = JSON.parse(projection.latest_event_body);
+    } catch (_e) {
+      // Fallback if not JSON
+    }
+
+    const state = {
+      invoiceId: safeId,
+      status: eventBody.status || projection.latest_event_type,
+      fundedAmount: eventBody.fundedAmount || 0,
+      latest_ledger_sequence: parseInt(projection.latest_ledger_sequence, 10),
+      latest_event_type: projection.latest_event_type,
+      fromProjection: true
+    };
+
+    // Update cache
+    if (cache) {
+      await cache.setSummary(safeId, state, state.latest_ledger_sequence);
+    }
+    return state;
+  }
+
+  // Fallback to live read
+  const baseState = await _fetchBaseEscrowState(safeId);
+  const legalHold = await fetchLegalHold(safeId);
+
+  const state = {
+    ...baseState,
+    legal_hold: legalHold,
+    latest_event_type: 'live_read'
+  };
+
+  if (cache) {
+    // For live reads, we might not know the exact ledger, so we omit it
+    await cache.setSummary(safeId, state);
+  }
+
+  return state;
+}
+
+
+
 module.exports = {
   readEscrowState,
   readEscrowStateWithAttestations,

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const db = require('../db'); // project's shared Knex instance
+const db = require('../db/knex'); // project's shared Knex instance
 
 const TABLE = 'investor_commitments';
 
@@ -100,7 +100,9 @@ async function updateCommitment(id, fields) {
     .where({ id })
     .update({ ...fields, updated_at: db.fn.now() })
     .returning('*');
-  if (!row) throw new Error(`Commitment not found: ${id}`);
+  if (!row) {
+    throw new Error(`Commitment not found: ${id}`);
+  }
   return row;
 }
 

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -1,6 +1,15 @@
 
+process.env.JWT_SECRET = 'test-secret-at-least-32-characters-long-string-for-jest';
+require('../../src/config').validate();
+
+let mockInMemoryDb = [];
+let mockCurrentTable = null;
+
 jest.mock('../../src/db/knex', () => {
-  const m = jest.fn(() => m);
+  const m = jest.fn((table) => {
+    mockCurrentTable = table;
+    return m;
+  });
   m.where = jest.fn().mockReturnThis();
   m.whereNotIn = jest.fn().mockReturnThis();
   m.whereNull = jest.fn().mockReturnThis();
@@ -8,8 +17,16 @@ jest.mock('../../src/db/knex', () => {
   m.leftJoin = jest.fn().mockReturnThis();
   m.orderBy = jest.fn().mockReturnThis();
   m.limit = jest.fn().mockReturnThis();
+  m.offset = jest.fn().mockReturnThis();
   m.select = jest.fn().mockReturnThis();
-  m.insert = jest.fn().mockReturnThis();
+  m.insert = jest.fn((row) => {
+    const rows = Array.isArray(row) ? row : [row];
+    const inserted = rows.map(r => ({ id: Math.random().toString(), created_at: new Date().toISOString(), ...r }));
+    if (mockCurrentTable === 'audit_log_events') {
+      mockInMemoryDb.push(...inserted);
+    }
+    return Promise.resolve(inserted);
+  });
   m.update = jest.fn().mockReturnThis();
   m.del = jest.fn().mockResolvedValue(1);
   m.first = jest.fn().mockResolvedValue({ id: 'test', kyc_status: 'approved' });
@@ -19,5 +36,35 @@ jest.mock('../../src/db/knex', () => {
   m.orWhere = jest.fn().mockReturnThis();
   m.count = jest.fn().mockResolvedValue([{ count: 25 }]);
   m.raw = jest.fn();
+  m.then = jest.fn((onFulfilled) => {
+    if (mockCurrentTable === 'audit_log_events') {
+      return Promise.resolve(mockInMemoryDb).then(onFulfilled);
+    }
+    return Promise.resolve([]).then(onFulfilled);
+  });
   return m;
 }, { virtual: true });
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  nativeToScVal: jest.fn(),
+  Address: {
+    fromString: jest.fn(() => ({
+      toScVal: jest.fn(),
+    })),
+  },
+  Keypair: {
+    fromSecret: jest.fn(() => ({
+      publicKey: jest.fn(() => 'mock-public-key'),
+      sign: jest.fn(),
+    })),
+  },
+}), { virtual: true });
+
+jest.mock('@stellar/stellar-sdk/rpc', () => ({
+  Server: jest.fn().mockImplementation(() => ({
+    getTransaction: jest.fn(),
+    sendTransaction: jest.fn(),
+    simulateTransaction: jest.fn(),
+  })),
+}), { virtual: true });
+

--- a/tests/security.middleware.test.js
+++ b/tests/security.middleware.test.js
@@ -43,11 +43,11 @@ describe('Security Middlewares Integration', () => {
     const response = await request(app)
       .post('/api/invoices')
       .set('Authorization', `Bearer ${token}`)
-      .send({ amount: 100, customer: 'Test Corp' });
+      .send({ amount: 100, buyer: 'Acme', seller: 'Seller', dueDate: '2026-12-31', currency: 'USD', invoiceNumber: 'INV-123' });
 
     expect(response.status).toBe(201);
 
-    const logs = getAuditLogs();
+    const logs = await getAuditLogs();
     const lastLog = logs[logs.length - 1];
     const logString = JSON.stringify(lastLog).toLowerCase();
 


### PR DESCRIPTION
this pr closes #285 This PR hardens the HTTP security headers and Content-Security-Policy (CSP) across the API surface while maintaining the functionality of the OpenAPI documentation routes. It also addresses several pre-existing syntax, reference, and mock errors that were preventing the test suite and application from starting.