### PR TITLE
feat(resiliency): route Soroban reads through circuit breaker with metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,14 @@ tests/load/reports/
 
 ## Resiliency & Retries
 
+### Soroban RPC Circuit Breaker
+
+Soroban RPC reads are routed through a circuit breaker to prevent cascading failures during sustained RPC outages.
+The breaker trips to an `OPEN` state after a configurable threshold of failures (default 5) and begins failing fast,
+returning a `503 Service Unavailable` with `code = 'CIRCUIT_OPEN'`.
+
+After a recovery timeout (default 10s), the breaker transitions to `HALF_OPEN` and probes the RPC. If successful, it closes and resumes normal operation; if it fails, it re-opens. State transitions are tracked as a Prometheus metric: `soroban_circuit_breaker_state_transitions_total`.
+
 ### Security notes
 
 - Remote load targets are blocked by default.

--- a/src/errors/mapError.js
+++ b/src/errors/mapError.js
@@ -73,6 +73,16 @@ function mapError(error) {
     };
   }
 
+  if (error && typeof error === "object" && error.code === "CIRCUIT_OPEN") {
+    return {
+      status: 503,
+      code: "CIRCUIT_OPEN",
+      message: "Service temporarily unavailable due to upstream outage. Circuit breaker is OPEN.",
+      retryable: true,
+      retryHint: "Retry the request in a few moments.",
+    };
+  }
+
   const status = (error && error.status) || 500;
   return {
     status,

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -147,6 +147,18 @@ const footprintCacheEvictionsTotal = new client.Counter({
 });
 
 /**
+ * Counter: Soroban circuit breaker state transitions.
+ * Incremented each time the circuit breaker changes state (e.g., to OPEN or HALF_OPEN).
+ * @type {import('prom-client').Counter}
+ */
+const sorobanCircuitBreakerStateTransitionsTotal = new client.Counter({
+  name: 'soroban_circuit_breaker_state_transitions_total',
+  help: 'Total number of state transitions in the Soroban circuit breaker',
+  labelNames: ['state'],
+  registers: [registry],
+});
+
+/**
  * Express middleware that enforces metrics auth.
  *
  * @param {import('express').Request} req
@@ -204,6 +216,7 @@ module.exports = {
   footprintCacheHitsTotal,
   footprintCacheMissesTotal,
   footprintCacheEvictionsTotal,
+  sorobanCircuitBreakerStateTransitionsTotal,
   escrowReconciliationMismatches,
   readinessGauge,
 };

--- a/src/services/soroban.js
+++ b/src/services/soroban.js
@@ -42,7 +42,11 @@ const sharedBreaker = new CircuitBreaker({
   failureThreshold: parseInt(process.env.SOROBAN_CB_FAILURE_THRESHOLD || '5', 10),
   recoveryTimeout: parseInt(process.env.SOROBAN_CB_RECOVERY_TIMEOUT || '10000', 10),
   onStateChange: (oldState, newState) => {
-    if (metrics && metrics.sorobanCircuitBreakerStateTransitionsTotal) {
+    if (
+      metrics &&
+      metrics.sorobanCircuitBreakerStateTransitionsTotal &&
+      typeof metrics.sorobanCircuitBreakerStateTransitionsTotal.labels === 'function'
+    ) {
       metrics.sorobanCircuitBreakerStateTransitionsTotal.labels(newState).inc();
     }
   }

--- a/src/services/soroban.js
+++ b/src/services/soroban.js
@@ -10,6 +10,9 @@
 
 'use strict';
 
+const { CircuitBreaker } = require('../utils/circuitBreaker');
+const metrics = require('../metrics');
+
 /**
  * Retry configuration used for all Soroban contract calls.
  *
@@ -30,6 +33,20 @@ const SOROBAN_RETRY_CONFIG = {
  * @constant {Set<number>}
  */
 const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
+
+/**
+ * Shared Circuit Breaker instance for all Soroban RPC reads.
+ * Protects against cascading failures by failing fast during sustained outages.
+ */
+const sharedBreaker = new CircuitBreaker({
+  failureThreshold: parseInt(process.env.SOROBAN_CB_FAILURE_THRESHOLD || '5', 10),
+  recoveryTimeout: parseInt(process.env.SOROBAN_CB_RECOVERY_TIMEOUT || '10000', 10),
+  onStateChange: (oldState, newState) => {
+    if (metrics && metrics.sorobanCircuitBreakerStateTransitionsTotal) {
+      metrics.sorobanCircuitBreakerStateTransitionsTotal.labels(newState).inc();
+    }
+  }
+});
 
 /**
  * Sleeps for `ms` milliseconds.
@@ -179,7 +196,7 @@ async function withRetry(operation, config) {
  */
 async function callSorobanContract(operation, config) {
   const cfg = config ? { ...SOROBAN_RETRY_CONFIG, ...config } : SOROBAN_RETRY_CONFIG;
-  return withRetry(operation, cfg);
+  return sharedBreaker.execute(() => withRetry(operation, cfg));
 }
 
 module.exports = {
@@ -190,4 +207,5 @@ module.exports = {
   isRetryable,
   SOROBAN_RETRY_CONFIG,
   RETRYABLE_STATUS_CODES,
+  sharedBreaker,
 };

--- a/src/services/soroban.test.js
+++ b/src/services/soroban.test.js
@@ -34,5 +34,40 @@ describe('Soroban Integration Wrapper', () => {
       await expect(callSorobanContract(operation)).rejects.toThrow('Invalid arguments');
       expect(operation).toHaveBeenCalledTimes(1);
     });
+
+    it('should trip the circuit breaker on sustained transient errors', async () => {
+      const { sharedBreaker } = require('./soroban');
+      
+      // Reset breaker state for clean test
+      sharedBreaker.state = 'CLOSED';
+      sharedBreaker.failureCount = 0;
+      
+      const operation = jest.fn().mockImplementation(() => {
+        const err = new Error('503 Service Unavailable');
+        err.status = 503;
+        return Promise.reject(err);
+      });
+
+      // Provide a fast retry config so test doesn't hang
+      const fastConfig = { maxRetries: 0, baseDelay: 0, maxDelay: 0 };
+      
+      // Fail enough times to trip the breaker (default threshold is 5)
+      for (let i = 0; i < 5; i++) {
+        await expect(callSorobanContract(operation, fastConfig)).rejects.toThrow('503 Service Unavailable');
+      }
+
+      // Next call should fail fast from the breaker
+      const fastFailOp = jest.fn();
+      let caughtError;
+      try {
+        await callSorobanContract(fastFailOp, fastConfig);
+      } catch (e) {
+        caughtError = e;
+      }
+      
+      expect(caughtError).toBeDefined();
+      expect(caughtError.code).toBe('CIRCUIT_OPEN');
+      expect(fastFailOp).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/circuitBreaker.js
+++ b/src/utils/circuitBreaker.js
@@ -44,6 +44,7 @@ class CircuitBreaker {
   /**
    * Updates the internal state and fires the onStateChange callback if provided.
    * @param {string} newState - The new state to transition to.
+   * @returns {void}
    */
   _transitionState(newState) {
     if (this.state !== newState) {

--- a/src/utils/circuitBreaker.js
+++ b/src/utils/circuitBreaker.js
@@ -28,15 +28,31 @@ class CircuitBreaker {
    * @param {number} [options.failureThreshold=5] - Number of failures before state changes to OPEN.
    * @param {number} [options.recoveryTimeout=10000] - Time in ms before state changes from OPEN to HALF_OPEN.
    * @param {Function} [options.fallbackLogic=null] - Optional fallback function executed when circuit is OPEN.
+   * @param {Function} [options.onStateChange=null] - Optional callback triggered on state transitions `(oldState, newState)`.
    */
   constructor(options = {}) {
     this.failureThreshold = options.failureThreshold || 5;
     this.recoveryTimeout = options.recoveryTimeout || 10000;
     this.fallbackLogic = options.fallbackLogic || null;
+    this.onStateChange = options.onStateChange || null;
 
     this.state = CircuitBreakerState.CLOSED;
     this.failureCount = 0;
     this.nextAttemptTime = Date.now();
+  }
+
+  /**
+   * Updates the internal state and fires the onStateChange callback if provided.
+   * @param {string} newState - The new state to transition to.
+   */
+  _transitionState(newState) {
+    if (this.state !== newState) {
+      const oldState = this.state;
+      this.state = newState;
+      if (typeof this.onStateChange === 'function') {
+        this.onStateChange(oldState, newState);
+      }
+    }
   }
 
   /**
@@ -49,13 +65,15 @@ class CircuitBreaker {
     if (this.state === CircuitBreakerState.OPEN) {
       if (Date.now() >= this.nextAttemptTime) {
         // Time has elapsed, transition to HALF_OPEN to test the resource.
-        this.state = CircuitBreakerState.HALF_OPEN;
+        this._transitionState(CircuitBreakerState.HALF_OPEN);
       } else {
         // Circuit is still OPEN. Fail fast or use fallback.
         if (this.fallbackLogic) {
           return this.fallbackLogic();
         }
-        throw new Error('Circuit Breaker is OPEN. Operation failed fast.');
+        const err = new Error('Circuit Breaker is OPEN. Operation failed fast.');
+        err.code = 'CIRCUIT_OPEN';
+        throw err;
       }
     }
 
@@ -76,7 +94,7 @@ class CircuitBreaker {
   onSuccess(response) {
     this.failureCount = 0;
     if (this.state === CircuitBreakerState.HALF_OPEN) {
-      this.state = CircuitBreakerState.CLOSED;
+      this._transitionState(CircuitBreakerState.CLOSED);
     }
     return response;
   }
@@ -92,7 +110,7 @@ class CircuitBreaker {
     this.failureCount += 1;
 
     if (this.state === CircuitBreakerState.HALF_OPEN || this.failureCount >= this.failureThreshold) {
-      this.state = CircuitBreakerState.OPEN;
+      this._transitionState(CircuitBreakerState.OPEN);
       this.nextAttemptTime = Date.now() + this.recoveryTimeout;
     }
 

--- a/src/utils/circuitBreaker.test.js
+++ b/src/utils/circuitBreaker.test.js
@@ -51,7 +51,16 @@ describe('CircuitBreaker', () => {
 
         const operation = jest.fn();
 
-        await expect(cb.execute(operation)).rejects.toThrow('Circuit Breaker is OPEN. Operation failed fast.');
+        let caughtError;
+        try {
+            await cb.execute(operation);
+        } catch (err) {
+            caughtError = err;
+        }
+
+        expect(caughtError).toBeDefined();
+        expect(caughtError.message).toBe('Circuit Breaker is OPEN. Operation failed fast.');
+        expect(caughtError.code).toBe('CIRCUIT_OPEN');
         expect(operation).not.toHaveBeenCalled();
     });
 
@@ -100,5 +109,33 @@ describe('CircuitBreaker', () => {
         expect(operation).toHaveBeenCalledTimes(1);
         expect(cb.state).toBe(CircuitBreakerState.OPEN);
         expect(cb.failureCount).toBe(1); // incremented
+    });
+
+    it('should trigger onStateChange callback upon state transitions', async () => {
+        const onStateChange = jest.fn();
+        cb = new CircuitBreaker({
+            failureThreshold: 1,
+            recoveryTimeout: 5000,
+            onStateChange
+        });
+
+        const operation = jest.fn().mockRejectedValue(new Error('failure'));
+
+        // Trip the breaker
+        await expect(cb.execute(operation)).rejects.toThrow('failure');
+        expect(onStateChange).toHaveBeenCalledWith(CircuitBreakerState.CLOSED, CircuitBreakerState.OPEN);
+
+        // Fast fail won't transition
+        await expect(cb.execute(operation)).rejects.toThrow('Circuit Breaker is OPEN. Operation failed fast.');
+        expect(onStateChange).toHaveBeenCalledTimes(1);
+
+        // Advance time to HALF_OPEN
+        jest.setSystemTime(Date.now() + 5001);
+        operation.mockResolvedValue('success');
+        await cb.execute(operation);
+        
+        expect(onStateChange).toHaveBeenCalledWith(CircuitBreakerState.OPEN, CircuitBreakerState.HALF_OPEN);
+        expect(onStateChange).toHaveBeenCalledWith(CircuitBreakerState.HALF_OPEN, CircuitBreakerState.CLOSED);
+        expect(onStateChange).toHaveBeenCalledTimes(3);
     });
 });


### PR DESCRIPTION
This PR integrates the CircuitBreaker utility with the Soroban RPC read operations. Previously, a sustained RPC outage would cause every request to exhaust its full retry budget via SOROBAN_RETRY_CONFIG, leading to cascading failures and blocked resources.

Soroban read operations (callSorobanContract) are now routed through a shared CircuitBreaker instance. The system will fail fast (503 Service Unavailable) during a sustained outage and safely recover via half-open probing.

Changes Included
Resiliency: Created a shared CircuitBreaker in src/services/soroban.js that wraps the internal withRetry operation, ensuring we don't double-count failures.
Error Mapping: Modified CircuitBreaker to emit a specific CIRCUIT_OPEN error code, mapped gracefully to a 503 Service Unavailable response via src/errors/mapError.js with retryable: true.
Metrics: Registered soroban_circuit_breaker_state_transitions_total as a Prometheus metric in src/metrics.js and wired it up via the onStateChange callback in CircuitBreaker.
Documentation: Added a dedicated sub-section under "Resiliency & Retries" in README.md to explain the circuit breaker parameters.
Testing: Added comprehensive unit tests in both circuitBreaker.test.js and soroban.test.js to ensure state transitions, callbacks, and fast-fail behavior all function correctly.
Security Notes
Input Sanitization: Circuit breaker state tracking (CLOSED, OPEN, HALF_OPEN) depends strictly on network fault counts and is entirely decoupled from user inputs. It cannot be maliciously manipulated by untrusted payloads.
Information Disclosure: Internal Soroban RPC URLs, stack traces, and raw HTTP responses are intercepted by the error mapper and are not leaked to external consumers when the circuit breaker trips.
Test Coverage & Validation
text
[Insert npm test output here]
Checklist:

 Tested locally (npm test, npm run lint)
 >95% test coverage maintained on impacted modules
 PR description contains security notes
 README.md updated with Resiliency notes
 
 closes #270 