### PR TITLE
fix(investor-commitment): validate amountStroops format before persis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,64 @@ The backend supports durable idempotency keys for funding operations to safely r
 
 ---
 
+## Investor Commitment
+
+`src/services/investorCommitment.js` persists funding intents from the `POST /api/invest/fund-invoice` flow and exposes an in-memory lock store for the `GET /api/investor/locks` routes.
+
+### Amount validation
+
+`amountStroops` is the on-chain principal unit. The service enforces strict format rules **before any database write**:
+
+| Rule | Detail |
+|------|--------|
+| Type | Must be a `string` — numeric types are rejected, never coerced |
+| Format | Digits only — no decimal point, no sign, no scientific notation |
+| Leading zeros | Rejected (e.g. `"007"`) |
+| Range | Must be `> 0` and `≤ 10^18` stroops (≈ 10 billion XLM) |
+
+Any violation throws a `CommitmentValidationError` with a typed `.code`:
+
+| Code | Trigger |
+|------|---------|
+| `INVALID_AMOUNT_TYPE` | Value is not a string |
+| `INVALID_AMOUNT_FORMAT` | Contains non-digit characters or leading zeros |
+| `INVALID_AMOUNT_RANGE` | Value is zero |
+| `INVALID_AMOUNT_OVERFLOW` | Value exceeds the upper bound |
+| `INVALID_INVESTOR_ADDRESS` | Investor address fails Stellar address validation |
+| `AMOUNT_IMMUTABLE` | Caller attempted to update `amount_stroops` via `updateCommitment` |
+
+### Address validation
+
+`validateAddress(address)` checks that the investor address is a valid Stellar public key (G… or C… prefix, 56 base-32 characters). It returns `{ valid, reason }` and is also called from the `GET /api/investor/locks` routes to validate the `funderAddress` query parameter.
+
+### Idempotency
+
+`persistCommitment` accepts an optional `idempotencyKey`. When a row with that key already exists the function returns it immediately — no second insert is made. `updateCommitment` refuses to modify `amount_stroops` to prevent silent corruption of commitment records.
+
+### In-memory lock store
+
+The service maintains a `Map`-backed lock cache (claimNotBefore, investorEffectiveYieldBps) mirrored from the DB. All cached entries carry `stale: true` because they are not read live from the chain.
+
+| Function | Purpose |
+|----------|---------|
+| `seedInvestorLocks()` | Populate representative data (used in tests) |
+| `clearInvestorLocks()` | Wipe the cache (used between test suites) |
+| `setInvestorLock(params)` | Upsert a lock record |
+| `getInvestorLock(invoiceId, funderAddress)` | Look up a single lock |
+| `getInvestorLocksByAddress(funderAddress, opts)` | Filter by funder address |
+| `getAllInvestorLocks(opts)` | List all locks |
+
+### API routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/investor/locks` | List locks, optional `funderAddress` / `invoiceId` filters |
+| `GET` | `/api/investor/locks/:invoiceId` | Single lock for a specific invoice and funder |
+
+Both routes require a valid JWT (`Authorization: Bearer <token>`). An invalid `funderAddress` returns `400` with `{ error: "invalid Stellar address: …" }`.
+
+---
+
 ## Security audit log (Issue #116)
 
 The backend now supports a database-backed append-only audit log for:

--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,7 @@ const invoiceStateRoutes = require('./routes/invoiceStateRoutes');
 const adminEscrowRoutes = require('./routes/adminEscrow');
 const kycRoutes = require('./routes/kyc');
 const v1Routes = require('./routes/v1');
+const investorRoutes = require('./routes/investor');
 
 /**
  * Returns a 403 JSON response only for the dedicated blocked-origin CORS error.
@@ -311,6 +312,7 @@ function createApp() {
   app.use('/api/invoices', invoiceFileRoutes);
   app.use('/api/invoices', invoiceStateRoutes);
   app.use('/api/invest', investRoutes);
+  app.use('/api/investor', investorRoutes);
   app.use('/api/kyc', kycRoutes);
   app.use('/api/marketplace', marketplaceRoutes);
   app.use('/api/retention', retentionRoutes);

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -19,6 +19,104 @@ const db = require('../db/knex'); // project's shared Knex instance
 
 const TABLE = 'investor_commitments';
 
+// Stellar public key: G or C followed by exactly 55 base-32 characters (A-Z2-7)
+const STELLAR_ADDRESS_RE = /^[CG][A-Z2-7]{55}$/;
+
+// Sane upper bound: 10^18 stroops (≈ 10 billion XLM — exceeds total supply)
+const MAX_STROOP_AMOUNT = 10n ** 18n;
+
+/**
+ * Typed error thrown when commitment input fails validation.
+ * Callers can use `instanceof CommitmentValidationError` to distinguish
+ * domain errors from unexpected runtime failures.
+ */
+class CommitmentValidationError extends Error {
+  /**
+   * @param {string} message - Human-readable description.
+   * @param {string} code    - Machine-readable error code.
+   */
+  constructor(message, code) {
+    super(message);
+    this.name = 'CommitmentValidationError';
+    this.code = code;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
+ * Validate that a value is a safe positive integer string suitable for
+ * on-chain stroop math.
+ *
+ * Rules:
+ *  - Must be a `string` (never coerced — callers must convert first)
+ *  - Must contain only ASCII decimal digits (no sign, no decimal point,
+ *    no scientific notation, no whitespace)
+ *  - Must not have leading zeros (e.g. "007" is rejected)
+ *  - Must be strictly positive (> 0)
+ *  - Must not exceed MAX_STROOP_AMOUNT (10^18 stroops ≈ 10 billion XLM)
+ *
+ * @param {unknown} value - The candidate amount value.
+ * @throws {CommitmentValidationError} When the value is not a valid stroop amount.
+ */
+function validateAmountStroops(value) {
+  if (typeof value !== 'string') {
+    throw new CommitmentValidationError(
+      `amountStroops must be a string, got ${typeof value}`,
+      'INVALID_AMOUNT_TYPE'
+    );
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new CommitmentValidationError(
+      'amountStroops must contain only decimal digits (no sign, decimals, or spaces)',
+      'INVALID_AMOUNT_FORMAT'
+    );
+  }
+
+  // Reject leading zeros ("007", "00") but allow "0" itself for the zero check below
+  if (value.length > 1 && value[0] === '0') {
+    throw new CommitmentValidationError(
+      'amountStroops must not have leading zeros',
+      'INVALID_AMOUNT_FORMAT'
+    );
+  }
+
+  const big = BigInt(value);
+
+  if (big <= 0n) {
+    throw new CommitmentValidationError(
+      'amountStroops must be a positive integer (> 0)',
+      'INVALID_AMOUNT_RANGE'
+    );
+  }
+
+  if (big > MAX_STROOP_AMOUNT) {
+    throw new CommitmentValidationError(
+      `amountStroops exceeds maximum allowed value (${MAX_STROOP_AMOUNT.toString()})`,
+      'INVALID_AMOUNT_OVERFLOW'
+    );
+  }
+}
+
+/**
+ * Validate a Stellar public key (G... or C..., 56 characters total).
+ *
+ * @param {string} address - The candidate Stellar address.
+ * @returns {{ valid: boolean, reason: string }} Result object.
+ */
+function validateAddress(address) {
+  if (!address || typeof address !== 'string') {
+    return { valid: false, reason: 'invalid Stellar address: must be a non-empty string' };
+  }
+  if (!STELLAR_ADDRESS_RE.test(address)) {
+    return {
+      valid: false,
+      reason: 'invalid Stellar address: must start with G or C and be 56 base-32 characters',
+    };
+  }
+  return { valid: true, reason: '' };
+}
+
 /**
  * @typedef {Object} CommitmentRecord
  * @property {string}  id
@@ -43,13 +141,14 @@ const TABLE = 'investor_commitments';
  * @param {string} params.invoiceId
  * @param {string} params.investorAddress
  * @param {string} params.escrowAddress
- * @param {string|number} params.amountStroops
+ * @param {string} params.amountStroops   — must be a valid positive integer string
  * @param {'requires_signature'|'submitted'|'stubbed'} params.status
  * @param {string|null} [params.unsignedXdr]
  * @param {string|null} [params.txHash]
  * @param {string|null} [params.ledger]
  * @param {string|null} [params.idempotencyKey]
  * @returns {Promise<CommitmentRecord>}
+ * @throws {CommitmentValidationError} When inputs fail validation.
  */
 async function persistCommitment({
   invoiceId,
@@ -62,6 +161,15 @@ async function persistCommitment({
   ledger = null,
   idempotencyKey = null,
 }) {
+  // Validate amount — throws CommitmentValidationError for any invalid format
+  validateAmountStroops(amountStroops);
+
+  // Validate investor address
+  const addrResult = validateAddress(investorAddress);
+  if (!addrResult.valid) {
+    throw new CommitmentValidationError(addrResult.reason, 'INVALID_INVESTOR_ADDRESS');
+  }
+
   // Idempotency check: return early if we've already processed this exact request
   if (idempotencyKey) {
     const existing = await db(TABLE).where({ idempotency_key: idempotencyKey }).first();
@@ -75,7 +183,7 @@ async function persistCommitment({
       invoice_id: invoiceId,
       investor_address: investorAddress,
       escrow_address: escrowAddress,
-      amount_stroops: String(amountStroops),
+      amount_stroops: amountStroops,
       status,
       unsigned_xdr: unsignedXdr,
       tx_hash: txHash,
@@ -91,11 +199,22 @@ async function persistCommitment({
  * Update the status of an existing commitment (e.g. once the investor submits
  * the signed XDR and we observe the ledger result).
  *
+ * amount_stroops is immutable after creation — passing it in fields violates
+ * idempotency and is rejected with a typed error.
+ *
  * @param {string} id        — commitment UUID
  * @param {Partial<CommitmentRecord>} fields
  * @returns {Promise<CommitmentRecord>}
+ * @throws {CommitmentValidationError} When fields attempts to change amount_stroops.
  */
 async function updateCommitment(id, fields) {
+  if ('amount_stroops' in fields || 'amountStroops' in fields) {
+    throw new CommitmentValidationError(
+      'amount_stroops is immutable after commitment creation and cannot be updated',
+      'AMOUNT_IMMUTABLE'
+    );
+  }
+
   const [row] = await db(TABLE)
     .where({ id })
     .update({ ...fields, updated_at: db.fn.now() })
@@ -117,8 +236,114 @@ async function findCommitments(investorAddress, invoiceId) {
   return db(TABLE).where({ investor_address: investorAddress, invoice_id: invoiceId }).orderBy('created_at', 'desc');
 }
 
+// ─── In-memory investor lock store ───────────────────────────────────────────
+// Mirrors on-chain lock data (claimNotBefore, yield) into a local cache.
+// Marked stale=true because they are read from a DB mirror, not live chain state.
+
+/** @type {Map<string, Object>} key: `${invoiceId}:${funderAddress}` */
+const investorLocks = new Map();
+
+/** @param {string} invoiceId @param {string} funderAddress @returns {string} */
+function lockKey(invoiceId, funderAddress) {
+  return `${invoiceId}:${funderAddress}`;
+}
+
+/** Wipe all in-memory lock records (used in tests). */
+function clearInvestorLocks() {
+  investorLocks.clear();
+}
+
+/** Pre-populate the store with representative seed data for testing. */
+function seedInvestorLocks() {
+  setInvestorLock({
+    funderAddress: 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK',
+    claimNotBefore: '2026-01-01T00:00:00Z',
+    investorEffectiveYieldBps: 800,
+    invoiceId: 'inv_7788',
+  });
+  setInvestorLock({
+    funderAddress: 'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL',
+    claimNotBefore: '2026-02-01T00:00:00Z',
+    investorEffectiveYieldBps: 750,
+    invoiceId: 'inv_9900',
+  });
+}
+
+/**
+ * Upsert a lock record. Overwrites an existing entry for the same
+ * (invoiceId, funderAddress) pair.
+ *
+ * @param {Object} params
+ * @param {string} params.funderAddress
+ * @param {string} params.claimNotBefore
+ * @param {number} params.investorEffectiveYieldBps
+ * @param {string} params.invoiceId
+ * @returns {Object} The stored lock record.
+ */
+function setInvestorLock({ funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId }) {
+  const key = lockKey(invoiceId, funderAddress);
+  const record = { funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId, stale: true };
+  investorLocks.set(key, record);
+  return record;
+}
+
+/**
+ * Retrieve a single lock by invoice and funder.
+ *
+ * @param {string} invoiceId
+ * @param {string} funderAddress
+ * @returns {Object|undefined}
+ */
+function getInvestorLock(invoiceId, funderAddress) {
+  return investorLocks.get(lockKey(invoiceId, funderAddress));
+}
+
+/**
+ * Retrieve all locks for a given funder address, with optional invoiceId filter.
+ *
+ * @param {string} funderAddress
+ * @param {{ invoiceId?: string }} [opts]
+ * @returns {Object[]}
+ */
+function getInvestorLocksByAddress(funderAddress, opts = {}) {
+  const results = [];
+  for (const lock of investorLocks.values()) {
+    if (lock.funderAddress !== funderAddress) continue;
+    if (opts.invoiceId && lock.invoiceId !== opts.invoiceId) continue;
+    results.push(lock);
+  }
+  return results;
+}
+
+/**
+ * Retrieve all locks, with optional invoiceId filter.
+ *
+ * @param {{ invoiceId?: string }} [opts]
+ * @returns {Object[]}
+ */
+function getAllInvestorLocks(opts = {}) {
+  const results = [];
+  for (const lock of investorLocks.values()) {
+    if (opts.invoiceId && lock.invoiceId !== opts.invoiceId) continue;
+    results.push(lock);
+  }
+  return results;
+}
+
 module.exports = {
+  // Validation
+  CommitmentValidationError,
+  validateAmountStroops,
+  validateAddress,
+  // DB persistence
   persistCommitment,
   updateCommitment,
   findCommitments,
+  // In-memory lock store
+  clearInvestorLocks,
+  seedInvestorLocks,
+  setInvestorLock,
+  getInvestorLock,
+  getInvestorLocksByAddress,
+  getAllInvestorLocks,
 };

--- a/tests/investorCommitment.validation.test.js
+++ b/tests/investorCommitment.validation.test.js
@@ -1,0 +1,318 @@
+'use strict';
+
+/**
+ * tests/investorCommitment.validation.test.js
+ *
+ * Unit tests for amountStroops validation and investorAddress validation
+ * in src/services/investorCommitment.js.
+ *
+ * The knex DB is mocked globally via tests/mocks/setup.js.
+ * All tests that exercise DB paths rely on the global mock's .first()
+ * returning a row (simulating an existing idempotency-key match).
+ */
+
+const {
+  CommitmentValidationError,
+  validateAmountStroops,
+  validateAddress,
+  persistCommitment,
+  updateCommitment,
+} = require('../src/services/investorCommitment');
+
+const VALID_ADDRESS = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const VALID_C_ADDRESS = 'CDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+
+// ─── CommitmentValidationError ────────────────────────────────────────────────
+
+describe('CommitmentValidationError', () => {
+  it('is an instance of Error', () => {
+    const err = new CommitmentValidationError('bad input', 'TEST_CODE');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(CommitmentValidationError);
+  });
+
+  it('carries name, message, and code', () => {
+    const err = new CommitmentValidationError('test message', 'MY_CODE');
+    expect(err.name).toBe('CommitmentValidationError');
+    expect(err.message).toBe('test message');
+    expect(err.code).toBe('MY_CODE');
+  });
+});
+
+// ─── validateAmountStroops ────────────────────────────────────────────────────
+
+describe('validateAmountStroops', () => {
+  describe('valid inputs', () => {
+    it('accepts "1" (minimum positive)', () => {
+      expect(() => validateAmountStroops('1')).not.toThrow();
+    });
+
+    it('accepts a typical stroop amount', () => {
+      expect(() => validateAmountStroops('10000000')).not.toThrow();
+    });
+
+    it('accepts large but sane amount', () => {
+      expect(() => validateAmountStroops('999999999999999')).not.toThrow();
+    });
+
+    it('accepts exactly 10^18 (max boundary)', () => {
+      expect(() => validateAmountStroops('1000000000000000000')).not.toThrow();
+    });
+  });
+
+  describe('type rejection', () => {
+    it('rejects a number type (not coerced)', () => {
+      expect(() => validateAmountStroops(1000000)).toThrow(CommitmentValidationError);
+      expect(() => validateAmountStroops(1000000)).toThrow(/must be a string/);
+    });
+
+    it('rejects null', () => {
+      expect(() => validateAmountStroops(null)).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects undefined', () => {
+      expect(() => validateAmountStroops(undefined)).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects a BigInt type', () => {
+      expect(() => validateAmountStroops(1000000n)).toThrow(CommitmentValidationError);
+    });
+  });
+
+  describe('format rejection', () => {
+    it('rejects float string "1.5"', () => {
+      const err = catchError(() => validateAmountStroops('1.5'));
+      expect(err).toBeInstanceOf(CommitmentValidationError);
+      expect(err.code).toBe('INVALID_AMOUNT_FORMAT');
+    });
+
+    it('rejects scientific notation "1e7"', () => {
+      expect(() => validateAmountStroops('1e7')).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects negative string "-1"', () => {
+      const err = catchError(() => validateAmountStroops('-1'));
+      expect(err).toBeInstanceOf(CommitmentValidationError);
+      expect(err.code).toBe('INVALID_AMOUNT_FORMAT');
+    });
+
+    it('rejects string with spaces " 100"', () => {
+      expect(() => validateAmountStroops(' 100')).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects non-numeric string "abc"', () => {
+      expect(() => validateAmountStroops('abc')).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects empty string', () => {
+      expect(() => validateAmountStroops('')).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects string with leading zeros "007"', () => {
+      const err = catchError(() => validateAmountStroops('007'));
+      expect(err).toBeInstanceOf(CommitmentValidationError);
+      expect(err.code).toBe('INVALID_AMOUNT_FORMAT');
+    });
+
+    it('rejects "00"', () => {
+      expect(() => validateAmountStroops('00')).toThrow(CommitmentValidationError);
+    });
+
+    it('rejects hex string "0xff"', () => {
+      expect(() => validateAmountStroops('0xff')).toThrow(CommitmentValidationError);
+    });
+  });
+
+  describe('range rejection', () => {
+    it('rejects zero "0"', () => {
+      const err = catchError(() => validateAmountStroops('0'));
+      expect(err).toBeInstanceOf(CommitmentValidationError);
+      expect(err.code).toBe('INVALID_AMOUNT_RANGE');
+    });
+
+    it('rejects amount exceeding 10^18', () => {
+      const err = catchError(() => validateAmountStroops('1000000000000000001'));
+      expect(err).toBeInstanceOf(CommitmentValidationError);
+      expect(err.code).toBe('INVALID_AMOUNT_OVERFLOW');
+    });
+
+    it('rejects very large overflow value', () => {
+      expect(() => validateAmountStroops('9'.repeat(30))).toThrow(CommitmentValidationError);
+    });
+  });
+});
+
+// ─── validateAddress ──────────────────────────────────────────────────────────
+
+describe('validateAddress', () => {
+  it('accepts valid G-prefix address', () => {
+    expect(validateAddress(VALID_ADDRESS)).toEqual({ valid: true, reason: '' });
+  });
+
+  it('accepts valid C-prefix address', () => {
+    expect(validateAddress(VALID_C_ADDRESS)).toEqual({ valid: true, reason: '' });
+  });
+
+  it('rejects empty string', () => {
+    const result = validateAddress('');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/non-empty string/);
+  });
+
+  it('rejects null', () => {
+    expect(validateAddress(null).valid).toBe(false);
+  });
+
+  it('rejects undefined', () => {
+    expect(validateAddress(undefined).valid).toBe(false);
+  });
+
+  it('rejects wrong prefix X', () => {
+    const result = validateAddress('XDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/G or C/);
+  });
+
+  it('rejects address that is too short', () => {
+    expect(validateAddress('GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL').valid).toBe(false);
+  });
+
+  it('rejects address that is too long (57 chars)', () => {
+    expect(validateAddress('G' + 'A'.repeat(56)).valid).toBe(false);
+  });
+
+  it('rejects address with lowercase characters', () => {
+    const lower = VALID_ADDRESS.toLowerCase();
+    expect(validateAddress(lower).valid).toBe(false);
+  });
+
+  it('rejects address containing invalid base-32 char (1)', () => {
+    // "1" is not in A-Z2-7
+    const bad = 'G' + '1'.repeat(55);
+    expect(validateAddress(bad).valid).toBe(false);
+  });
+});
+
+// ─── persistCommitment — validation guard ─────────────────────────────────────
+
+describe('persistCommitment — validation', () => {
+  const baseParams = {
+    invoiceId: 'inv_test_001',
+    investorAddress: VALID_ADDRESS,
+    escrowAddress: VALID_C_ADDRESS,
+    amountStroops: '10000000',
+    status: 'requires_signature',
+    idempotencyKey: 'unique-key-abc123',
+  };
+
+  it('throws CommitmentValidationError for float amountStroops', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, amountStroops: '1.5' })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('throws CommitmentValidationError for negative amountStroops string', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, amountStroops: '-100' })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('throws CommitmentValidationError for zero amountStroops', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, amountStroops: '0' })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('throws CommitmentValidationError for numeric type (not coerced)', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, amountStroops: 10000000 })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('throws CommitmentValidationError for empty string amountStroops', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, amountStroops: '' })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('throws CommitmentValidationError for overflow amountStroops', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, amountStroops: '9'.repeat(25) })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('throws CommitmentValidationError for invalid investor address', async () => {
+    const err = await rejectsWith(
+      persistCommitment({ ...baseParams, investorAddress: 'not-a-stellar-address' })
+    );
+    expect(err).toBeInstanceOf(CommitmentValidationError);
+    expect(err.code).toBe('INVALID_INVESTOR_ADDRESS');
+  });
+
+  it('throws CommitmentValidationError for empty investor address', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, investorAddress: '' })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('returns existing row on duplicate idempotency key without re-inserting', async () => {
+    // The global knex mock's .first() always resolves with a row, simulating a hit
+    const result = await persistCommitment({ ...baseParams, idempotencyKey: 'dup-key-xyz' });
+    expect(result).toBeDefined();
+    expect(result.id).toBeDefined();
+  });
+
+  it('does not throw for valid inputs with idempotency key (mock returns existing row)', async () => {
+    await expect(
+      persistCommitment({ ...baseParams, idempotencyKey: 'valid-idem-key' })
+    ).resolves.toBeDefined();
+  });
+});
+
+// ─── updateCommitment — immutability guard ────────────────────────────────────
+
+describe('updateCommitment — immutability', () => {
+  it('throws CommitmentValidationError when amount_stroops is in fields', async () => {
+    const err = await rejectsWith(
+      updateCommitment('some-uuid', { status: 'submitted', amount_stroops: '99999' })
+    );
+    expect(err).toBeInstanceOf(CommitmentValidationError);
+    expect(err.code).toBe('AMOUNT_IMMUTABLE');
+  });
+
+  it('throws CommitmentValidationError when amountStroops (camelCase) is in fields', async () => {
+    await expect(
+      updateCommitment('some-uuid', { amountStroops: '50000' })
+    ).rejects.toThrow(CommitmentValidationError);
+  });
+
+  it('rejects duplicate update that would change amount', async () => {
+    const err = await rejectsWith(
+      updateCommitment('some-uuid', { amount_stroops: '1' })
+    );
+    expect(err.code).toBe('AMOUNT_IMMUTABLE');
+    expect(err.message).toMatch(/immutable/);
+  });
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Synchronously catches and returns a thrown error; returns null if no throw. */
+function catchError(fn) {
+  try {
+    fn();
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+/** Resolves with the rejection reason of a Promise; throws if it resolves. */
+async function rejectsWith(promise) {
+  try {
+    await promise;
+    throw new Error('Expected promise to reject but it resolved');
+  } catch (e) {
+    return e;
+  }
+}


### PR DESCRIPTION
…tence

Adds strict pre-write validation to persistCommitment and updateCommitment in src/services/investorCommitment.js to prevent malformed stroop amounts from corrupting commitment records and downstream on-chain funding math.

- Introduce CommitmentValidationError (typed, machine-readable .code)
- Add validateAmountStroops(): rejects non-strings, floats, negatives, leading zeros, zero, and values above 10^18 stroops; never coerces
- Add validateAddress(): validates Stellar G.../C... public key format
- Call both validators at the top of persistCommitment before any DB write
- Guard updateCommitment against amount_stroops mutations (AMOUNT_IMMUTABLE)
- Add in-memory lock store (clearInvestorLocks, seedInvestorLocks, setInvestorLock, getInvestorLock, getInvestorLocksByAddress, getAllInvestorLocks) required by investor.locks routes and tests
- Mount /api/investor router in app.js (was missing, causing 404s)
- Add tests/investorCommitment.validation.test.js (45 tests covering all edge cases: type, format, range, overflow, address, idempotency, immutability)
- All 64 investor tests now pass (19 pre-existing + 45 new)
- Update README with Investor Commitment section documenting error codes, address validation, idempotency rules, lock store API, and routes

Closes #375