### PR TITLE
feat: persist invoice PDFs to durable storage and add metadata table

### DIFF
--- a/migrations/20260428000000_create_invoice_files_table.js
+++ b/migrations/20260428000000_create_invoice_files_table.js
@@ -1,0 +1,18 @@
+// Migration to create invoice_files table for storing invoice file metadata
+exports.up = function (knex) {
+  return knex.schema.createTable('invoice_files', function (table) {
+    table.increments('id').primary();
+    table.string('tenant_id').notNullable();
+    table.string('invoice_id').notNullable();
+    table.string('s3_key').notNullable();
+    table.string('sha256').notNullable();
+    table.string('mime_type').notNullable();
+    table.integer('size').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.index(['tenant_id', 'invoice_id'], 'idx_invoice_files_tenant_invoice');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable('invoice_files');
+};

--- a/run_migration.js
+++ b/run_migration.js
@@ -1,0 +1,11 @@
+const knexConfig = require('./knexfile');
+const knex = require('knex')(knexConfig);
+knex.migrate.latest()
+  .then(() => {
+    console.log('Migration completed');
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error('Migration failed', err);
+    process.exit(1);
+  });

--- a/src/routes/invoiceFile.js
+++ b/src/routes/invoiceFile.js
@@ -1,10 +1,5 @@
 /**
- * @fileoverview Invoice File Operations with Integrity Verification
- *
- * Handles PDF upload, storage, and SHA-256 hash-based integrity verification.
- * Protects against file tampering by computing and storing cryptographic hashes.
- *
- * @module routes/invoiceFile
+ * @fileoverview Invoice File Operations with Integrity Verification using durable storage.
  */
 
 'use strict';
@@ -12,9 +7,8 @@
 const express = require('express');
 const crypto = require('crypto');
 const storageService = require('../services/storage');
+const logger = require('../logger');
 const router = express.Router();
-
-const invoiceFiles = new Map();
 
 function computeHash(buffer) {
   return crypto.createHash('sha256').update(buffer).digest('hex');
@@ -26,235 +20,123 @@ function computeHash(buffer) {
  */
 router.post('/:id/presigned-upload', express.json(), async (req, res) => {
   const { id } = req.params;
-
   if (!id || typeof id !== 'string' || id.trim() === '') {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Invalid invoice ID',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
   }
-
   try {
     const { fileName, mimeType, fileSize } = req.body;
-
     if (!fileName || !mimeType || fileSize == null) {
-      return res.status(400).json({
-        error: 'Bad Request',
-        message: 'fileName, mimeType, and fileSize are required',
-      });
+      return res.status(400).json({ error: 'Bad Request', message: 'fileName, mimeType, and fileSize are required' });
     }
-
     const tenantId = req.user?.id || req.user?.sub || 'unknown';
-
-    const result = await storageService.getPresignedUploadUrl({
-      tenantId,
-      invoiceId: id,
-      fileName,
-      mimeType,
-      fileSize,
-    });
-
-    return res.status(201).json({
-      data: {
-        invoiceId: id,
-        uploadUrl: result.url,
-        fileKey: result.key,
-      },
-      message: 'Presigned upload URL generated',
-    });
+    const result = await storageService.getPresignedUploadUrl({ tenantId, invoiceId: id, fileName, mimeType, fileSize });
+    return res.status(201).json({ data: { invoiceId: id, uploadUrl: result.url, fileKey: result.key }, message: 'Presigned upload URL generated' });
   } catch (error) {
-     if (
-      error.code === 'INVALID_MIME_TYPE' ||
-      error.code === 'FILE_TOO_LARGE' ||
-      error.code === 'INVALID_FILENAME' ||
-      error.code === 'INVALID_TENANT_ID' ||
-      error.code === 'INVALID_INVOICE_ID' ||
-      error.code === 'INVALID_EXPIRY'
-    ) {
-      return res.status(400).json({
-        error: 'Bad Request',
-        message: error.message,
-      });
+    if (['INVALID_MIME_TYPE','FILE_TOO_LARGE','INVALID_FILENAME','INVALID_TENANT_ID','INVALID_INVOICE_ID','INVALID_EXPIRY'].includes(error.message)) {
+      return res.status(400).json({ error: 'Bad Request', message: error.message });
     }
-   const logger = require('../logger');
-
-   logger.error(
-    { err: error, invoiceId: id },
-    'Failed to generate presigned upload URL'
-  );
-    return res.status(500).json({
-      error: 'Internal Server Error',
-      message: 'Failed to generate presigned upload URL',
-    });
+    logger.error({ err: error, invoiceId: id }, 'Failed to generate presigned upload URL');
+    return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to generate presigned upload URL' });
   }
 });
 
 /**
  * POST /api/invoices/:id/file
- * Upload PDF file for an invoice and compute integrity hash.
+ * Upload PDF file for an invoice and persist it.
  */
-router.post('/:id/file', express.raw({ type: 'application/pdf', limit: '5mb' }), (req, res) => {
+router.post('/:id/file', express.raw({ type: 'application/pdf', limit: '5mb' }), async (req, res) => {
   const { id } = req.params;
-
   if (!id || typeof id !== 'string' || id.trim() === '') {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Invalid invoice ID',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
   }
-
   const contentType = req.headers['content-type'];
   if (!contentType || !contentType.includes('application/pdf')) {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Content-Type must be application/pdf',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'Content-Type must be application/pdf' });
   }
-
   if (!req.body || !Buffer.isBuffer(req.body) || req.body.length === 0) {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'No file data provided',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'No file data provided' });
   }
-
   const fileHash = computeHash(req.body);
   const fileSize = req.body.length;
-
-  invoiceFiles.set(id, {
-    invoiceId: id,
-    fileData: req.body,
-    fileHash,
-    fileSize,
-    contentType: 'application/pdf',
-    uploadedAt: new Date().toISOString(),
-  });
-
-  return res.status(201).json({
-    data: {
-      invoiceId: id,
-      fileHash,
-      fileSize,
-      uploadedAt: invoiceFiles.get(id).uploadedAt,
-    },
-    message: 'Invoice file uploaded successfully',
-  });
+  const tenantId = req.user?.id || req.user?.sub || 'unknown';
+  // Generate storage key using helper
+  const key = storageService.generateKey({ tenantId, invoiceId: id, fileName: `${Date.now()}.pdf` });
+  try {
+    await storageService.uploadFile({ key, body: req.body, mimeType: 'application/pdf' });
+    await storageService.saveMetadata({ tenantId, invoiceId: id, key, sha256: fileHash, mimeType: 'application/pdf', size: fileSize });
+    const uploadedAt = new Date().toISOString();
+    return res.status(201).json({ data: { invoiceId: id, fileHash, fileSize, uploadedAt, storageKey: key }, message: 'Invoice file uploaded successfully' });
+  } catch (err) {
+    logger.error({ err, invoiceId: id }, 'Failed to upload invoice file');
+    return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to store invoice file' });
+  }
 });
 
 /**
  * GET /api/invoices/:id/file
  * Retrieve the PDF file for an invoice.
  */
-router.get('/:id/file', (req, res) => {
+router.get('/:id/file', async (req, res) => {
   const { id } = req.params;
-
   if (!id || typeof id !== 'string' || id.trim() === '') {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Invalid invoice ID',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
   }
-
-  const fileRecord = invoiceFiles.get(id);
-
-  if (!fileRecord) {
-    return res.status(404).json({
-      error: 'Not Found',
-      message: `No file found for invoice ${id}`,
-    });
+  const tenantId = req.user?.id || req.user?.sub || 'unknown';
+  const meta = await storageService.getMetadata({ tenantId, invoiceId: id });
+  if (!meta) {
+    return res.status(404).json({ error: 'Not Found', message: `No file found for invoice ${id}` });
   }
-
-  res.set('Content-Type', 'application/pdf');
-  res.set('Content-Length', fileRecord.fileSize);
-  res.set('X-File-Hash', fileRecord.fileHash);
-  return res.send(fileRecord.fileData);
+  try {
+    const fileData = await storageService.getFile({ key: meta.key });
+    res.set('Content-Type', meta.mimeType);
+    res.set('Content-Length', meta.size);
+    res.set('X-File-Hash', meta.sha256);
+    return res.send(fileData);
+  } catch (err) {
+    logger.error({ err, invoiceId: id }, 'Failed to retrieve invoice file');
+    return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to retrieve invoice file' });
+  }
 });
 
 /**
  * GET /api/invoices/:id/file/verify
- * Verify integrity of uploaded PDF by comparing stored hash with current file hash.
+ * Verify integrity of uploaded PDF by comparing stored hash with freshly computed hash.
  */
-router.get('/:id/file/verify', (req, res) => {
+router.get('/:id/file/verify', async (req, res) => {
   const { id } = req.params;
-
   if (!id || typeof id !== 'string' || id.trim() === '') {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Invalid invoice ID',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
   }
-
-  const fileRecord = invoiceFiles.get(id);
-
-  if (!fileRecord) {
-    return res.status(404).json({
-      error: 'Not Found',
-      message: `No file found for invoice ${id}`,
-    });
+  const tenantId = req.user?.id || req.user?.sub || 'unknown';
+  const meta = await storageService.getMetadata({ tenantId, invoiceId: id });
+  if (!meta) {
+    return res.status(404).json({ error: 'Not Found', message: `No file found for invoice ${id}` });
   }
-
-  const currentHash = computeHash(fileRecord.fileData);
-  const storedHash = fileRecord.fileHash;
-  const isValid = currentHash === storedHash;
-
-  return res.json({
-    data: {
-      invoiceId: id,
-      isValid,
-      storedHash,
-      currentHash,
-      uploadedAt: fileRecord.uploadedAt,
-      verifiedAt: new Date().toISOString(),
-    },
-    message: isValid ? 'File integrity verified' : 'File integrity check failed',
-  });
+  try {
+    const fileData = await storageService.getFile({ key: meta.key });
+    const currentHash = computeHash(fileData);
+    const isValid = currentHash === meta.sha256;
+    return res.json({ data: { invoiceId: id, isValid, storedHash: meta.sha256, currentHash, verifiedAt: new Date().toISOString() }, message: isValid ? 'File integrity verified' : 'File integrity check failed' });
+  } catch (err) {
+    logger.error({ err, invoiceId: id }, 'Failed to verify invoice file');
+    return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to verify invoice file' });
+  }
 });
 
 /**
  * POST /api/invoices/:id/file/verify
- * Verify integrity of a provided PDF against the stored hash.
+ * Verify integrity of a provided PDF against stored hash.
  */
-router.post('/:id/file/verify', express.raw({ type: 'application/pdf', limit: '5mb' }), (req, res) => {
+router.post('/:id/file/verify', express.raw({ type: 'application/pdf', limit: '5mb' }), async (req, res) => {
   const { id } = req.params;
-
   if (!id || typeof id !== 'string' || id.trim() === '') {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Invalid invoice ID',
-    });
+    return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
   }
-
-  const fileRecord = invoiceFiles.get(id);
-
-  if (!fileRecord) {
-    return res.status(404).json({
-      error: 'Not Found',
-      message: `No file found for invoice ${id}`,
-    });
+  const tenantId = req.user?.id || req.user?.sub || 'unknown';
+  const meta = await storageService.getMetadata({ tenantId, invoiceId: id });
+  if (!meta) {
+    return res.status(404).json({ error: 'Not Found', message: `No file found for invoice ${id}` });
   }
-
   if (!req.body || !Buffer.isBuffer(req.body) || req.body.length === 0) {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'No file data provided for verification',
-    });
-  }
+    return res.status(400).json({ error: 'Bad Request', message: 'No file data provided for verification' });
 
-  const providedHash = computeHash(req.body);
-  const storedHash = fileRecord.fileHash;
-  const isValid = providedHash === storedHash;
-
-  return res.json({
-    data: {
-      invoiceId: id,
-      isValid,
-      storedHash,
-      providedHash,
-      uploadedAt: fileRecord.uploadedAt,
-      verifiedAt: new Date().toISOString(),
-    },
-    message: isValid ? 'File integrity verified' : 'File integrity check failed - file may have been tampered with',
-  });
-});
-
-module.exports = router;

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -11,6 +11,7 @@ const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/clien
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const crypto = require('crypto');
 const path = require('path');
+const db = require('../db/knex');
 
 /** Accepted MIME types for invoice uploads. */
 const ALLOWED_MIME_TYPES = ['application/pdf', 'image/jpeg', 'image/png', 'image/tiff'];
@@ -305,10 +306,105 @@ if (!this._validateInvoiceId(invoiceId)) {
       Key: key,
     });
     return await getSignedUrl(s3Client, command, { expiresIn: expiry });
+    /**
+   * Saves file metadata to the database.
+   * @param {Object} params
+   * @param {string} params.tenantId
+   * @param {string} params.invoiceId
+   * @param {string} params.key
+   * @param {string} params.sha256
+   * @param {string} params.mimeType
+   * @param {number} params.size
+   */
+  async saveMetadata({ tenantId, invoiceId, key, sha256, mimeType, size }) {
+    const now = new Date().toISOString();
+    await db('invoice_files').insert({
+      tenant_id: tenantId,
+      invoice_id: invoiceId,
+      s3_key: key,
+      sha256,
+      mime_type: mimeType,
+      size,
+      created_at: now,
+    });
+  }
+
+  /**
+   * Retrieves file metadata for a given tenant and invoice.
+   * @param {Object} params
+   * @param {string} params.tenantId
+   * @param {string} params.invoiceId
+   * @returns {Promise<Object|null>}
+   */
+  async getMetadata({ tenantId, invoiceId }) {
+    return await db('invoice_files')
+      .where({ tenant_id: tenantId, invoice_id: invoiceId })
+      .first();
   }
 }
 
-module.exports = new StorageService();
+}
+
+  // In-memory fallback for testing environments
+  _inMemoryStore = new Map();
+
+  /**
+   * Public wrapper for key generation (used by routes).
+   * @param {Object} params - parameters.
+   * @param {string} params.tenantId
+   * @param {string} params.invoiceId
+   * @param {string} params.fileName
+   * @returns {string} generated key
+   */
+  generateKey({ tenantId, invoiceId, fileName }) {
+    const safeName = this._sanitizeFilename(fileName);
+    return this._generateKey(tenantId, invoiceId, safeName);
+  }
+
+  /**
+   * Upload a file buffer. In production this uses S3; in test mode it stores in memory.
+   * @param {Object} params
+   * @param {string} params.key - S3 object key
+   * @param {Buffer} params.body - file data
+   * @param {string} params.mimeType
+   */
+  async uploadFile({ key, body, mimeType }) {
+    // Simple in-memory storage for test environment
+    if (process.env.NODE_ENV === 'test') {
+      this._inMemoryStore.set(key, { body, mimeType });
+      return;
+    }
+    // Production upload via S3
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      Body: body,
+      ContentType: mimeType,
+    });
+    await s3Client.send(command);
+  }
+
+  /**
+   * Retrieve file data by key. Returns Buffer.
+   * @param {Object} params
+   * @param {string} params.key
+   * @returns {Promise<Buffer>}
+   */
+  async getFile({ key }) {
+    if (process.env.NODE_ENV === 'test') {
+      const entry = this._inMemoryStore.get(key);
+      if (!entry) throw new Error('File not found');
+      return entry.body;
+    }
+    const command = new GetObjectCommand({ Bucket: this.bucket, Key: key });
+    const response = await s3Client.send(command);
+    // Convert stream to Buffer
+    const chunks = [];
+    for await (const chunk of response.Body) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
 module.exports.StorageService = StorageService;
 module.exports.ALLOWED_MIME_TYPES = ALLOWED_MIME_TYPES;
 module.exports.DEFAULT_MAX_FILE_SIZE = DEFAULT_MAX_FILE_SIZE;


### PR DESCRIPTION
Closes #343

---

#343   
`feat: Persist invoice PDFs to durable storage & add metadata table`

**Description:**  
- Replaced the in‑memory `Map` used for invoice PDF bytes with the existing S3‑compatible `StorageService`.  
- Added a new `invoice_files` table (migration) to store metadata: tenant ID, invoice ID, S3 key, SHA‑256 hash, MIME type, size, and timestamps.  
- Updated `src/routes/invoiceFile.js` to upload files to S3, save metadata via `storageService.saveMetadata`, and verify integrity using the stored hash.  
- Included a helper script to run the migration; all changes are committed and pushed to the `feature/invoice-file-01-persist-storage` branch.