### PR TITLE
feat(workers): persist queued tx submissions for crash-safe resumption

### DIFF
--- a/DB_MIGRATIONS.md
+++ b/DB_MIGRATIONS.md
@@ -31,6 +31,9 @@ Key components
 | `20260601000000_create_idempotency_keys.sql` | SQL | **node-pg-migrate** | Idempotency keys table |
 | `20260601000001_create_investor_commitments.js` | JS | **node-pg-migrate** | Investor commitments |
 | `20260602000000_create_webhook_dead_letters.sql` | SQL | **node-pg-migrate** | Dead‑letter queue for webhooks |
+| `20260618000000_create_tx_submissions.sql` | SQL | **node-pg-migrate** | Durable queue for in-flight Soroban tx submissions |
+
+`tx_submissions` stores durable Soroban submission jobs (`id`, `payload_fingerprint`, sanitized `payload`, `status`, `attempts`, timestamps). Secret-like payload fields are redacted before insert; on restart, non-terminal rows are restored and requeued by `DurableJobQueue.restore()`.
 
 **Authoritative scripts**
 - `npm run db:setup` → runs `node-pg-migrate up` (same as `db:migrate`).

--- a/README.md
+++ b/README.md
@@ -1100,5 +1100,61 @@ WHERE id = 'your-tenant-id';
 
 ---
 
+## Soroban transaction submission queue
+
+Background Soroban transaction submissions are processed by `src/workers/txSubmitter.js` using the shared `BackgroundWorker` loop. By default, queued submissions are persisted to the `tx_submissions` table so in-flight jobs survive process restarts.
+
+### How it works
+
+1. **Enqueue** — `createTxSubmitterWorker(...).enqueueTxSubmission(payload)` writes a row to `tx_submissions` with a SHA-256 payload fingerprint and a sanitized JSON payload.
+2. **Process** — the worker dequeues jobs, runs the existing retry classifier / fee-bump logic in `submitWithRetry`, and updates row status (`processing`, `completed`, `retrying`, `failed`).
+3. **Restart** — on startup, `restore()` reloads non-terminal rows (`pending`, `processing`, `retrying`), resets interrupted `processing` jobs back to `pending`, and requeues them idempotently.
+
+Apply the migration before enabling durable mode in production:
+
+```bash
+npm run db:migrate
+```
+
+Migration file: `migrations/20260618000000_create_tx_submissions.sql`
+
+### Usage
+
+```js
+const { createTxSubmitterWorker } = require('./src/workers/txSubmitter');
+
+const submitter = createTxSubmitterWorker(submitToHorizon, {
+  retryConfig: {
+    maxRetries: 3,
+    baseDelayMs: 500,
+    maxDelayMs: 20000,
+    feeBumpMultiplier: 2,
+  },
+});
+
+await submitter.start();
+const jobId = await submitter.enqueueTxSubmission({ signedTransactionXdr: '<signed-xdr>' });
+```
+
+Pass `{ durable: false }` for in-memory-only queues (local tests and ephemeral environments).
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SOROBAN_TX_SUBMIT_MAX_RETRIES` | `3` | Max in-handler retry attempts for transient Soroban errors |
+| `SOROBAN_TX_SUBMIT_BASE_DELAY_MS` | `500` | Base exponential backoff delay (ms) |
+| `SOROBAN_TX_SUBMIT_MAX_DELAY_MS` | `20000` | Backoff cap (ms) |
+| `SOROBAN_TX_FEE_BUMP_MULTIPLIER` | `2` | Fee-bump multiplier forwarded to submit handler |
+
+### Security notes
+
+- Raw secret keys and other sensitive fields (`secretKey`, `privateKey`, `seed`, `apiKey`, etc.) are redacted before persistence.
+- Only signed transaction envelopes and non-secret metadata are stored in `payload`.
+- `restore()` is idempotent — repeated startup calls do not duplicate in-memory jobs.
+- Attempt counts remain bounded by the existing retry classifier and queue retry limits.
+
+---
+
 ## License
 MIT (see root LiquiFact project for full license).

--- a/migrations/20260618000000_create_tx_submissions.sql
+++ b/migrations/20260618000000_create_tx_submissions.sql
@@ -1,0 +1,23 @@
+-- Durable queue for in-flight Soroban transaction submissions
+CREATE TABLE IF NOT EXISTS tx_submissions (
+  id VARCHAR(64) PRIMARY KEY,
+  job_type VARCHAR(128) NOT NULL,
+  payload_fingerprint VARCHAR(64) NOT NULL,
+  payload JSONB NOT NULL,
+  status VARCHAR(32) NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  priority INTEGER NOT NULL DEFAULT 0,
+  delay_until_ms BIGINT NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_submissions_status
+  ON tx_submissions (status);
+
+CREATE INDEX IF NOT EXISTS idx_tx_submissions_non_terminal
+  ON tx_submissions (status, created_at ASC)
+  WHERE status IN ('pending', 'processing', 'retrying');

--- a/src/workers/jobQueue.js
+++ b/src/workers/jobQueue.js
@@ -12,6 +12,7 @@
  */
 
 const crypto = require('crypto');
+const logger = require('../logger');
 
 /**
  * Job status enumeration
@@ -25,6 +26,14 @@ const JOB_STATUS = {
   FAILED: 'failed',
   RETRYING: 'retrying',
 };
+
+const REDACTED = '[REDACTED]';
+const SECRET_KEY_PATTERN = /secret|password|token|privatekey|private_key|seed|signingkey|signing_key|apikey|api_key/i;
+const NON_TERMINAL_STATUSES = [
+  JOB_STATUS.PENDING,
+  JOB_STATUS.PROCESSING,
+  JOB_STATUS.RETRYING,
+];
 
 /**
  * In-memory job queue for managing asynchronous background tasks.
@@ -331,5 +340,284 @@ class JobQueue {
   }
 }
 
+/**
+ * Recursively sorts object keys for deterministic serialization.
+ *
+ * @param {any} value - Value to sort.
+ * @returns {any} Value with sorted object keys.
+ */
+function sortKeys(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+
+  return Object.keys(value).sort().reduce((acc, key) => {
+    acc[key] = sortKeys(value[key]);
+    return acc;
+  }, {});
+}
+
+/**
+ * Removes secret-like fields before a job payload is persisted.
+ *
+ * @param {any} payload - Raw job payload.
+ * @returns {any} Sanitized payload safe for database storage.
+ */
+function sanitizePayloadForPersistence(payload) {
+  if (payload === null || typeof payload !== 'object') {
+    return payload;
+  }
+
+  if (Array.isArray(payload)) {
+    return payload.map(sanitizePayloadForPersistence);
+  }
+
+  return Object.entries(payload).reduce((acc, [key, value]) => {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      acc[key] = REDACTED;
+      return acc;
+    }
+
+    if (value !== null && typeof value === 'object') {
+      acc[key] = sanitizePayloadForPersistence(value);
+      return acc;
+    }
+
+    acc[key] = value;
+    return acc;
+  }, {});
+}
+
+/**
+ * Computes a stable SHA-256 fingerprint for a sanitized payload.
+ *
+ * @param {Object} payload - Sanitized payload object.
+ * @returns {string} Hex-encoded SHA-256 digest.
+ */
+function computePayloadFingerprint(payload) {
+  const canonical = JSON.stringify(sortKeys(payload));
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/**
+ * Database-backed job queue for crash-safe transaction submission.
+ *
+ * Persists enqueue/ack/retry transitions to `tx_submissions` and can restore
+ * non-terminal jobs after process restart.
+ *
+ * @class DurableJobQueue
+ * @extends JobQueue
+ */
+class DurableJobQueue extends JobQueue {
+  /**
+   * Creates a durable queue backed by the shared Knex database.
+   *
+   * @param {Object} options - Queue configuration.
+   * @param {import('knex').Knex} options.db - Shared Knex instance.
+   * @param {string} [options.tableName='tx_submissions'] - Persistence table name.
+   * @param {number} [options.maxRetries=3] - Maximum retry attempts per job.
+   * @param {number} [options.maxQueueSize=10000] - Maximum in-memory queue size.
+   */
+  constructor(options = {}) {
+    super(options);
+
+    if (!options.db || typeof options.db !== 'function') {
+      throw new Error('DurableJobQueue requires a Knex db instance');
+    }
+
+    this.db = options.db;
+    this.tableName = options.tableName || 'tx_submissions';
+    this._restored = false;
+  }
+
+  /**
+   * Persists a newly enqueued job row.
+   *
+   * @param {string} type - Job type identifier.
+   * @param {Object} payload - Raw job payload.
+   * @param {Object} [options={}] - Enqueue options.
+   * @returns {Promise<string>} Generated job ID.
+   */
+  async enqueue(type, payload, options = {}) {
+    const jobId = super.enqueue(type, payload, options);
+    const job = this.getJob(jobId);
+    const sanitizedPayload = sanitizePayloadForPersistence(payload);
+
+    await this.db(this.tableName).insert({
+      id: jobId,
+      job_type: type,
+      payload_fingerprint: computePayloadFingerprint(sanitizedPayload),
+      payload: JSON.stringify(sanitizedPayload),
+      status: job.status,
+      attempts: job.attempts,
+      priority: job.priority,
+      delay_until_ms: job.delayMs,
+      last_error: job.lastError,
+      created_at: new Date(job.createdAt),
+      started_at: null,
+      completed_at: null,
+      updated_at: new Date(),
+    });
+
+    return jobId;
+  }
+
+  /**
+   * Marks a job complete in memory and in the database.
+   *
+   * @param {string} jobId - Job identifier.
+   * @returns {void}
+   */
+  ack(jobId) {
+    super.ack(jobId);
+    const job = this.getJob(jobId);
+    this._persistJobState(job).catch((err) => {
+      logger.warn({ err: err.message, jobId }, 'Failed to persist tx submission ack');
+    });
+  }
+
+  /**
+   * Schedules or finalizes a retry in memory and in the database.
+   *
+   * @param {string} jobId - Job identifier.
+   * @param {Error} error - Failure error.
+   * @returns {void}
+   */
+  retry(jobId, error) {
+    super.retry(jobId, error);
+    const job = this.getJob(jobId);
+    this._persistJobState(job).catch((err) => {
+      logger.warn({ err: err.message, jobId }, 'Failed to persist tx submission retry');
+    });
+  }
+
+  /**
+   * Dequeues the next ready job and marks it processing in the database.
+   *
+   * @returns {Object|null} Next job to process.
+   */
+  dequeue() {
+    const job = super.dequeue();
+    if (job) {
+      this._persistJobState(job).catch((err) => {
+        logger.warn({ err: err.message, jobId: job.id }, 'Failed to persist tx submission dequeue');
+      });
+    }
+    return job;
+  }
+
+  /**
+   * Restores non-terminal jobs from the database after restart.
+   *
+   * Processing jobs are reset to pending so they can be safely retried.
+   * Calling restore more than once is idempotent.
+   *
+   * @returns {Promise<{restored: number, skipped: number}>} Restore summary.
+   */
+  async restore() {
+    if (this._restored) {
+      return { restored: 0, skipped: 0 };
+    }
+
+    const rows = await this.db(this.tableName)
+      .whereIn('status', NON_TERMINAL_STATUSES)
+      .orderBy('created_at', 'asc');
+
+    let restored = 0;
+    let skipped = 0;
+
+    for (const row of rows) {
+      if (this.jobs.has(row.id)) {
+        skipped += 1;
+        continue;
+      }
+
+      const job = this._rowToJob(row);
+
+      if (row.status === JOB_STATUS.PROCESSING) {
+        job.status = JOB_STATUS.PENDING;
+        job.startedAt = null;
+        await this.db(this.tableName)
+          .where({ id: row.id })
+          .update({
+            status: JOB_STATUS.PENDING,
+            started_at: null,
+            updated_at: new Date(),
+          });
+      }
+
+      this.jobs.set(job.id, job);
+
+      if (job.status === JOB_STATUS.RETRYING) {
+        this.retryQueue.push(job.id);
+      } else {
+        this.queue.push(job.id);
+      }
+
+      restored += 1;
+    }
+
+    this._restored = true;
+    return { restored, skipped };
+  }
+
+  /**
+   * Writes the current in-memory job state to the database.
+   *
+   * @private
+   * @param {Object} job - In-memory job object.
+   * @returns {Promise<number>} Number of updated rows.
+   */
+  async _persistJobState(job) {
+    return this.db(this.tableName)
+      .where({ id: job.id })
+      .update({
+        status: job.status,
+        attempts: job.attempts,
+        priority: job.priority,
+        delay_until_ms: job.delayMs,
+        last_error: job.lastError,
+        started_at: job.startedAt ? new Date(job.startedAt) : null,
+        completed_at: job.completedAt ? new Date(job.completedAt) : null,
+        updated_at: new Date(),
+      });
+  }
+
+  /**
+   * Converts a persisted row into an in-memory job object.
+   *
+   * @private
+   * @param {Object} row - Database row.
+   * @returns {Object} Job object compatible with JobQueue.
+   */
+  _rowToJob(row) {
+    let payload = row.payload;
+    if (typeof payload === 'string') {
+      payload = JSON.parse(payload);
+    }
+
+    return {
+      id: row.id,
+      type: row.job_type,
+      payload,
+      status: row.status,
+      priority: row.priority || 0,
+      delayMs: Number(row.delay_until_ms || 0),
+      createdAt: row.created_at ? new Date(row.created_at).getTime() : Date.now(),
+      startedAt: row.started_at ? new Date(row.started_at).getTime() : null,
+      completedAt: row.completed_at ? new Date(row.completed_at).getTime() : null,
+      attempts: row.attempts || 0,
+      lastError: row.last_error || null,
+    };
+  }
+}
+
 module.exports = JobQueue;
 module.exports.JOB_STATUS = JOB_STATUS;
+module.exports.DurableJobQueue = DurableJobQueue;
+module.exports.sanitizePayloadForPersistence = sanitizePayloadForPersistence;
+module.exports.computePayloadFingerprint = computePayloadFingerprint;

--- a/src/workers/jobWorker.test.js
+++ b/src/workers/jobWorker.test.js
@@ -7,7 +7,12 @@
 
 const JobQueue = require('./jobQueue');
 const BackgroundWorker = require('./worker');
-const { JOB_STATUS } = require('./jobQueue');
+const {
+  JOB_STATUS,
+  DurableJobQueue,
+  sanitizePayloadForPersistence,
+  computePayloadFingerprint,
+} = require('./jobQueue');
 
 describe('JobQueue', () => {
   let queue;
@@ -432,6 +437,113 @@ describe('JobQueue', () => {
       const cleared = queue.clear();
       expect(cleared).toBe(0);
     });
+  });
+});
+
+function createInMemoryTxSubmissionStore() {
+  const rows = new Map();
+
+  const db = jest.fn(() => {
+    const query = {
+      _where: null,
+      _whereIn: null,
+      insert(data) {
+        rows.set(data.id, { ...data });
+        return Promise.resolve([data]);
+      },
+      where(criteria) {
+        query._where = criteria;
+        return query;
+      },
+      whereIn(_column, values) {
+        query._whereIn = values;
+        return query;
+      },
+      orderBy() {
+        return query;
+      },
+      update(patch) {
+        let matches = [...rows.values()];
+        if (query._whereIn) {
+          matches = matches.filter((row) => query._whereIn.includes(row.status));
+        }
+        if (query._where && query._where.id) {
+          matches = matches.filter((row) => row.id === query._where.id);
+        }
+        for (const row of matches) {
+          rows.set(row.id, { ...row, ...patch });
+        }
+        return Promise.resolve(matches.length);
+      },
+      then(resolve, reject) {
+        let matches = [...rows.values()];
+        if (query._whereIn) {
+          matches = matches.filter((row) => query._whereIn.includes(row.status));
+        }
+        matches.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+        return Promise.resolve(matches).then(resolve, reject);
+      },
+    };
+    return query;
+  });
+
+  return { db, rows };
+}
+
+describe('DurableJobQueue persistence hooks', () => {
+  it('redacts secret-like payload fields before persistence helpers run', () => {
+    const sanitized = sanitizePayloadForPersistence({
+      signedTransactionXdr: 'AAABBB',
+      nested: { apiKey: 'secret-value' },
+    });
+
+    expect(sanitized.nested.apiKey).toBe('[REDACTED]');
+    expect(computePayloadFingerprint(sanitized)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('persists enqueue, processing, and completed states', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const queue = new DurableJobQueue({ db });
+
+    const jobId = await queue.enqueue('submit_soroban_tx', { signedTransactionXdr: 'AAABBB' });
+    expect(rows.get(jobId).status).toBe(JOB_STATUS.PENDING);
+
+    const job = queue.dequeue();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(rows.get(jobId).status).toBe(JOB_STATUS.PROCESSING);
+
+    queue.ack(job.id);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(rows.get(jobId).status).toBe(JOB_STATUS.COMPLETED);
+  });
+
+  it('persists retry and failed states when attempts are exhausted', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const queue = new DurableJobQueue({ db, maxRetries: 0 });
+
+    const jobId = await queue.enqueue('submit_soroban_tx', { signedTransactionXdr: 'AAABBB' });
+    queue.dequeue();
+    queue.retry(jobId, new Error('tx_bad_seq'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(rows.get(jobId).status).toBe(JOB_STATUS.FAILED);
+    expect(rows.get(jobId).last_error).toBe('tx_bad_seq');
+  });
+
+  it('restores pending jobs idempotently after restart', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const writer = new DurableJobQueue({ db });
+
+    const jobId = await writer.enqueue('submit_soroban_tx', { signedTransactionXdr: 'AAABBB' });
+    rows.set(jobId, { ...rows.get(jobId), status: JOB_STATUS.PROCESSING, attempts: 1 });
+
+    const restoredQueue = new DurableJobQueue({ db });
+    const first = await restoredQueue.restore();
+    const second = await restoredQueue.restore();
+
+    expect(first).toEqual({ restored: 1, skipped: 0 });
+    expect(second).toEqual({ restored: 0, skipped: 0 });
+    expect(restoredQueue.getJob(jobId).status).toBe(JOB_STATUS.PENDING);
   });
 });
 

--- a/src/workers/txSubmitter.js
+++ b/src/workers/txSubmitter.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const JobQueue = require('./jobQueue');
+const { JobQueue, DurableJobQueue } = require('./jobQueue');
 const BackgroundWorker = require('./worker');
 const logger = require('../logger');
+const db = require('../db/knex');
 
 const DEFAULT_CONFIG = {
   maxRetries: Math.min(parseInt(process.env.SOROBAN_TX_SUBMIT_MAX_RETRIES || '3', 10), 10),
@@ -111,22 +112,61 @@ async function handleTxSubmitJob(job, submitTransactionFn, config = {}) {
 /**
  * Creates a worker for background transaction submission.
  *
+ * When `durable` is enabled (default), jobs are persisted to `tx_submissions`
+ * and restored on startup so in-flight Soroban submissions survive restarts.
+ *
  * @param {Function} submitTransactionFn - Function to submit transactions.
  * @param {object} [options={}] - Worker and retry options.
+ * @param {boolean} [options.durable=true] - Persist queued submissions to Postgres.
+ * @param {import('knex').Knex} [options.db] - Knex instance for persistence.
+ * @param {string} [options.tableName='tx_submissions'] - Persistence table name.
  * @returns {object} The worker controller object.
  */
 function createTxSubmitterWorker(submitTransactionFn, options = {}) {
-  const txQueue = new JobQueue({ maxRetries: 0 });
+  const durable = options.durable !== false;
+  const persistenceDb = options.db || db;
+  const txQueue = durable
+    ? new DurableJobQueue({
+      maxRetries: 0,
+      db: persistenceDb,
+      tableName: options.tableName || 'tx_submissions',
+    })
+    : new JobQueue({ maxRetries: 0 });
   const txWorker = new BackgroundWorker({ jobQueue: txQueue, pollIntervalMs: options.pollIntervalMs ?? 100, maxConcurrency: options.maxConcurrency ?? 1 });
+  let restored = !durable;
 
   txWorker.registerHandler('submit_soroban_tx', async (job) => {
     return handleTxSubmitJob(job, submitTransactionFn, options.retryConfig);
   });
 
+  /**
+   * Restores durable jobs from the database once per process.
+   *
+   * @returns {Promise<{restored: number, skipped: number}>} Restore summary.
+   */
+  async function ensureRestored() {
+    if (restored || typeof txQueue.restore !== 'function') {
+      return { restored: 0, skipped: 0 };
+    }
+
+    const summary = await txQueue.restore();
+    restored = true;
+    return summary;
+  }
+
   return {
     txQueue,
     txWorker,
-    enqueueTxSubmission: (payload, enqueueOptions = {}) => txQueue.enqueue('submit_soroban_tx', payload, enqueueOptions),
+    restore: ensureRestored,
+    enqueueTxSubmission: async (payload, enqueueOptions = {}) => {
+      await ensureRestored();
+      return txQueue.enqueue('submit_soroban_tx', payload, enqueueOptions);
+    },
+    start: async () => {
+      await ensureRestored();
+      txWorker.start();
+    },
+    stop: (timeoutMs) => txWorker.stop(timeoutMs),
   };
 }
 

--- a/tests/txSubmitter.test.js
+++ b/tests/txSubmitter.test.js
@@ -215,7 +215,11 @@ describe('submitWithRetry', () => {
   });
 
   it('does not exceed maxRetries even for persistent transient errors', async () => {
-    const op = jest.fn(async () => { throw new Error('ECONNRESET'); });
+    const op = jest.fn(async () => {
+      const err = new Error('connection reset');
+      err.code = 'ECONNRESET';
+      throw err;
+    });
     const cfg = { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 };
     await expect(submitWithRetry(op, cfg)).rejects.toThrow();
     expect(op).toHaveBeenCalledTimes(3); // attempts 0, 1, 2
@@ -322,38 +326,225 @@ describe('createTxSubmitterWorker', () => {
       return { status: 'ok' };
     });
 
-    const { txQueue, txWorker, enqueueTxSubmission } = createTxSubmitterWorker(submitFn, {
+    const { txQueue, enqueueTxSubmission, start, stop } = createTxSubmitterWorker(submitFn, {
+      durable: false,
       pollIntervalMs: 10,
       maxConcurrency: 1,
       retryConfig: { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 },
     });
 
-    txWorker.start();
-    const jobId = enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
+    await start();
+    const jobId = await enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(txQueue.getJob(jobId).status).toBe('completed');
     expect(submitFn).toHaveBeenCalledTimes(2);
 
-    await txWorker.stop();
+    await stop();
   });
 
   it('marks the job as failed on a permanent error', async () => {
     const submitFn = jest.fn(async () => { throw new Error('insufficient fee'); });
 
-    const { txQueue, txWorker, enqueueTxSubmission } = createTxSubmitterWorker(submitFn, {
+    const { txQueue, enqueueTxSubmission, start, stop } = createTxSubmitterWorker(submitFn, {
+      durable: false,
       pollIntervalMs: 10,
       maxConcurrency: 1,
       retryConfig: { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 },
     });
 
-    txWorker.start();
-    const jobId = enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
+    await start();
+    const jobId = await enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(txQueue.getJob(jobId).status).toBe('failed');
     expect(submitFn).toHaveBeenCalledTimes(1); // no retry for permanent error
 
-    await txWorker.stop();
+    await stop();
+  });
+});
+
+function createInMemoryTxSubmissionStore() {
+  const rows = new Map();
+
+  const db = jest.fn(() => {
+    const query = {
+      _where: null,
+      _whereIn: null,
+      insert(data) {
+        rows.set(data.id, { ...data });
+        return Promise.resolve([data]);
+      },
+      where(criteria) {
+        query._where = criteria;
+        return query;
+      },
+      whereIn(_column, values) {
+        query._whereIn = values;
+        return query;
+      },
+      orderBy() {
+        return query;
+      },
+      update(patch) {
+        let matches = [...rows.values()];
+        if (query._whereIn) {
+          matches = matches.filter((row) => query._whereIn.includes(row.status));
+        }
+        if (query._where && query._where.id) {
+          matches = matches.filter((row) => row.id === query._where.id);
+        }
+        for (const row of matches) {
+          rows.set(row.id, { ...row, ...patch });
+        }
+        return Promise.resolve(matches.length);
+      },
+      then(resolve, reject) {
+        let matches = [...rows.values()];
+        if (query._whereIn) {
+          matches = matches.filter((row) => query._whereIn.includes(row.status));
+        }
+        matches.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+        return Promise.resolve(matches).then(resolve, reject);
+      },
+    };
+    return query;
+  });
+
+  return { db, rows };
+}
+
+describe('createTxSubmitterWorker durable persistence', () => {
+  it('persists enqueue and ack transitions', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const submitFn = jest.fn(async () => ({ status: 'ok' }));
+
+    const { enqueueTxSubmission, start, stop } = createTxSubmitterWorker(submitFn, {
+      db,
+      pollIntervalMs: 10,
+      retryConfig: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await start();
+    const jobId = await enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await stop();
+
+    const row = rows.get(jobId);
+    expect(row.status).toBe('completed');
+    expect(row.payload).toContain('signedTransactionXdr');
+    expect(row.payload_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(row.attempts).toBe(1);
+  });
+
+  it('retries transient failures, then marks the row completed', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    let attempts = 0;
+    const submitFn = jest.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('tx_bad_seq');
+      }
+      return { status: 'ok' };
+    });
+
+    const { enqueueTxSubmission, start, stop } = createTxSubmitterWorker(submitFn, {
+      db,
+      pollIntervalMs: 10,
+      retryConfig: { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await start();
+    const jobId = await enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await stop();
+
+    expect(submitFn).toHaveBeenCalledTimes(2);
+    expect(rows.get(jobId).status).toBe('completed');
+  });
+
+  it('dead-letters exhausted retries in the database', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const submitFn = jest.fn(async () => { throw new Error('tx_bad_seq'); });
+
+    const { enqueueTxSubmission, start, stop } = createTxSubmitterWorker(submitFn, {
+      db,
+      pollIntervalMs: 10,
+      retryConfig: { maxRetries: 1, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await start();
+    const jobId = await enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await stop();
+
+    const row = rows.get(jobId);
+    expect(row.status).toBe('failed');
+    expect(row.last_error).toContain('tx_bad_seq');
+  });
+
+  it('restores non-terminal jobs after restart without duplicating them', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const submitFn = jest.fn(async () => ({ status: 'ok' }));
+
+    const first = createTxSubmitterWorker(submitFn, {
+      db,
+      pollIntervalMs: 10,
+      retryConfig: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    const jobId = await first.enqueueTxSubmission({ signedTransactionXdr: 'AAABBB' });
+    await first.stop();
+
+    rows.set(jobId, {
+      ...rows.get(jobId),
+      status: 'processing',
+      attempts: 1,
+    });
+
+    const second = createTxSubmitterWorker(submitFn, {
+      db,
+      pollIntervalMs: 10,
+      retryConfig: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    const firstRestore = await second.restore();
+    const secondRestore = await second.restore();
+
+    expect(firstRestore).toEqual({ restored: 1, skipped: 0 });
+    expect(secondRestore).toEqual({ restored: 0, skipped: 0 });
+    expect(second.txQueue.getJob(jobId)).toBeTruthy();
+    expect(second.txQueue.getStats().pending + second.txQueue.getStats().retrying).toBe(1);
+
+    await second.start();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await second.stop();
+
+    expect(submitFn).toHaveBeenCalledTimes(1);
+    expect(rows.get(jobId).status).toBe('completed');
+  });
+
+  it('does not persist secret-like payload fields', async () => {
+    const { db, rows } = createInMemoryTxSubmissionStore();
+    const submitFn = jest.fn(async () => ({ status: 'ok' }));
+
+    const { enqueueTxSubmission, start, stop } = createTxSubmitterWorker(submitFn, {
+      db,
+      pollIntervalMs: 10,
+      retryConfig: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 5 },
+    });
+
+    await start();
+    const jobId = await enqueueTxSubmission({
+      signedTransactionXdr: 'AAABBB',
+      secretKey: 'SUPER-SECRET',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await stop();
+
+    const persisted = JSON.parse(rows.get(jobId).payload);
+    expect(persisted.signedTransactionXdr).toBe('AAABBB');
+    expect(persisted.secretKey).toBe('[REDACTED]');
+    expect(rows.get(jobId).payload).not.toContain('SUPER-SECRET');
   });
 });


### PR DESCRIPTION
Closes #274 

### Summary
Implement durable persistence for queued transaction submissions


