### PR TITLE
Fix pagination to the marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,37 @@ The API is documented using OpenAPI 3.0 specification.
 
 The documentation covers all public endpoints including health checks, invoice management, escrow operations, and investment opportunities.
 
-- **Marketplace**: `GET /api/marketplace` - Search and sort invoices by yield, maturity, and funded ratio. Supports advanced filtering (`yieldBpsMin`, `maturityDateTo`, `fundedRatioMin`, etc.) and pagination.
+- **Marketplace**: `GET /api/marketplace` - Search and sort invoices by yield, maturity, and funded ratio. Supports advanced filtering (`yieldBpsMin`, `maturityDateTo`, `fundedRatioMin`, etc.) and both **cursor-based** and offset pagination.
 
-**Example:**
+  **Cursor pagination (recommended)** — stable under inserts/deletes; use the `nextCursor` value from one response as the `cursor` param in the next request. Cursors are opaque and HMAC-signed; any modification returns 400.
+
+  **Offset pagination (legacy)** — use `page` + `limit` as before. `nextCursor` and `hasMore` are also returned so clients can migrate incrementally.
+
+  | Param | Mode | Description |
+  |---|---|---|
+  | `cursor` | Cursor | Opaque cursor from previous `nextCursor`; invalidates `page` |
+  | `limit` | Both | Page size (1–100, default 10) |
+  | `page` | Offset | 1-based page number (ignored when `cursor` present) |
+  | `sortBy` | Both | `yield_bps` \| `maturity_date` \| `funded_ratio` \| `amount` \| `created_at` |
+  | `order` | Both | `asc` \| `desc` (must be consistent across pages in cursor mode) |
+
+**Example — first page (cursor mode):**
 ```bash
 curl -H "Authorization: Bearer <token>" \
-     "http://localhost:3001/api/marketplace?yieldBpsMin=500&sortBy=yield_bps&order=desc"
+     "http://localhost:3001/api/marketplace?sortBy=yield_bps&order=desc&limit=10"
+# Response meta: { total, limit, hasMore, nextCursor }
+```
+
+**Example — next page:**
+```bash
+curl -H "Authorization: Bearer <token>" \
+     "http://localhost:3001/api/marketplace?sortBy=yield_bps&order=desc&limit=10&cursor=<nextCursor>"
+```
+
+**Example — with filters (offset mode):**
+```bash
+curl -H "Authorization: Bearer <token>" \
+     "http://localhost:3001/api/marketplace?yieldBpsMin=500&sortBy=yield_bps&order=desc&page=2&limit=10"
 ```
 
 ---

--- a/src/routes/marketplace.js
+++ b/src/routes/marketplace.js
@@ -9,6 +9,7 @@ const express = require('express');
 const router = express.Router();
 const marketplaceService = require('../services/marketplaceService');
 const { validateMarketplaceQueryParams } = require('../utils/validators');
+const { CursorError } = require('../utils/cursorPagination');
 const { authenticatedTenantStack } = require('../middleware/stacks');
 const logger = require('../logger');
 
@@ -19,7 +20,21 @@ router.use(...authenticatedTenantStack);
  * /api/marketplace:
  *   get:
  *     summary: Search and sort marketplace invoices
- *     description: Retrieve a paginated list of invoices available in the marketplace with advanced filtering and sorting.
+ *     description: |
+ *       Retrieve a paginated list of invoices available in the marketplace with
+ *       advanced filtering and sorting.
+ *
+ *       **Pagination modes**
+ *
+ *       | Mode | Parameters | Notes |
+ *       |------|-----------|-------|
+ *       | Cursor (recommended) | `cursor` + `limit` | Stable under inserts/deletes; use `nextCursor` from the previous response |
+ *       | Offset (legacy) | `page` + `limit` | Backward-compatible; may drift on busy datasets |
+ *
+ *       When `cursor` is supplied, `page` is ignored.
+ *       The cursor is opaque and HMAC-signed — any modification returns 400.
+ *       Cursors are tied to a specific `sortBy` field; switching sort order
+ *       mid-pagination requires starting from the first page (no `cursor`).
  *     tags: [Marketplace]
  *     security:
  *       - bearerAuth: []
@@ -28,16 +43,19 @@ router.use(...authenticatedTenantStack);
  *         name: status
  *         schema:
  *           type: string
- *         description: Filter by invoice status
+ *           enum: [verified, partially_funded]
+ *         description: Filter by invoice status (only publicly investable statuses allowed)
  *       - in: query
  *         name: yieldBpsMin
  *         schema:
  *           type: integer
+ *           minimum: 0
  *         description: Minimum yield in basis points
  *       - in: query
  *         name: yieldBpsMax
  *         schema:
  *           type: integer
+ *           minimum: 0
  *         description: Maximum yield in basis points
  *       - in: query
  *         name: maturityDateFrom
@@ -55,32 +73,45 @@ router.use(...authenticatedTenantStack);
  *         name: fundedRatioMin
  *         schema:
  *           type: number
- *         description: Minimum funded ratio (0-100)
+ *           minimum: 0
+ *           maximum: 100
+ *         description: Minimum funded ratio (0–100)
  *       - in: query
  *         name: fundedRatioMax
  *         schema:
  *           type: number
- *         description: Maximum funded ratio (0-100)
+ *           minimum: 0
+ *           maximum: 100
+ *         description: Maximum funded ratio (0–100)
  *       - in: query
  *         name: sortBy
  *         schema:
  *           type: string
  *           enum: [yield_bps, maturity_date, funded_ratio, amount, created_at]
- *         description: Field to sort by
+ *           default: created_at
+ *         description: Field to sort by. Must stay constant across pages when using cursor pagination.
  *       - in: query
  *         name: order
  *         schema:
  *           type: string
  *           enum: [asc, desc]
  *           default: desc
- *         description: Sort order
+ *         description: Sort order. Must stay constant across pages when using cursor pagination.
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *         description: |
+ *           Opaque, HMAC-signed cursor returned as `nextCursor` in a previous
+ *           response.  When present, offset-based `page` is ignored.
+ *           A malformed or tampered cursor returns 400.
  *       - in: query
  *         name: page
  *         schema:
  *           type: integer
  *           minimum: 1
  *           default: 1
- *         description: Page number
+ *         description: Page number (offset mode only; ignored when `cursor` is supplied)
  *       - in: query
  *         name: limit
  *         schema:
@@ -88,7 +119,7 @@ router.use(...authenticatedTenantStack);
  *           minimum: 1
  *           maximum: 100
  *           default: 10
- *         description: Items per page
+ *         description: Items per page (applies to both pagination modes)
  *     responses:
  *       200:
  *         description: Marketplace invoices retrieved successfully
@@ -96,7 +127,42 @@ router.use(...authenticatedTenantStack);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/MarketplaceListResponse'
+ *             examples:
+ *               cursorFirstPage:
+ *                 summary: First page (cursor mode)
+ *                 value:
+ *                   data: []
+ *                   meta:
+ *                     total: 42
+ *                     limit: 10
+ *                     hasMore: true
+ *                     nextCursor: "eyJzb3J0RmllbGQiOiJ5aWVsZF9icHMi....<sig>"
+ *                   message: "Marketplace invoices retrieved successfully."
+ *               cursorLastPage:
+ *                 summary: Last page (cursor mode)
+ *                 value:
+ *                   data: []
+ *                   meta:
+ *                     total: 42
+ *                     limit: 10
+ *                     hasMore: false
+ *                     nextCursor: null
+ *                   message: "Marketplace invoices retrieved successfully."
+ *               offsetMode:
+ *                 summary: Offset mode (legacy)
+ *                 value:
+ *                   data: []
+ *                   meta:
+ *                     total: 42
+ *                     page: 2
+ *                     limit: 10
+ *                     totalPages: 5
+ *                     hasMore: true
+ *                     nextCursor: "eyJzb3J0RmllbGQiOiJ5aWVsZF9icHMi....<sig>"
+ *                   message: "Marketplace invoices retrieved successfully."
  *       400:
+ *         description: |
+ *           Invalid query parameters or malformed/tampered cursor.
  *         $ref: '#/components/responses/Problem400'
  *       401:
  *         $ref: '#/components/responses/Problem401'
@@ -123,15 +189,26 @@ router.get('/', async (req, res, next) => {
       });
     }
 
-    const result = await marketplaceService.getMarketplaceInvoices({
-      tenantId: req.tenantId,
-      queryParams: validatedParams,
-    });
+    let result;
+    try {
+      result = await marketplaceService.getMarketplaceInvoices({
+        tenantId: req.tenantId,
+        queryParams: validatedParams,
+      });
+    } catch (err) {
+      // CursorError is a client error (malformed/tampered cursor) → 400
+      if (err instanceof CursorError) {
+        return res.status(400).json({ errors: [err.message] });
+      }
+      throw err;
+    }
 
-    logger.info({ 
-      requestId: req.id, 
+    logger.info({
+      requestId: req.id,
       count: result.data.length,
-      total: result.meta.total 
+      total: result.meta.total,
+      hasMore: result.meta.hasMore,
+      usedCursor: Boolean(validatedParams.pagination && validatedParams.pagination.cursor),
     }, 'Retrieved marketplace invoices');
 
     return res.json({

--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -127,30 +127,29 @@ async function getMarketplaceInvoices({ tenantId, queryParams }) {
     : 'created_at';
   const order = (sorting.order === 'asc') ? 'asc' : 'desc';
 
-  // ── Base query (tenant-scoped, visibility-filtered) ──────────────────────
+  // ── Base query factory (tenant-scoped, visibility-filtered) ─────────────
   const baseQuery = () =>
     db('invoices')
       .whereNull('deleted_at')
       .where('tenant_id', tenantId)
       .whereIn('status', PUBLIC_INVESTABLE_INVOICE_STATUSES);
 
-  // ── Total count (always offset-independent) ──────────────────────────────
+  // ── Total count (filter-aware, always offset-independent) ────────────────
   let countQ = baseQuery();
   _applyFilters(countQ, filters);
   const countRow = await countQ.count('* as total').first();
   const total = parseInt(countRow.total ?? countRow['count(*)'] ?? 0);
 
-  // ── Data query ────────────────────────────────────────────────────────────
-  let dataQ = baseQuery().select('*');
-  _applyFilters(dataQ, filters);
-
   const useCursor = Boolean(pagination.cursor);
 
+  // ── Cursor-based keyset pagination ────────────────────────────────────────
   if (useCursor) {
-    // Cursor-based keyset pagination
     // decodeCursor validates HMAC and sort-field match; throws CursorError on failure.
     const decoded = decodeCursor(pagination.cursor, sortField);
     const { sortValue, id: lastId } = decoded;
+
+    let dataQ = baseQuery().select('*');
+    _applyFilters(dataQ, filters);
 
     // Keyset predicate:
     //   ASC:  (sortField > lastValue) OR (sortField = lastValue AND id > lastId)
@@ -162,47 +161,19 @@ async function getMarketplaceInvoices({ tenantId, queryParams }) {
           this.where(sortField, '=', sortValue).where('id', gtOp, lastId);
         });
     });
-  }
 
-  // Apply sort: primary on sortField, secondary tiebreaker on id
-  dataQ.orderBy(sortField, order).orderBy('id', order);
+    // Primary sort on sortField, secondary tiebreaker on id
+    dataQ.orderBy(sortField, order).orderBy('id', order);
 
-  // Fetch one extra row to determine `hasMore`
-  const rows = await dataQ.limit(limit + 1);
+    // Fetch one extra row to determine hasMore without a second COUNT query
+    const rows = await dataQ.limit(limit + 1);
+    const hasMore = rows.length > limit;
+    const data = hasMore ? rows.slice(0, limit) : rows;
 
-  const hasMore = rows.length > limit;
-  const data = hasMore ? rows.slice(0, limit) : rows;
-
-  // Build nextCursor from last item in the returned page (if there is a next page)
-  let nextCursor = null;
-  if (hasMore && data.length > 0) {
-    const lastRow = data[data.length - 1];
-    nextCursor = encodeCursor({
-      sortField,
-      sortValue: lastRow[sortField],
-      id: lastRow.id,
-    });
-  }
-
-  // ── Offset fallback (legacy mode) ─────────────────────────────────────────
-  if (!useCursor) {
-    const page = Math.max(1, parseInt(pagination.page) || 1);
-    const offset = (page - 1) * limit;
-    const pagedRows = await baseQuery()
-      .select('*')
-      .where(qb => { _applyFilters(qb, filters); })
-      .orderBy(sortField, order)
-      .orderBy('id', order)
-      .limit(limit + 1)
-      .offset(offset);
-
-    const pagedHasMore = pagedRows.length > limit;
-    const pagedData = pagedHasMore ? pagedRows.slice(0, limit) : pagedRows;
-
-    let pagedNextCursor = null;
-    if (pagedHasMore && pagedData.length > 0) {
-      const lastRow = pagedData[pagedData.length - 1];
-      pagedNextCursor = encodeCursor({
+    let nextCursor = null;
+    if (hasMore && data.length > 0) {
+      const lastRow = data[data.length - 1];
+      nextCursor = encodeCursor({
         sortField,
         sortValue: lastRow[sortField],
         id: lastRow.id,
@@ -210,25 +181,47 @@ async function getMarketplaceInvoices({ tenantId, queryParams }) {
     }
 
     return {
-      data: pagedData,
+      data,
       meta: {
         total,
-        page,
         limit,
-        totalPages: Math.ceil(total / limit),
-        hasMore: pagedHasMore,
-        nextCursor: pagedNextCursor,
+        hasMore,
+        nextCursor,
       },
     };
   }
 
+  // ── Offset-based pagination (legacy, backward-compatible) ─────────────────
+  const page = Math.max(1, parseInt(pagination.page) || 1);
+  const offset = (page - 1) * limit;
+
+  let dataQ = baseQuery().select('*');
+  _applyFilters(dataQ, filters);
+  dataQ.orderBy(sortField, order).orderBy('id', order);
+
+  const pagedRows = await dataQ.limit(limit + 1).offset(offset);
+  const pagedHasMore = pagedRows.length > limit;
+  const pagedData = pagedHasMore ? pagedRows.slice(0, limit) : pagedRows;
+
+  let pagedNextCursor = null;
+  if (pagedHasMore && pagedData.length > 0) {
+    const lastRow = pagedData[pagedData.length - 1];
+    pagedNextCursor = encodeCursor({
+      sortField,
+      sortValue: lastRow[sortField],
+      id: lastRow.id,
+    });
+  }
+
   return {
-    data,
+    data: pagedData,
     meta: {
       total,
+      page,
       limit,
-      hasMore,
-      nextCursor,
+      totalPages: Math.ceil(total / limit),
+      hasMore: pagedHasMore,
+      nextCursor: pagedNextCursor,
     },
   };
 }

--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -1,13 +1,38 @@
 'use strict';
 
 const db = require('../db/knex');
+const { encodeCursor, decodeCursor, CursorError } = require('../utils/cursorPagination');
 
 /**
  * Marketplace Service
- * 
- * Handles database operations for the marketplace, allowing search and 
- * sorting of invoices by yield, maturity, and funded ratio.
- * 
+ *
+ * Handles database operations for the marketplace, allowing search and sorting
+ * of invoices by yield, maturity, and funded ratio.
+ *
+ * Pagination modes
+ * ─────────────────
+ * 1. Cursor-based (preferred): supply `pagination.cursor`.  The service decodes
+ *    the opaque cursor, validates its HMAC signature, and converts it into a
+ *    keyset WHERE clause (`(sortField, id) > (lastValue, lastId)` for ASC, or
+ *    the reverse for DESC).  This is stable under inserts/deletes and scales to
+ *    arbitrarily large tables without the drift that OFFSET causes.
+ *
+ * 2. Offset-based (legacy / backward-compatible): supply `pagination.page` and
+ *    `pagination.limit` without `pagination.cursor`.  Returns the same response
+ *    shape as before so existing clients are unaffected.  `nextCursor` and
+ *    `hasMore` are still included in the meta block.
+ *
+ * Security
+ * ────────
+ * - Tenant scoping (`WHERE tenant_id = ?`) is always applied server-side and
+ *   cannot be altered by cursor content.
+ * - Filter constraints are re-applied on every request; a cursor cannot be used
+ *   to retrieve rows that would otherwise be excluded by the caller's filters.
+ * - Cursors are HMAC-signed; any structural change causes a CursorError which
+ *   the route layer maps to HTTP 400.
+ * - Sort-field mismatch between the cursor and the current request is detected
+ *   and rejected before the query is built.
+ *
  * @module services/marketplaceService
  */
 
@@ -15,7 +40,12 @@ const db = require('../db/knex');
  * Configuration for marketplace query options.
  */
 const MARKETPLACE_QUERY_CONFIG = {
-  allowedFilters: ['status', 'yieldBpsMin', 'yieldBpsMax', 'maturityDateFrom', 'maturityDateTo', 'fundedRatioMin', 'fundedRatioMax'],
+  allowedFilters: [
+    'status',
+    'yieldBpsMin', 'yieldBpsMax',
+    'maturityDateFrom', 'maturityDateTo',
+    'fundedRatioMin', 'fundedRatioMax',
+  ],
   allowedSortFields: ['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at'],
   columnMap: {
     yieldBpsMin: 'yield_bps',
@@ -26,83 +56,181 @@ const MARKETPLACE_QUERY_CONFIG = {
     fundedRatioMax: 'funded_ratio',
     yieldBps: 'yield_bps',
     maturityDate: 'maturity_date',
-    fundedRatio: 'funded_ratio'
-  }
+    fundedRatio: 'funded_ratio',
+  },
 };
 
 /**
  * Explicit visibility rules for marketplace listings.
  *
  * Only these invoice statuses are considered publicly investable (i.e. appear
- * in the marketplace/invest listings). Other statuses are tenant-private and
+ * in the marketplace/invest listings).  Other statuses are tenant-private and
  * MUST NOT be exposed via read/list endpoints.
  */
 const PUBLIC_INVESTABLE_INVOICE_STATUSES = Object.freeze(['verified', 'partially_funded']);
 
 /**
- * Retrieves invoices for the marketplace with filtering, sorting, and pagination.
- * 
- * @param {Object} options - The validated query parameters + tenant context.
- * @param {string} options.tenantId - The resolved tenant identifier (server-side).
- * @param {Object} options.queryParams - The validated query parameters.
- * @returns {Promise<{data: Array, meta: Object}>} A promise that resolves to the list of invoices and metadata.
+ * Applies shared filter conditions to a Knex query builder.
+ * Extracted so the same logic is used for both the data query and the count
+ * query, avoiding accidental drift between the two.
+ *
+ * @param {import('knex').QueryBuilder} query
+ * @param {Object} filters - Validated filter params from `validateMarketplaceQueryParams`.
+ * @returns {import('knex').QueryBuilder} The same query builder (mutated in place).
+ */
+function _applyFilters(query, filters) {
+  if (filters.yieldBpsMin !== undefined) { query.where('yield_bps', '>=', filters.yieldBpsMin); }
+  if (filters.yieldBpsMax !== undefined) { query.where('yield_bps', '<=', filters.yieldBpsMax); }
+  if (filters.maturityDateFrom) { query.where('maturity_date', '>=', filters.maturityDateFrom); }
+  if (filters.maturityDateTo)   { query.where('maturity_date', '<=', filters.maturityDateTo);   }
+  if (filters.fundedRatioMin !== undefined) { query.where('funded_ratio', '>=', filters.fundedRatioMin); }
+  if (filters.fundedRatioMax !== undefined) { query.where('funded_ratio', '<=', filters.fundedRatioMax); }
+  if (filters.status) { query.where('status', filters.status); }
+  return query;
+}
+
+/**
+ * Retrieves invoices for the marketplace with filtering, sorting, and
+ * cursor-based (or offset) pagination.
+ *
+ * @param {Object}  options
+ * @param {string}  options.tenantId    - The resolved tenant identifier (server-side).
+ * @param {Object}  options.queryParams - Validated query parameters from the validator.
+ * @param {Object}  [options.queryParams.filters={}]
+ * @param {Object}  [options.queryParams.sorting={}]
+ * @param {Object}  [options.queryParams.pagination={}]
+ *   - `cursor`  {string}  — opaque cursor for keyset pagination
+ *   - `page`    {number}  — 1-based page number (offset mode, ignored when cursor present)
+ *   - `limit`   {number}  — page size (1–100, default 10)
+ *
+ * @returns {Promise<{data: Array, meta: Object}>}
+ *   `meta` always contains `{ total, limit, nextCursor, hasMore }`.
+ *   In offset mode it also contains `{ page, totalPages }`.
+ *
+ * @throws {CursorError} When the cursor is malformed or tampered (route maps to 400).
+ * @throws {Error}       On unexpected database errors.
  */
 async function getMarketplaceInvoices({ tenantId, queryParams }) {
-  try {
-    if (!tenantId || typeof tenantId !== 'string') {
-      throw new Error('Missing tenant context');
-    }
-    const { filters = {}, sorting = {}, pagination = { page: 1, limit: 10 } } = queryParams;
-    
-    let query = db('invoices')
-      .select('*')
+  if (!tenantId || typeof tenantId !== 'string') {
+    throw new Error('Missing tenant context');
+  }
+
+  const {
+    filters = {},
+    sorting = {},
+    pagination = {},
+  } = queryParams;
+
+  const limit = Math.max(1, Math.min(100, parseInt(pagination.limit) || 10));
+  const sortField = (sorting.sortBy && MARKETPLACE_QUERY_CONFIG.allowedSortFields.includes(sorting.sortBy))
+    ? sorting.sortBy
+    : 'created_at';
+  const order = (sorting.order === 'asc') ? 'asc' : 'desc';
+
+  // ── Base query (tenant-scoped, visibility-filtered) ──────────────────────
+  const baseQuery = () =>
+    db('invoices')
       .whereNull('deleted_at')
       .where('tenant_id', tenantId)
       .whereIn('status', PUBLIC_INVESTABLE_INVOICE_STATUSES);
 
-    // Apply filters
-    if (filters.yieldBpsMin) {query.where('yield_bps', '>=', filters.yieldBpsMin);}
-    if (filters.yieldBpsMax) {query.where('yield_bps', '<=', filters.yieldBpsMax);}
-    if (filters.maturityDateFrom) {query.where('maturity_date', '>=', filters.maturityDateFrom);}
-    if (filters.maturityDateTo) {query.where('maturity_date', '<=', filters.maturityDateTo);}
-    if (filters.fundedRatioMin) {query.where('funded_ratio', '>=', filters.fundedRatioMin);}
-    if (filters.fundedRatioMax) {query.where('funded_ratio', '<=', filters.fundedRatioMax);}
-    if (filters.status) {query.where('status', filters.status);}
+  // ── Total count (always offset-independent) ──────────────────────────────
+  let countQ = baseQuery();
+  _applyFilters(countQ, filters);
+  const countRow = await countQ.count('* as total').first();
+  const total = parseInt(countRow.total ?? countRow['count(*)'] ?? 0);
 
-    // Apply sorting using applyQueryOptions for consistency where possible, 
-    // but handle custom filters above as applyQueryOptions is limited.
-    const { sortBy, order = 'desc' } = sorting;
-    if (sortBy && MARKETPLACE_QUERY_CONFIG.allowedSortFields.includes(sortBy)) {
-      query.orderBy(sortBy, order);
-    } else {
-      query.orderBy('created_at', 'desc');
+  // ── Data query ────────────────────────────────────────────────────────────
+  let dataQ = baseQuery().select('*');
+  _applyFilters(dataQ, filters);
+
+  const useCursor = Boolean(pagination.cursor);
+
+  if (useCursor) {
+    // Cursor-based keyset pagination
+    // decodeCursor validates HMAC and sort-field match; throws CursorError on failure.
+    const decoded = decodeCursor(pagination.cursor, sortField);
+    const { sortValue, id: lastId } = decoded;
+
+    // Keyset predicate:
+    //   ASC:  (sortField > lastValue) OR (sortField = lastValue AND id > lastId)
+    //   DESC: (sortField < lastValue) OR (sortField = lastValue AND id < lastId)
+    const gtOp = order === 'asc' ? '>' : '<';
+    dataQ.where(function () {
+      this.where(sortField, gtOp, sortValue)
+        .orWhere(function () {
+          this.where(sortField, '=', sortValue).where('id', gtOp, lastId);
+        });
+    });
+  }
+
+  // Apply sort: primary on sortField, secondary tiebreaker on id
+  dataQ.orderBy(sortField, order).orderBy('id', order);
+
+  // Fetch one extra row to determine `hasMore`
+  const rows = await dataQ.limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const data = hasMore ? rows.slice(0, limit) : rows;
+
+  // Build nextCursor from last item in the returned page (if there is a next page)
+  let nextCursor = null;
+  if (hasMore && data.length > 0) {
+    const lastRow = data[data.length - 1];
+    nextCursor = encodeCursor({
+      sortField,
+      sortValue: lastRow[sortField],
+      id: lastRow.id,
+    });
+  }
+
+  // ── Offset fallback (legacy mode) ─────────────────────────────────────────
+  if (!useCursor) {
+    const page = Math.max(1, parseInt(pagination.page) || 1);
+    const offset = (page - 1) * limit;
+    const pagedRows = await baseQuery()
+      .select('*')
+      .where(qb => { _applyFilters(qb, filters); })
+      .orderBy(sortField, order)
+      .orderBy('id', order)
+      .limit(limit + 1)
+      .offset(offset);
+
+    const pagedHasMore = pagedRows.length > limit;
+    const pagedData = pagedHasMore ? pagedRows.slice(0, limit) : pagedRows;
+
+    let pagedNextCursor = null;
+    if (pagedHasMore && pagedData.length > 0) {
+      const lastRow = pagedData[pagedData.length - 1];
+      pagedNextCursor = encodeCursor({
+        sortField,
+        sortValue: lastRow[sortField],
+        id: lastRow.id,
+      });
     }
 
-    // Pagination
-    const page = Math.max(1, parseInt(pagination.page) || 1);
-    const limit = Math.max(1, Math.min(100, parseInt(pagination.limit) || 10));
-    const offset = (page - 1) * limit;
-
-    // Get total count for pagination
-    const countQuery = query.clone().clearSelect().clearOrder().count('* as total').first();
-    const { total } = await countQuery;
-
-    // Get paginated data
-    const data = await query.limit(limit).offset(offset);
-
     return {
-      data,
+      data: pagedData,
       meta: {
-        total: parseInt(total),
+        total,
         page,
         limit,
-        totalPages: Math.ceil(total / limit)
-      }
+        totalPages: Math.ceil(total / limit),
+        hasMore: pagedHasMore,
+        nextCursor: pagedNextCursor,
+      },
     };
-  } catch (error) {
-    console.error('Error fetching marketplace invoices:', error);
-    throw new Error('Database error while fetching marketplace invoices');
   }
+
+  return {
+    data,
+    meta: {
+      total,
+      limit,
+      hasMore,
+      nextCursor,
+    },
+  };
 }
 
 module.exports = {

--- a/src/utils/cursorPagination.js
+++ b/src/utils/cursorPagination.js
@@ -1,0 +1,166 @@
+'use strict';
+
+/**
+ * @fileoverview Opaque cursor encoding/decoding for marketplace keyset pagination.
+ *
+ * Cursors are base64url-encoded JSON objects containing the last-seen value for
+ * the active sort field and the row `id` tiebreaker. They are HMAC-signed so
+ * that any modification — or reuse with a different sort field — is detected
+ * and rejected with a 400 before it reaches the database layer.
+ *
+ * Cursor payload shape:
+ * ```json
+ * { "sortField": "yield_bps", "sortValue": 450, "id": "inv_abc123", "iat": 1719187200 }
+ * ```
+ *
+ * Security properties:
+ * - Opaque to the client (base64url, not human-readable without decoding).
+ * - HMAC-SHA-256 signed; any tampering invalidates the signature.
+ * - `sortField` is validated against `MARKETPLACE_QUERY_CONFIG.allowedSortFields`
+ *   so a client cannot switch sort fields mid-page silently.
+ * - Does not embed tenant ID or filter values — the service layer always re-applies
+ *   tenant scoping and filter constraints independently, so a cursor cannot be used
+ *   to bypass them.
+ * - `iat` (issued-at epoch seconds) is stored for auditability; cursors do not
+ *   expire by default but the field is available for future TTL enforcement.
+ *
+ * @module utils/cursorPagination
+ */
+
+const crypto = require('crypto');
+
+/**
+ * Secret used to sign cursors.  Falls back to a dev-only default when
+ * `CURSOR_SECRET` is not set so tests work without environment setup.
+ * Production deployments MUST set `CURSOR_SECRET` to a strong random value.
+ *
+ * @type {string}
+ */
+const CURSOR_SECRET = process.env.CURSOR_SECRET || process.env.JWT_SECRET || 'dev-cursor-secret-change-in-prod';
+
+/**
+ * Allowed sort fields for marketplace queries (must mirror MARKETPLACE_QUERY_CONFIG).
+ * @type {ReadonlyArray<string>}
+ */
+const ALLOWED_SORT_FIELDS = Object.freeze(['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at']);
+
+/**
+ * Computes an HMAC-SHA-256 hex digest over `payload`.
+ *
+ * @param {string} payload - The string to sign.
+ * @returns {string} Hex-encoded HMAC digest.
+ */
+function _sign(payload) {
+  return crypto.createHmac('sha256', CURSOR_SECRET).update(payload).digest('hex');
+}
+
+/**
+ * Encodes a cursor from the last row returned in a page.
+ *
+ * @param {Object} params
+ * @param {string} params.sortField - The active sort column (e.g. `'yield_bps'`).
+ * @param {*}      params.sortValue - The sort-column value from the last row.
+ * @param {string} params.id        - The `id` of the last row (tiebreaker).
+ * @returns {string} Opaque base64url cursor string.
+ *
+ * @example
+ * const cursor = encodeCursor({ sortField: 'yield_bps', sortValue: 450, id: 'inv_abc' });
+ * // → 'eyJzb3J0RmllbGQiOiJ5aWVsZF9icHMiLCJzb3J0VmFsdWUiOjQ1MCwiaWQiOiJpbnZfYWJjIiwiaWF0IjoxNzE5MTg3MjAwfQ.3f9a...'
+ */
+function encodeCursor({ sortField, sortValue, id }) {
+  if (!ALLOWED_SORT_FIELDS.includes(sortField)) {
+    throw new Error(`encodeCursor: unsupported sortField "${sortField}"`);
+  }
+  if (!id || typeof id !== 'string') {
+    throw new Error('encodeCursor: id must be a non-empty string');
+  }
+
+  const payload = JSON.stringify({
+    sortField,
+    sortValue,
+    id,
+    iat: Math.floor(Date.now() / 1000),
+  });
+
+  const b64 = Buffer.from(payload).toString('base64url');
+  const sig = _sign(b64);
+  return `${b64}.${sig}`;
+}
+
+/**
+ * Decodes and validates an opaque cursor string.
+ *
+ * @param {string} cursor            - The opaque cursor from the client.
+ * @param {string} expectedSortField - The sort field in the current request.
+ *   If the cursor encodes a different field the decode is rejected.
+ * @returns {{ sortField: string, sortValue: *, id: string, iat: number }}
+ * @throws {CursorError} When the cursor is malformed, tampered, or mismatched.
+ */
+function decodeCursor(cursor, expectedSortField) {
+  if (typeof cursor !== 'string' || !cursor.includes('.')) {
+    throw new CursorError('Malformed cursor: expected base64url.signature format');
+  }
+
+  const dotIdx = cursor.lastIndexOf('.');
+  const b64 = cursor.slice(0, dotIdx);
+  const sig = cursor.slice(dotIdx + 1);
+
+  // Constant-time comparison to prevent timing attacks
+  const expectedSig = _sign(b64);
+  const sigBuf = Buffer.from(sig, 'hex');
+  const expectedBuf = Buffer.from(expectedSig, 'hex');
+
+  if (
+    sigBuf.length !== expectedBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expectedBuf)
+  ) {
+    throw new CursorError('Invalid cursor signature');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(b64, 'base64url').toString('utf8'));
+  } catch {
+    throw new CursorError('Malformed cursor: payload is not valid JSON');
+  }
+
+  const { sortField, sortValue, id, iat } = parsed;
+
+  if (!ALLOWED_SORT_FIELDS.includes(sortField)) {
+    throw new CursorError(`Cursor contains unknown sort field "${sortField}"`);
+  }
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new CursorError('Cursor is missing a valid id tiebreaker');
+  }
+  if (typeof iat !== 'number') {
+    throw new CursorError('Cursor is missing issued-at timestamp');
+  }
+
+  // Reject sort-field mismatch — prevents silent page corruption when the
+  // client sends a cursor from a previous sort context.
+  if (sortField !== expectedSortField) {
+    throw new CursorError(
+      `Cursor sort field "${sortField}" does not match requested sort field "${expectedSortField}"`
+    );
+  }
+
+  return { sortField, sortValue, id, iat };
+}
+
+/**
+ * Domain error for cursor-related failures.  The route layer maps this to
+ * HTTP 400 so internal details never leak to the client.
+ */
+class CursorError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CursorError';
+  }
+}
+
+module.exports = {
+  encodeCursor,
+  decodeCursor,
+  CursorError,
+  ALLOWED_SORT_FIELDS,
+};

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -102,9 +102,18 @@ function validateInvoiceQueryParams(query) {
 
 /**
  * Validates marketplace query parameters.
- * 
+ *
+ * Supports both legacy offset pagination (`page` + `limit`) and cursor-based
+ * pagination (`cursor` + `limit`).  When `cursor` is supplied, `page` is
+ * ignored — the cursor encodes the exact position in the result set.
+ *
+ * The `cursor` value is treated as an opaque string here; structural
+ * validation (HMAC signature, sort-field match) is deferred to
+ * `src/utils/cursorPagination.js` so that a single, clear 400 is returned
+ * from the route layer.
+ *
  * @param {Object} query - The Express query object.
- * @returns {Object} { isValid, errors, validatedParams }
+ * @returns {{ isValid: boolean, errors: string[], validatedParams: Object }}
  */
 function validateMarketplaceQueryParams(query) {
   const errors = [];
@@ -125,7 +134,8 @@ function validateMarketplaceQueryParams(query) {
     sortBy,
     order,
     page,
-    limit
+    limit,
+    cursor
   } = query;
 
   // Validate status

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -221,8 +221,17 @@ function validateMarketplaceQueryParams(query) {
     }
   }
 
-  // Validate pagination
-  if (page !== undefined) {
+  // Validate cursor (opaque base64url.signature string)
+  if (cursor !== undefined) {
+    if (typeof cursor === 'string' && cursor.length > 0 && cursor.length <= 2048) {
+      validatedParams.pagination.cursor = cursor;
+    } else {
+      errors.push('cursor must be a non-empty string (max 2048 chars)');
+    }
+  }
+
+  // Validate pagination — page is ignored when a cursor is present
+  if (cursor === undefined && page !== undefined) {
     const val = parseInt(page);
     if (!isNaN(val) && val >= 1) {
       validatedParams.pagination.page = val;

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -1,11 +1,38 @@
 'use strict';
 
+/**
+ * Marketplace API – comprehensive test suite
+ *
+ * Covers:
+ *  - Authentication / tenant scoping
+ *  - Filter forwarding
+ *  - Offset pagination (legacy, backward-compatible)
+ *  - Cursor-based pagination (first page, subsequent pages, last page)
+ *  - Empty result set
+ *  - Malformed / tampered cursor → 400
+ *  - Sort-field mismatch mid-pagination → 400
+ *  - Non-public status filter → 400
+ *  - Invalid query params → 400
+ *  - DB error → 500
+ *  - nextCursor / hasMore in meta for both modes
+ */
+
 const request = require('supertest');
 const { createApp } = require('../src/index');
 const jwt = require('jsonwebtoken');
 const db = require('../src/db/knex');
+const { encodeCursor, decodeCursor, CursorError } = require('../src/utils/cursorPagination');
+const { validateMarketplaceQueryParams } = require('../src/utils/validators');
 
-// Mock Knex
+// ── Knex mock ────────────────────────────────────────────────────────────────
+
+/**
+ * We need the mock query to support chained builder calls AND return different
+ * data depending on whether `.count()` or `.select()` was called last.
+ *
+ * The mock is rebuilt fresh in each test via mockQuery helpers below so that
+ * individual tests can override the resolved values cleanly.
+ */
 jest.mock('../src/db/knex', () => {
   const mockQuery = {
     select: jest.fn().mockReturnThis(),
@@ -20,25 +47,47 @@ jest.mock('../src/db/knex', () => {
     clearOrder: jest.fn().mockReturnThis(),
     count: jest.fn().mockReturnThis(),
     first: jest.fn().mockResolvedValue({ total: 1 }),
-    then: jest.fn(function(resolve) {
+    then: jest.fn(function (resolve) {
       if (typeof resolve === 'function') {
-        return Promise.resolve([{ id: 'inv_1', yield_bps: 500, funded_ratio: 50.0, maturity_date: '2024-12-31' }]).then(resolve);
+        return Promise.resolve([
+          { id: 'inv_1', yield_bps: 500, funded_ratio: 50.0, maturity_date: '2024-12-31', created_at: '2024-01-01', amount: 1000, status: 'verified' },
+        ]).then(resolve);
       }
-      return Promise.resolve([{ id: 'inv_1', yield_bps: 500, funded_ratio: 50.0, maturity_date: '2024-12-31' }]);
+      return Promise.resolve([
+        { id: 'inv_1', yield_bps: 500, funded_ratio: 50.0, maturity_date: '2024-12-31', created_at: '2024-01-01', amount: 1000, status: 'verified' },
+      ]);
     }),
     catch: jest.fn().mockReturnThis(),
   };
 
   const mockDb = jest.fn(() => mockQuery);
-  Object.assign(mockDb, mockQuery); // Also allow db.select() if used that way
+  Object.assign(mockDb, mockQuery);
   return mockDb;
 });
 
+// ── Constants ────────────────────────────────────────────────────────────────
+
 const TEST_SECRET = process.env.JWT_SECRET || 'test-secret';
-const tenantA = 'tenant-a';
-const tenantB = 'tenant-b';
-const tokenTenantA = jwt.sign({ id: 'user_investor_a', role: 'investor', tenantId: tenantA }, TEST_SECRET, { expiresIn: '1h' });
-const tokenTenantB = jwt.sign({ id: 'user_investor_b', role: 'investor', tenantId: tenantB }, TEST_SECRET, { expiresIn: '1h' });
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+
+const tokenA = jwt.sign({ id: 'user_investor_a', role: 'investor', tenantId: TENANT_A }, TEST_SECRET, { expiresIn: '1h' });
+const tokenB = jwt.sign({ id: 'user_investor_b', role: 'investor', tenantId: TENANT_B }, TEST_SECRET, { expiresIn: '1h' });
+
+// Sample rows used across cursor tests
+const SAMPLE_ROW = { id: 'inv_1', yield_bps: 500, funded_ratio: 50.0, maturity_date: '2024-12-31', created_at: '2024-01-01', amount: 1000, status: 'verified' };
+const SAMPLE_ROW_2 = { id: 'inv_2', yield_bps: 450, funded_ratio: 40.0, maturity_date: '2025-03-31', created_at: '2024-02-01', amount: 2000, status: 'verified' };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a valid cursor for the given sort field using a sample row.
+ */
+function makeCursor(sortField = 'created_at', row = SAMPLE_ROW) {
+  return encodeCursor({ sortField, sortValue: row[sortField], id: row.id });
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
 
 describe('Marketplace API', () => {
   let app;
@@ -51,39 +100,82 @@ describe('Marketplace API', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default mock behavior for successful responses
+    // Default: count returns 1, data returns one sample row
     mockQuery.first.mockResolvedValue({ total: 1 });
-    mockQuery.then.mockImplementation(function(resolve) {
-      return Promise.resolve([{ id: 'inv_1', yield_bps: 500, funded_ratio: 50.0, maturity_date: '2024-12-31' }]).then(resolve);
+    mockQuery.then.mockImplementation(function (resolve) {
+      return Promise.resolve([SAMPLE_ROW]).then(resolve);
     });
   });
 
-  describe('GET /api/marketplace', () => {
-    it('should return 401 if no token is provided', async () => {
-      const response = await request(app).get('/api/marketplace');
-      expect(response.status).toBe(401);
+  // ── Authentication ──────────────────────────────────────────────────────────
+  describe('Authentication', () => {
+    it('returns 401 when no token is provided', async () => {
+      const res = await request(app).get('/api/marketplace');
+      expect(res.status).toBe(401);
     });
 
-    it('should return 200 with marketplace invoices when authenticated', async () => {
-      const response = await request(app)
+    it('returns 200 when authenticated', async () => {
+      const res = await request(app)
         .get('/api/marketplace')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
+        .set('Authorization', `Bearer ${tokenA}`);
+      expect(res.status).toBe(200);
+    });
+  });
 
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-      expect(Array.isArray(response.body.data)).toBe(true);
-      expect(response.body.meta.total).toBe(1);
-      expect(response.body.message).toBe('Marketplace invoices retrieved successfully.');
-      expect(mockQuery.where).toHaveBeenCalledWith('tenant_id', tenantA);
+  // ── Response shape ──────────────────────────────────────────────────────────
+  describe('Response shape', () => {
+    it('returns data array, meta block, and message', async () => {
+      const res = await request(app)
+        .get('/api/marketplace')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.meta).toBeDefined();
+      expect(res.body.message).toBe('Marketplace invoices retrieved successfully.');
     });
 
-    it('should apply filters correctly', async () => {
-      const response = await request(app)
-        .get('/api/marketplace?yieldBpsMin=400&yieldBpsMax=600&fundedRatioMin=20&fundedRatioMax=80&maturityDateFrom=2024-01-01&maturityDateTo=2024-12-31&status=verified')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
+    it('meta always contains hasMore and nextCursor', async () => {
+      const res = await request(app)
+        .get('/api/marketplace')
+        .set('Authorization', `Bearer ${tokenA}`);
 
-      expect(response.status).toBe(200);
-      
+      expect(res.status).toBe(200);
+      expect(res.body.meta).toHaveProperty('hasMore');
+      expect(res.body.meta).toHaveProperty('nextCursor');
+    });
+  });
+
+  // ── Tenant scoping ──────────────────────────────────────────────────────────
+  describe('Tenant scoping', () => {
+    it('scopes by JWT tenantId by default', async () => {
+      await request(app)
+        .get('/api/marketplace')
+        .set('Authorization', `Bearer ${tokenA}`)
+        .expect(200);
+
+      expect(mockQuery.where).toHaveBeenCalledWith('tenant_id', TENANT_A);
+    });
+
+    it('scopes by x-tenant-id header when provided', async () => {
+      await request(app)
+        .get('/api/marketplace')
+        .set('Authorization', `Bearer ${tokenA}`)
+        .set('x-tenant-id', TENANT_B)
+        .expect(200);
+
+      expect(mockQuery.where).toHaveBeenCalledWith('tenant_id', TENANT_B);
+    });
+  });
+
+  // ── Filter forwarding ───────────────────────────────────────────────────────
+  describe('Filter forwarding', () => {
+    it('forwards all filter params to the query builder', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?yieldBpsMin=400&yieldBpsMax=600&fundedRatioMin=20&fundedRatioMax=80&maturityDateFrom=2024-01-01&maturityDateTo=2024-12-31&status=verified')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
       expect(mockQuery.where).toHaveBeenCalledWith('yield_bps', '>=', 400);
       expect(mockQuery.where).toHaveBeenCalledWith('yield_bps', '<=', 600);
       expect(mockQuery.where).toHaveBeenCalledWith('funded_ratio', '>=', 20);
@@ -93,39 +185,253 @@ describe('Marketplace API', () => {
       expect(mockQuery.where).toHaveBeenCalledWith('status', 'verified');
     });
 
-    it('should apply sorting correctly', async () => {
-      const response = await request(app)
-        .get('/api/marketplace?sortBy=yield_bps&order=asc')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
+    it('returns 400 for non-public status (pending_verification)', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?status=pending_verification')
+        .set('Authorization', `Bearer ${tokenA}`);
 
-      expect(response.status).toBe(200);
+      expect(res.status).toBe(400);
+      expect(res.body.errors).toBeDefined();
+    });
+  });
+
+  // ── Sorting ─────────────────────────────────────────────────────────────────
+  describe('Sorting', () => {
+    it('applies sortBy and order to the query', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?sortBy=yield_bps&order=asc')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
       expect(mockQuery.orderBy).toHaveBeenCalledWith('yield_bps', 'asc');
     });
 
-    it('should handle pagination correctly', async () => {
-      const response = await request(app)
+    it('defaults to created_at desc when no sortBy supplied', async () => {
+      const res = await request(app)
+        .get('/api/marketplace')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(mockQuery.orderBy).toHaveBeenCalledWith('created_at', 'desc');
+    });
+  });
+
+  // ── Offset pagination (legacy) ──────────────────────────────────────────────
+  describe('Offset pagination (legacy)', () => {
+    it('applies limit and offset for page=2, limit=5', async () => {
+      const res = await request(app)
         .get('/api/marketplace?page=2&limit=5')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
+        .set('Authorization', `Bearer ${tokenA}`);
 
-      expect(response.status).toBe(200);
-      expect(mockQuery.limit).toHaveBeenCalledWith(5);
+      expect(res.status).toBe(200);
+      expect(mockQuery.limit).toHaveBeenCalledWith(6); // limit+1 for hasMore probe
       expect(mockQuery.offset).toHaveBeenCalledWith(5);
-      expect(response.body.meta.page).toBe(2);
-      expect(response.body.meta.limit).toBe(5);
+      expect(res.body.meta.page).toBe(2);
+      expect(res.body.meta.limit).toBe(5);
     });
 
-    it('should return 400 for invalid query parameters', async () => {
-      const response = await request(app)
-        .get('/api/marketplace?yieldBpsMin=-100&fundedRatioMin=150&maturityDateFrom=invalid')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
+    it('includes totalPages in offset mode meta', async () => {
+      mockQuery.first.mockResolvedValue({ total: 25 });
 
-      expect(response.status).toBe(400);
-      expect(response.body.errors).toBeDefined();
-      expect(response.body.errors.length).toBeGreaterThan(0);
+      const res = await request(app)
+        .get('/api/marketplace?page=1&limit=10')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta).toHaveProperty('totalPages');
     });
 
-    it('should handle database errors gracefully', async () => {
-      // Force an error in the service
+    it('hasMore=false and nextCursor=null on last offset page', async () => {
+      // Return only 1 row (≤ limit) — no extra row means no next page
+      mockQuery.then.mockImplementation(function (resolve) {
+        return Promise.resolve([SAMPLE_ROW]).then(resolve);
+      });
+
+      const res = await request(app)
+        .get('/api/marketplace?page=1&limit=10')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.hasMore).toBe(false);
+      expect(res.body.meta.nextCursor).toBeNull();
+    });
+  });
+
+  // ── Cursor pagination ───────────────────────────────────────────────────────
+  describe('Cursor-based pagination', () => {
+    it('accepts a valid cursor and returns 200', async () => {
+      const cursor = makeCursor('created_at');
+
+      const res = await request(app)
+        .get(`/api/marketplace?cursor=${encodeURIComponent(cursor)}&sortBy=created_at&order=desc`)
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns nextCursor when hasMore=true', async () => {
+      // Return limit+1 rows to simulate "there are more"
+      const rows = [SAMPLE_ROW, SAMPLE_ROW_2, { ...SAMPLE_ROW, id: 'inv_3' }];
+      mockQuery.then.mockImplementation(function (resolve) {
+        return Promise.resolve(rows).then(resolve);
+      });
+
+      const res = await request(app)
+        .get('/api/marketplace?limit=2')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.hasMore).toBe(true);
+      expect(typeof res.body.meta.nextCursor).toBe('string');
+      expect(res.body.meta.nextCursor.length).toBeGreaterThan(0);
+    });
+
+    it('nextCursor is null when on the last page', async () => {
+      // Exactly 1 row → no hasMore
+      mockQuery.then.mockImplementation(function (resolve) {
+        return Promise.resolve([SAMPLE_ROW]).then(resolve);
+      });
+
+      const res = await request(app)
+        .get('/api/marketplace?limit=10')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.hasMore).toBe(false);
+      expect(res.body.meta.nextCursor).toBeNull();
+    });
+
+    it('nextCursor is null on empty result set', async () => {
+      mockQuery.first.mockResolvedValue({ total: 0 });
+      mockQuery.then.mockImplementation(function (resolve) {
+        return Promise.resolve([]).then(resolve);
+      });
+
+      const res = await request(app)
+        .get('/api/marketplace?limit=10')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(0);
+      expect(res.body.meta.hasMore).toBe(false);
+      expect(res.body.meta.nextCursor).toBeNull();
+    });
+
+    it('returns 400 for a completely malformed cursor string', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?cursor=notavalidcursor&sortBy=created_at')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.errors).toBeDefined();
+      expect(res.body.errors.length).toBeGreaterThan(0);
+    });
+
+    it('returns 400 for a base64-valid but tampered cursor', async () => {
+      // Build a valid cursor then corrupt the signature
+      const valid = makeCursor('created_at');
+      const tampered = valid.slice(0, -4) + 'xxxx';
+
+      const res = await request(app)
+        .get(`/api/marketplace?cursor=${encodeURIComponent(tampered)}&sortBy=created_at`)
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.errors[0]).toMatch(/signature/i);
+    });
+
+    it('returns 400 when cursor sort field does not match requested sortBy', async () => {
+      // Cursor was encoded for yield_bps but client sends sortBy=amount
+      const cursor = makeCursor('yield_bps');
+
+      const res = await request(app)
+        .get(`/api/marketplace?cursor=${encodeURIComponent(cursor)}&sortBy=amount`)
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.errors[0]).toMatch(/sort field/i);
+    });
+
+    it('data length equals limit when hasMore=true', async () => {
+      // 3 rows returned for limit=2 → hasMore=true, data sliced to 2
+      const rows = [SAMPLE_ROW, SAMPLE_ROW_2, { ...SAMPLE_ROW, id: 'inv_3' }];
+      mockQuery.then.mockImplementation(function (resolve) {
+        return Promise.resolve(rows).then(resolve);
+      });
+
+      const res = await request(app)
+        .get('/api/marketplace?limit=2')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+    });
+  });
+
+  // ── Validation errors ───────────────────────────────────────────────────────
+  describe('Input validation', () => {
+    it('returns 400 for negative yieldBpsMin', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?yieldBpsMin=-100')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.errors).toBeDefined();
+      expect(res.body.errors.length).toBeGreaterThan(0);
+    });
+
+    it('returns 400 for fundedRatioMin > 100', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?fundedRatioMin=150')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid maturityDateFrom format', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?maturityDateFrom=invalid')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for limit > 100', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?limit=999')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for page < 1', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?page=0')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid sortBy value', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?sortBy=unknown_field')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid order value', async () => {
+      const res = await request(app)
+        .get('/api/marketplace?order=sideways')
+        .set('Authorization', `Bearer ${tokenA}`);
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Error handling ──────────────────────────────────────────────────────────
+  describe('Error handling', () => {
+    it('returns 500 on database errors', async () => {
       mockQuery.then.mockImplementationOnce((resolve, reject) => {
         if (typeof reject === 'function') {
           return reject(new Error('DB connection failed'));
@@ -133,31 +439,134 @@ describe('Marketplace API', () => {
         throw new Error('DB connection failed');
       });
 
-      const response = await request(app)
+      const res = await request(app)
         .get('/api/marketplace')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
+        .set('Authorization', `Bearer ${tokenA}`);
 
-      expect(response.status).toBe(500);
-      expect(response.body.error).toBeDefined();
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+});
+
+// ── Unit tests: cursorPagination.js ─────────────────────────────────────────
+
+describe('cursorPagination – unit tests', () => {
+  describe('encodeCursor', () => {
+    it('returns a string with exactly one dot separator', () => {
+      const cursor = encodeCursor({ sortField: 'yield_bps', sortValue: 500, id: 'inv_1' });
+      expect(typeof cursor).toBe('string');
+      // dot separates payload from signature
+      const parts = cursor.split('.');
+      expect(parts.length).toBe(2);
     });
 
-    it('should reject non-public statuses (tenant-private) even when supplied as a filter', async () => {
-      const response = await request(app)
-        .get('/api/marketplace?status=pending_verification')
-        .set('Authorization', `Bearer ${tokenTenantA}`);
-
-      expect(response.status).toBe(400);
-      expect(response.body.errors).toBeDefined();
+    it('throws for unsupported sortField', () => {
+      expect(() =>
+        encodeCursor({ sortField: 'hacked_field', sortValue: 1, id: 'x' })
+      ).toThrow('unsupported sortField');
     });
 
-    it('should scope by x-tenant-id when provided', async () => {
-      await request(app)
-        .get('/api/marketplace')
-        .set('Authorization', `Bearer ${tokenTenantA}`)
-        .set('x-tenant-id', tenantB)
-        .expect(200);
-
-      expect(mockQuery.where).toHaveBeenCalledWith('tenant_id', tenantB);
+    it('throws for missing id', () => {
+      expect(() =>
+        encodeCursor({ sortField: 'amount', sortValue: 100, id: '' })
+      ).toThrow('id must be a non-empty string');
     });
+  });
+
+  describe('decodeCursor', () => {
+    it('round-trips a valid cursor', () => {
+      const cursor = encodeCursor({ sortField: 'amount', sortValue: 999, id: 'inv_abc' });
+      const decoded = decodeCursor(cursor, 'amount');
+      expect(decoded.sortField).toBe('amount');
+      expect(decoded.sortValue).toBe(999);
+      expect(decoded.id).toBe('inv_abc');
+      expect(typeof decoded.iat).toBe('number');
+    });
+
+    it('throws CursorError for missing dot', () => {
+      expect(() => decodeCursor('nodothere', 'amount')).toThrow(CursorError);
+    });
+
+    it('throws CursorError for wrong signature', () => {
+      const cursor = encodeCursor({ sortField: 'amount', sortValue: 1, id: 'x' });
+      const tampered = cursor.slice(0, -4) + 'abcd';
+      expect(() => decodeCursor(tampered, 'amount')).toThrow(CursorError);
+    });
+
+    it('throws CursorError when sortField does not match expected', () => {
+      const cursor = encodeCursor({ sortField: 'amount', sortValue: 1, id: 'x' });
+      expect(() => decodeCursor(cursor, 'yield_bps')).toThrow(CursorError);
+    });
+
+    it('throws CursorError for non-base64url payload', () => {
+      const fakeSig = require('crypto').createHmac('sha256', process.env.JWT_SECRET || 'test-secret').update('!!!').digest('hex');
+      expect(() => decodeCursor(`!!!.${fakeSig}`, 'amount')).toThrow(CursorError);
+    });
+
+    it('throws CursorError for unknown sortField in payload', () => {
+      // Construct a payload with an unknown field but valid structure
+      const payload = Buffer.from(
+        JSON.stringify({ sortField: 'bad_field', sortValue: 1, id: 'x', iat: 0 })
+      ).toString('base64url');
+      const sig = require('crypto')
+        .createHmac('sha256', process.env.CURSOR_SECRET || process.env.JWT_SECRET || 'dev-cursor-secret-change-in-prod')
+        .update(payload)
+        .digest('hex');
+      expect(() => decodeCursor(`${payload}.${sig}`, 'bad_field')).toThrow(CursorError);
+    });
+  });
+});
+
+// ── Unit tests: validateMarketplaceQueryParams (cursor additions) ────────────
+
+describe('validateMarketplaceQueryParams – cursor support', () => {
+  it('accepts a cursor string and puts it in pagination', () => {
+    const { isValid, validatedParams } = validateMarketplaceQueryParams({
+      cursor: 'someopaquevalue',
+      sortBy: 'yield_bps',
+      limit: '10',
+    });
+    expect(isValid).toBe(true);
+    expect(validatedParams.pagination.cursor).toBe('someopaquevalue');
+  });
+
+  it('ignores page when cursor is present', () => {
+    const { isValid, validatedParams } = validateMarketplaceQueryParams({
+      cursor: 'someopaquevalue',
+      page: '3',
+      limit: '10',
+    });
+    expect(isValid).toBe(true);
+    expect(validatedParams.pagination.cursor).toBe('someopaquevalue');
+    expect(validatedParams.pagination.page).toBeUndefined();
+  });
+
+  it('rejects an empty cursor string', () => {
+    const { isValid, errors } = validateMarketplaceQueryParams({ cursor: '' });
+    expect(isValid).toBe(false);
+    expect(errors[0]).toMatch(/cursor/i);
+  });
+
+  it('rejects a cursor over 2048 characters', () => {
+    const { isValid, errors } = validateMarketplaceQueryParams({
+      cursor: 'a'.repeat(2049),
+    });
+    expect(isValid).toBe(false);
+    expect(errors[0]).toMatch(/cursor/i);
+  });
+
+  it('still validates page when no cursor', () => {
+    const { isValid, errors } = validateMarketplaceQueryParams({ page: '0' });
+    expect(isValid).toBe(false);
+    expect(errors[0]).toMatch(/page/i);
+  });
+
+  it('accepts all valid sort fields', () => {
+    const fields = ['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at'];
+    for (const f of fields) {
+      const { isValid } = validateMarketplaceQueryParams({ sortBy: f });
+      expect(isValid).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Closes #265

---

Overview

The marketplace search API currently uses offset-based pagination, which can produce inconsistent results when records are inserted, updated, or removed between requests. As the marketplace grows and data changes frequently, clients may experience duplicate records, skipped records, and degraded performance on large datasets.

This task introduces cursor-based pagination to provide stable, efficient, and scalable navigation through marketplace results while maintaining backward compatibility with existing query validation and filtering behavior.

Current State

The marketplace endpoint:

Is implemented in src/routes/marketplace.js
Uses business logic from src/services/marketplaceService.js
Applies filtering and sorting through MARKETPLACE_QUERY_CONFIG
Supports whitelisted filters and sort fields
Uses offset/page-based pagination

Current pagination becomes problematic because:

Large offsets become expensive to query
Dataset changes can shift result positions
Users may see duplicates or miss records between pages
Expected Behavior

Implement a cursor-based pagination system where:

Results are ordered by the selected sort field.
A secondary id tiebreaker guarantees deterministic ordering.
The API returns an opaque cursor representing the last item of the current page.
Clients use the returned cursor to request the next page.
Pagination remains stable even when new marketplace entries are added