### PR TITLE
Feature/v1 invoices 25 patch delete

### DIFF
--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -22,7 +22,8 @@ const smeRouter = require('../sme');
 const { extractTenant } = require('../../middleware/tenant');
 const invoiceService = require('../../services/invoiceService');
 const AppError = require('../../errors/AppError');
-const { invoiceCreateSchema, parseValidationErrors } = require('../../schemas/invoice');
+const { invoiceCreateSchema, invoiceUpdateSchema, parseValidationErrors } = require('../../schemas/invoice');
+const { validatePatchFields, detectLockedFieldChange } = require('../../middleware/patchInvoice');
 
 // ── Sub-router mounts ────────────────────────────────────────────────────────
 router.use('/invest', investRoutes);
@@ -148,6 +149,92 @@ router.post('/invoices', extractTenant, async (req, res, next) => {
       data: invoice,
       message: 'Invoice created successfully.',
     });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+/**
+ * PATCH /v1/invoices/:id
+ *
+ * Partially updates an invoice scoped to the authenticated tenant. Field-level
+ * guards are applied via `validatePatchFields` which strips unknown keys and
+ * enforces the mutable-field set. Attempts to change locked fields for
+ * invoices in locked statuses result in a 422 AppError.
+ */
+router.patch('/invoices/:id', extractTenant, validatePatchFields, async (req, res, next) => {
+  try {
+    const invoiceId = String(req.params.id || '').trim();
+
+    // Validate sanitized payload with Zod update schema
+    const parsed = invoiceUpdateSchema.safeParse(req.sanitizedUpdate);
+    if (!parsed.success) {
+      const fieldErrors = parseValidationErrors(parsed.error);
+      return next(
+        new AppError({
+          type: 'https://liquifact.com/probs/validation-error',
+          title: 'Validation Error',
+          status: 422,
+          detail: 'Request body contains invalid or missing fields.',
+          instance: req.originalUrl,
+          code: 'VALIDATION_ERROR',
+          retryable: false,
+          fieldErrors,
+        }),
+      );
+    }
+
+    // Ensure resource exists and belongs to tenant
+    const existing = await invoiceService.getInvoiceById(invoiceId, req.tenantId);
+    if (!existing) {
+      return next(new AppError({ title: 'Not Found', status: 404, detail: 'Invoice not found' }));
+    }
+
+    // Enforce locked-field rules
+    const { locked, field } = detectLockedFieldChange(req.sanitizedUpdate, existing.status);
+    if (locked) {
+      return next(
+        new AppError({
+          type: 'https://liquifact.com/probs/validation-error',
+          title: 'Validation Error',
+          status: 422,
+          detail: `Field '${field}' cannot be modified when invoice status is '${existing.status}'.`,
+          instance: req.originalUrl,
+          code: 'LOCKED_FIELD',
+          retryable: false,
+          fieldErrors: { [field]: 'Field is locked for this invoice status' },
+        }),
+      );
+    }
+
+    const updates = parsed.data;
+    const updated = await invoiceService.updateInvoice(invoiceId, updates, req.tenantId);
+
+    if (!updated) {
+      return next(new AppError({ title: 'Not Found', status: 404, detail: 'Invoice not found' }));
+    }
+
+    return res.json({ data: updated, message: 'Invoice updated successfully.' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+/**
+ * DELETE /v1/invoices/:id
+ *
+ * Soft-deletes the invoice by setting `deleted_at`. Scoped to tenant.
+ */
+router.delete('/invoices/:id', extractTenant, async (req, res, next) => {
+  try {
+    const invoiceId = String(req.params.id || '').trim();
+
+    const deleted = await invoiceService.deleteInvoice(invoiceId, req.tenantId);
+    if (!deleted) {
+      return next(new AppError({ title: 'Not Found', status: 404, detail: 'Invoice not found' }));
+    }
+
+    return res.json({ data: deleted, message: 'Invoice deleted (soft-delete) successfully.' });
   } catch (err) {
     return next(err);
   }

--- a/src/services/invoiceService.js
+++ b/src/services/invoiceService.js
@@ -26,6 +26,8 @@
 const db = require('../db/knex');
 const { applyQueryOptions } = require('../utils/queryBuilder');
 const logger = require('../logger');
+const AppError = require('../errors/AppError');
+const { LOCKED_STATUSES } = require('../middleware/patchInvoice');
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -260,7 +262,22 @@ async function updateInvoice(id, updates = {}, tenantId) {
   if (!id) {
     throw new TypeError('invoice id required');
   }
+  // Ensure invoice exists and belongs to tenant
+  const existing = await db('invoices').where({ invoice_id: id, tenant_id: tenantId }).first();
+  if (!existing) {
+    return null;
+  }
 
+  // Reject updates when invoice is in a locked status
+  if (existing && LOCKED_STATUSES.has(existing.status)) {
+    throw new AppError({
+      type: 'https://liquifact.com/probs/validation-error',
+      title: 'Validation Error',
+      status: 422,
+      detail: `Invoice in status '${existing.status}' cannot be modified.`,
+      code: 'LOCKED_STATUS',
+    });
+  }
   const result = await db('invoices')
     .where({ invoice_id: id, tenant_id: tenantId })
     .update({ ...updates, updated_at: nowValue() })
@@ -285,6 +302,23 @@ async function updateInvoice(id, updates = {}, tenantId) {
 async function deleteInvoice(id, tenantId) {
   if (!id) {
     throw new TypeError('invoice id required');
+  }
+
+  // Ensure invoice exists and belongs to tenant
+  const existing = await db('invoices').where({ invoice_id: id, tenant_id: tenantId }).first();
+  if (!existing) {
+    return null;
+  }
+
+  // Reject deletes when invoice is in a locked status
+  if (existing && LOCKED_STATUSES.has(existing.status)) {
+    throw new AppError({
+      type: 'https://liquifact.com/probs/validation-error',
+      title: 'Validation Error',
+      status: 422,
+      detail: `Invoice in status '${existing.status}' cannot be deleted.`,
+      code: 'LOCKED_STATUS',
+    });
   }
 
   const ts = nowValue();

--- a/tests/v1.invoices.test.js
+++ b/tests/v1.invoices.test.js
@@ -130,6 +130,28 @@ function getInvoices(tenantId, query = {}) {
     .query(query);
 }
 
+/**
+ * PATCHs an invoice for the given tenant with the provided body.
+ * @param {string} tenantId
+ * @param {string} invoiceId
+ * @param {object} body
+ */
+function patchInvoice(tenantId, invoiceId, body) {
+  return request(app)
+    .patch(`/v1/invoices/${invoiceId}`)
+    .set('x-tenant-id', tenantId)
+    .send(body);
+}
+
+/**
+ * DELETEs an invoice for the given tenant.
+ */
+function deleteInvoiceRequest(tenantId, invoiceId) {
+  return request(app)
+    .delete(`/v1/invoices/${invoiceId}`)
+    .set('x-tenant-id', tenantId);
+}
+
 // ===========================================================================
 // Test suites
 // ===========================================================================
@@ -472,5 +494,90 @@ describe('RFC 7807 error response format', () => {
     // Tenant middleware returns a plain JSON error (not RFC 7807), consistent
     // with the existing middleware contract
     expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/invoices/:id — partial updates
+// ---------------------------------------------------------------------------
+
+describe('PATCH /v1/invoices/:id — partial updates', () => {
+  it('updates allowed fields and returns 200', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 400, customer: 'Updatable Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    const res = await patchInvoice(TENANT_A, invoiceId, { amount: 450, notes: 'Adjusted' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.amount).toBeDefined();
+    expect(Number(res.body.data.amount)).toBeCloseTo(450, 1);
+    expect(res.body.data.notes).toBe('Adjusted');
+  });
+
+  it('returns 422 when payload fails validation', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 300, customer: 'BadPatch Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    const res = await patchInvoice(TENANT_A, invoiceId, { amount: 'not-a-number' });
+    expect(res.status).toBe(422);
+    expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+  });
+
+  it('returns 404 for unknown invoice', async () => {
+    const res = await patchInvoice(TENANT_A, 'inv_does_not_exist', { amount: 100 });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when cross-tenant patch attempted', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 120, customer: 'CrossTenant Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    const res = await patchInvoice(TENANT_B, invoiceId, { amount: 130 });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects locked-field edits with 422', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 600, customer: 'Locked Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    // Mark invoice as verified in DB directly
+    await db('invoices').where({ invoice_id: invoiceId }).update({ status: 'verified' });
+
+    const res = await patchInvoice(TENANT_A, invoiceId, { amount: 700 });
+    expect(res.status).toBe(422);
+    expect(res.body.fieldErrors).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/invoices/:id — soft delete
+// ---------------------------------------------------------------------------
+
+describe('DELETE /v1/invoices/:id — soft delete', () => {
+  it('soft-deletes the invoice and it no longer appears in default list', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 250, customer: 'Delete API Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    const res = await deleteInvoiceRequest(TENANT_A, invoiceId);
+    expect(res.status).toBe(200);
+
+    const list = await getInvoices(TENANT_A);
+    expect(list.body.data.find((i) => i.invoice_id === invoiceId)).toBeUndefined();
+
+    const listAll = await getInvoices(TENANT_A, { includeDeleted: 'true' });
+    expect(listAll.body.data.find((i) => i.invoice_id === invoiceId)).toBeDefined();
+  });
+
+  it('returns 404 when deleting an invoice from another tenant', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 350, customer: 'NoDelete Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    const res = await deleteInvoiceRequest(TENANT_B, invoiceId);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when deleting non-existent invoice', async () => {
+    const res = await deleteInvoiceRequest(TENANT_A, 'inv_not_here');
+    expect(res.status).toBe(404);
   });
 });

--- a/tests/v1.invoices.test.js
+++ b/tests/v1.invoices.test.js
@@ -580,4 +580,15 @@ describe('DELETE /v1/invoices/:id — soft delete', () => {
     const res = await deleteInvoiceRequest(TENANT_A, 'inv_not_here');
     expect(res.status).toBe(404);
   });
+
+  it('rejects deletion of invoices in locked statuses with 422', async () => {
+    const created = await postInvoice(TENANT_A, { amount: 420, customer: 'Locked Delete Co' });
+    const invoiceId = created.body.data.invoice_id;
+
+    // Mark invoice as settled in DB directly
+    await db('invoices').where({ invoice_id: invoiceId }).update({ status: 'settled' });
+
+    const res = await deleteInvoiceRequest(TENANT_A, invoiceId);
+    expect(res.status).toBe(422);
+  });
 });


### PR DESCRIPTION
**Title:** feat(v1-invoices): add PATCH and soft-DELETE handlers with locked-status guards

**Description**
- Adds PATCH `/v1/invoices/:id` (Zod-validated) and DELETE `/v1/invoices/:id` (soft delete) to the v1 router.
- Enforces tenant scoping and locked-status rules so verified/funded/settled/cancelled invoices cannot be modified or deleted.
- Reuses existing field-level guards from `validatePatchFields` and returns RFC7807-style 422 problem details for validation/locked-field errors.

**What I changed**
- Updated route: index.js
- Enforced service-level checks: invoiceService.js
- Added tests: v1.invoices.test.js

**Behavior**
- PATCH validates `invoiceUpdateSchema` and only allows fields allowed by the `validatePatchFields` middleware.
- Attempts to change locked fields when invoice status is in the locked set produce 422 with `fieldErrors`.
- PATCH/DELETE return 404 when the invoice does not exist or belongs to a different tenant.
- DELETE performs a soft-delete (sets `deleted_at`) and is disallowed for locked statuses (422).
- Responses are returned in the standardized envelope; validation errors use RFC 7807 Problem+JSON.

**How to test locally**
```bash
# install deps (if needed)
npm install

# run the v1 integration tests
npx jest tests/v1.invoices.test.js --runInBand
```

**Files to review**
- index.js
- invoiceService.js
- v1.invoices.test.js

Closes: #367 