### PR TITLE
feat(escrow-read): serve funded/settled state from the projection tab…

### DIFF
--- a/docs/escrow-integration-overview.md
+++ b/docs/escrow-integration-overview.md
@@ -18,7 +18,7 @@
 | Area | Module | Current repo behavior | Target production behavior |
 |------|--------|----------------------|----------------------------|
 | Event ingest | [`src/jobs/escrowIndexer.js`](../src/jobs/escrowIndexer.js) | Horizon poll → `escrow_events` / `escrow_event_projection` | Same; optional Captive Core later |
-| Escrow read (service) | [`src/services/escrowRead.js`](../src/services/escrowRead.js) | Soroban RPC **stubs** for `get_escrow_state`, `get_legal_hold` | Real `LiquifactEscrow` contract reads |
+| Escrow read (service) | [`src/services/escrowRead.js`](../src/services/escrowRead.js) | **Projection-first** SQL read (`escrow_event_projection`) → neutral RPC stub for `get_escrow_state`; `get_legal_hold` stub | Real `LiquifactEscrow` contract reads |
 | Escrow read (minimal app) | [`src/app.js`](../src/app.js) | `GET /api/escrow/:invoiceId` via `resolveEscrowAddress` + placeholder Soroban op | Wire to `readEscrowState` + projection/cache |
 | Funding | [`src/services/escrowSubmit.js`](../src/services/escrowSubmit.js) | Validates payload; **`submitted: false`**; optional simulation | Build/sign/submit `fund_escrow` (delegated or custodial) |
 | Reconciliation | [`src/jobs/reconcileEscrow.js`](../src/jobs/reconcileEscrow.js) | Mock invoices + mock on-chain amounts | Real DB + contract `funded_amount` |
@@ -102,16 +102,26 @@ sequenceDiagram
 **Intended production path**
 
 1. Resolve contract/address: `resolveEscrowAddress(invoiceId)` from [`escrowMap.js`](../src/config/escrowMap.js) (env JSON `ESCROW_ADDR_BY_INVOICE`).
-2. Prefer latest **`escrow_event_projection`** row for fast off-chain summary (indexer).
-3. Enrich with live Soroban read: [`readEscrowState()`](../src/services/escrowRead.js) — concurrent base state + `fetchLegalHold()`; optional token metadata via [`tokenMeta.js`](../src/services/tokenMeta.js).
-4. Optional Redis cache: `REDIS_ESCROW_CACHE_*` (see `.env.example`).
+2. Prefer the **Redis cache** if `REDIS_ESCROW_CACHE_ENABLED=true` and the entry is fresh (`getEscrowStateWithProjection` only).
+3. Read the latest **`escrow_event_projection`** row via `_readBaseStateFromProjection()` — durable, indexed ingestion output from [`escrowIndexer.js`](../src/jobs/escrowIndexer.js).
+4. On cache miss + projection miss, fall through to a **neutral RPC stub** (`status: 'not_found'`, `fundedAmount: 0`). When the contract is wired, replace the stub with a real `LiquifactEscrow.get_escrow_state` invocation.
+
+For `readEscrowState` / `readFundedAmount` / `readEscrowStateWithAttestations` the chain is **test adapter → projection → neutral RPC stub** (no fabrication). All three top-level functions share `_fetchBaseEscrowState()` so projection shape stays consistent across read endpoints.
+
+**Base-state ordering** (shared by `readEscrowState`, `readFundedAmount`, `readEscrowStateWithAttestations`, `getEscrowStateWithProjection`):
+
+```
+adapter (if injected)  →  projection row  →  neutral RPC stub
+     ↓                        ↓                       ↓
+  bypass                    main source        last-resort fallback
+```
 
 **Current minimal app** ([`src/app.js`](../src/app.js))
 
-- `GET /api/escrow/:invoiceId` trims `invoiceId`, calls `resolveEscrowAddress`, wraps a **placeholder** Soroban operation in `callSorobanContract`, sets header **`X-Escrow-Address`**, returns `{ status: 'not_found', fundedAmount: 0 }` in the stub path.
+- `GET /api/escrow/:invoiceId` trims `invoiceId`, calls `resolveEscrowAddress`, delegates to [`getEscrowStateWithProjection()`](../src/services/escrowRead.js) which orchestrates the cache → projection → RPC chain, and sets header **`X-Escrow-Address`**.
 - Full-feature routes/tests often mount [`escrowRead.js`](../src/services/escrowRead.js) directly (see `tests/escrow.read.test.js`, `tests/escrow.legalhold.test.js`).
 
-**`readEscrowState` return shape (target):** `invoiceId`, `status`, `fundedAmount`, `legal_hold`, `funding_token`.
+**`readEscrowState` return shape (target):** `invoiceId`, `status`, `fundedAmount`, `legal_hold`, `funding_token`, `source`, `latest_ledger_sequence`, `latest_event_type`, `latest_event_id`, `latest_observed_at`.
 
 ---
 
@@ -255,6 +265,8 @@ Assume testnet configuration and a mapping entry in `ESCROW_ADDR_BY_INVOICE`.
 
 - **Indexer is read-only** — no Stellar secret keys; invalid events skipped; duplicate `event_id` safe ([indexing strategy](./escrow-indexing-strategy.md)).
 - **Funding stub** — no private keys in repo, logs, or API responses; custodial signing only via KMS aliases ([ops-signing](./ops-signing.md)).
+- **Escrow read** — projection-first lookup, never fabricated state. The legacy `funded_invoice` / `settled_invoice` stub fixtures have been removed because they misled investors and the reconciler into believing invoices had funded when the indexer had not yet recorded them. A missing projection now returns `status: 'not_found', fundedAmount: 0` (warn log on DB failure, fall through to RPC).
+- **No decimals for math** — Cached/projected decimals are never used to scale on-chain principal values. Reconciliation compares equal-unit amounts only. See [`TOKEN_METADATA.md`](./TOKEN_METADATA.md).
 - **Input validation** — strict patterns in `escrowSubmit` and `escrowRead`; oversized metadata rejected.
 - **Legal hold** — RPC failure defaults to **`legal_hold: false`** in `fetchLegalHold` (warn log); callers needing strict blocking should override via adapter.
 - **Idempotency** — required for live submit; stub accepts key for forward compatibility.

--- a/src/services/escrowRead.js
+++ b/src/services/escrowRead.js
@@ -3,7 +3,25 @@
  * the `get_legal_hold` flag from the LiquifactEscrow Soroban contract.
  *
  * The service is intentionally side-effect-free: it reads state and returns a
- * plain object.  All mutation (funding, settlement) lives in separate modules.
+ * plain object. All mutation (funding, settlement) lives in separate modules.
+ *
+ * Read ordering (when no test adapter is injected):
+ *
+ *   1. Cache      — optional Redis escrow summary cache (`REDIS_ESCROW_CACHE_*`).
+ *                   Orchestrated by {@link getEscrowStateWithProjection}; the
+ *                   lower-level readers prefer the projection first.
+ *   2. Projection — durable per-invoice `escrow_event_projection` row written
+ *                   by the indexer (`src/jobs/escrowIndexer.js`). Decimals on
+ *                   the projection are display-only — never used to scale
+ *                   on-chain principal math.
+ *   3. RPC stub   — production placeholder for the Soroban `get_escrow_state`
+ *                   call. Returns a neutral `{ status: 'not_found',
+ *                   fundedAmount: 0 }` shape so callers do not see fabricated
+ *                   state for invoice IDs the indexer has not yet recorded.
+ *
+ * Test injection: tests should supply `escrowAdapter` to short-circuit the
+ * projection + RPC fallback chain. Adapter injection takes precedence over
+ * the cache and projection paths so unit tests stay deterministic.
  *
  * @module services/escrowRead
  */
@@ -28,19 +46,32 @@ const cache = createRedisEscrowSummaryCache();
 const INVOICE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 
 /**
+ * Neutral base-state shape returned when neither the projection nor a test
+ * adapter has data for an invoice. Never fabricate funded amounts: a missing
+ * projection must look like "not on-chain yet", not like a funded stub.
+ *
+ * @constant {object}
+ */
+const NEUTRAL_BASE_STATE = Object.freeze({
+  status: "not_found",
+  fundedAmount: 0,
+  source: "rpc_stub",
+});
+
+/**
  * Validates an invoice ID string.
  *
  * @param {unknown} invoiceId - Value to validate.
  * @returns {{ valid: boolean, reason?: string }}
  */
 function validateInvoiceId(invoiceId) {
-  if (typeof invoiceId !== 'string' || invoiceId.trim() === '') {
-    return { valid: false, reason: 'invoiceId must be a non-empty string' };
+  if (typeof invoiceId !== "string" || invoiceId.trim() === "") {
+    return { valid: false, reason: "invoiceId must be a non-empty string" };
   }
   if (!INVOICE_ID_RE.test(invoiceId.trim())) {
     return {
       valid: false,
-      reason: 'invoiceId contains invalid characters (allowed: a-z A-Z 0-9 _ -)',
+      reason: "invoiceId contains invalid characters (allowed: a-z A-Z 0-9 _ -)",
     };
   }
   return { valid: true };
@@ -51,14 +82,14 @@ function validateInvoiceId(invoiceId) {
  *
  * In production this would invoke the real Soroban RPC; here we wrap the
  * operation in `callSorobanContract` so retries and error mapping are applied
- * consistently.  The `adapter` parameter lets tests inject a stub without
+ * consistently. The `adapter` parameter lets tests inject a stub without
  * monkey-patching the module.
  *
  * @param {string} invoiceId - Validated invoice identifier.
  * @param {Function} [adapter] - Optional async function `(invoiceId) => boolean`.
  *   Defaults to the production Soroban stub.
  * @returns {Promise<boolean>} Resolves to `true` when the escrow is under legal
- *   hold, `false` otherwise.  Defaults to `false` on any non-fatal error so
+ *   hold, `false` otherwise. Defaults to `false` on any non-fatal error so
  *   that a missing or unreachable contract never silently unblocks funding.
  */
 async function fetchLegalHold(invoiceId, adapter) {
@@ -73,17 +104,158 @@ async function fetchLegalHold(invoiceId, adapter) {
   try {
     const result = await callSorobanContract(operation);
     // Coerce to boolean; treat any truthy on-chain value as held.
-    return result === true || result === 1 || result === 'true';
+    return result === true || result === 1 || result === "true";
   } catch (err) {
     // Log without exposing internals; default to false (not held) so a
     // transient RPC failure does not permanently block all funding.
     // Callers that need stricter behaviour can override via the adapter.
     logger.warn(
       { invoiceId, errCode: err?.code },
-      'escrowRead: get_legal_hold call failed — defaulting to false',
+      "escrowRead: get_legal_hold call failed — defaulting to false",
     );
     return false;
   }
+}
+
+/**
+ * Safely parses the JSON `latest_event_body` written by the indexer projection.
+ * Returns an empty object on parse failure so callers can fall back to the
+ * envelope-level event type without crashing.
+ *
+ * @param {unknown} rawBody - Raw value from the projection row.
+ * @returns {object} Parsed event body (empty object on failure).
+ */
+function _parseEventBody(rawBody) {
+  if (rawBody && typeof rawBody === "string") {
+    try {
+      const parsed = JSON.parse(rawBody);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch (_err) {
+      return {};
+    }
+  }
+  if (rawBody && typeof rawBody === "object") {
+    return rawBody;
+  }
+  return {};
+}
+
+/**
+ * Normalises a `fundedAmount` candidate to a finite non-negative number. Falls
+ * back to `0` when the value is missing, NaN, or wrong-shaped so downstream
+ * arithmetic stays NaN-free.
+ *
+ * @param {unknown} raw - Any value (string, number).
+ * @returns {number} Finite number, 0 when unparseable.
+ */
+function _coerceFundedAmount(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    return 0;
+  }
+  return n;
+}
+
+/**
+ * Reads the latest projection row for an invoice and normalises it into the
+ * base-state envelope used by the rest of the read path.
+ *
+ * Security notes:
+ *  - We never trust `eventBody.status` / `eventBody.fundedAmount` to override
+ *    `latest_event_type` blindly; the envelope (`latest_event_type`) is the
+ *    indexer's source of truth, while `eventBody` provides enrichments.
+ *  - Decimals that may appear on the projection are display-only. They are
+ *    never copied into the base-state return value and must NEVER be used to
+ *    scale on-chain principal math (see `src/services/tokenMeta.js`).
+ *
+ * @param {string} safeId - Validated, trimmed invoice ID.
+ * @param {import('knex').Knex} [dbClient=db] - Knex instance (injectable for tests).
+ * @returns {Promise<object|null>} Normalised base state, or null when no
+ *   projection row exists for the invoice (or the DB read fails).
+ */
+async function _readBaseStateFromProjection(safeId, dbClient = db) {
+  try {
+    const projection = await dbClient("escrow_event_projection")
+      .where("invoice_id", safeId)
+      .first();
+
+    if (!projection) {
+      return null;
+    }
+
+    const eventBody = _parseEventBody(projection.latest_event_body);
+    const status =
+      (typeof eventBody.status === "string" && eventBody.status) ||
+      (typeof projection.latest_event_type === "string" &&
+        projection.latest_event_type) ||
+      "unknown";
+
+    const latestLedger = Number(projection.latest_ledger_sequence);
+    return {
+      invoiceId: safeId,
+      status,
+      fundedAmount: _coerceFundedAmount(eventBody.fundedAmount),
+      latest_ledger_sequence: Number.isFinite(latestLedger)
+        ? latestLedger
+        : null,
+      latest_event_type: projection.latest_event_type || null,
+      latest_event_id: projection.latest_event_id || null,
+      latest_paging_token: projection.latest_paging_token || null,
+      latest_observed_at: projection.latest_observed_at || null,
+      source: "projection",
+      // Backwards-compatible flag retained for callers that branch on it.
+      fromProjection: true,
+    };
+  } catch (err) {
+    // Treat any DB failure as "no projection" so the caller can attempt the
+    // RPC fallback instead of failing the whole read.
+    logger.warn(
+      { invoiceId: safeId, err: err?.message },
+      "escrowRead: projection read failed; falling back to RPC stub",
+    );
+    return null;
+  }
+}
+
+/**
+ * Fetches the base escrow state for an invoice using the projection-first
+ * ordering:
+ *
+ *   1. Test adapter (when provided)
+ *   2. `escrow_event_projection` row written by the indexer
+ *   3. Neutral RPC stub (no fabricated values)
+ *
+ * Previously the RPC fallback returned hardcoded funded_invoice /
+ * settled_invoice fixtures. Those were removed because they fabricated state
+ * for invoices the indexer had not yet recorded, which misled the
+ * reconciliation job and any investor-facing reads.
+ *
+ * @param {string} invoiceId - Validated invoice ID.
+ * @param {Function} [adapter] - Optional async test adapter.
+ * @param {object} [options={}]
+ * @param {import('knex').Knex} [options.dbClient=db] - Override the default
+ *   Knex instance for tests.
+ * @returns {Promise<object>} Base escrow state without `legal_hold`.
+ */
+async function _fetchBaseEscrowState(invoiceId, adapter, options = {}) {
+  // 1. Test adapter always wins — keeps unit tests deterministic.
+  if (adapter) {
+    return callSorobanContract(() => adapter(invoiceId));
+  }
+
+  const projectionState = await _readBaseStateFromProjection(
+    invoiceId,
+    options.dbClient,
+  );
+  if (projectionState) {
+    return projectionState;
+  }
+
+  // 3. Neutral RPC stub — never fabricate state for arbitrary invoice IDs.
+  return callSorobanContract(async () => ({
+    invoiceId,
+    ...NEUTRAL_BASE_STATE,
+  }));
 }
 
 /**
@@ -109,12 +281,18 @@ async function fetchLegalHold(invoiceId, adapter) {
  * @property {Object|null} funding_token - Token metadata (symbol, name, decimals).
  */
 async function readEscrowState(invoiceId, options = {}) {
-  const { legalHoldAdapter, escrowAdapter, fundingAsset, tokenMetaAdapter } = options;
+  const {
+    legalHoldAdapter,
+    escrowAdapter,
+    fundingAsset,
+    tokenMetaAdapter,
+    dbClient,
+  } = options;
 
   const { valid, reason } = validateInvoiceId(invoiceId);
   if (!valid) {
     const err = new Error(reason);
-    err.code = 'INVALID_INVOICE_ID';
+    err.code = "INVALID_INVOICE_ID";
     err.status = 400;
     throw err;
   }
@@ -123,11 +301,12 @@ async function readEscrowState(invoiceId, options = {}) {
 
   // Fetch base escrow state and legal hold flag concurrently.
   const [baseState, legalHold] = await Promise.all([
-    _fetchBaseEscrowState(safeId, escrowAdapter),
+    _fetchBaseEscrowState(safeId, escrowAdapter, { dbClient }),
     fetchLegalHold(safeId, legalHoldAdapter),
   ]);
 
-  // Fetch token metadata if funding asset is provided
+  // Fetch token metadata if funding asset is provided. This is best-effort:
+  // any failure is logged but does not fail the whole read (warn-and-continue).
   let tokenMetadata = null;
   if (fundingAsset) {
     try {
@@ -140,7 +319,7 @@ async function readEscrowState(invoiceId, options = {}) {
       // Log error but don't fail the entire request
       logger.warn(
         { invoiceId: safeId, asset: fundingAsset, error: error.message },
-        'escrowRead: Failed to fetch token metadata, continuing without it',
+        "escrowRead: Failed to fetch token metadata, continuing without it",
       );
     }
   }
@@ -150,39 +329,6 @@ async function readEscrowState(invoiceId, options = {}) {
     legal_hold: legalHold,
     funding_token: tokenMetadata,
   };
-}
-
-/**
- * Fetches the base escrow state (status, fundedAmount, etc.) from the contract.
- *
- * @param {string}    invoiceId     - Validated invoice ID.
- * @param {Function} [adapter]      - Optional test adapter.
- * @returns {Promise<object>} Base escrow state without `legal_hold`.
- */
-async function _fetchBaseEscrowState(invoiceId, adapter) {
-  const operation = adapter
-    ? () => adapter(invoiceId)
-    : async () => {
-        // Production stub — replace with real Soroban RPC invocation:
-        //   return sorobanClient.invokeContract(contractId, 'get_escrow_state', [invoiceId]);
-        // For testing webhooks, return different statuses based on invoiceId
-        let status = 'not_found';
-        let fundedAmount = 0;
-        if (invoiceId === 'funded_invoice') {
-          status = 'funded';
-          fundedAmount = 1000;
-        } else if (invoiceId === 'settled_invoice') {
-          status = 'settled';
-          fundedAmount = 1000;
-        }
-        return {
-          invoiceId,
-          status,
-          fundedAmount,
-        };
-      };
-
-  return callSorobanContract(operation);
 }
 
 /**
@@ -201,26 +347,29 @@ async function fetchAttestationAppendLog(invoiceId, adapter) {
         //   return sorobanClient.invokeContract(contractId, 'get_attestation_append_log', [invoiceId]);
         // Expected return: array of {index: number, digest: Buffer}
         return [
-          { index: 0, digest: Buffer.from('deadbeef', 'hex') },
-          { index: 1, digest: Buffer.from('cafebabe', 'hex') },
+          { index: 0, digest: Buffer.from("deadbeef", "hex") },
+          { index: 1, digest: Buffer.from("cafebabe", "hex") },
         ];
       };
 
   try {
     const result = await callSorobanContract(operation);
     if (!Array.isArray(result)) {
-      logger.warn({ invoiceId }, 'escrowRead: get_attestation_append_log returned non-array');
+      logger.warn(
+        { invoiceId },
+        "escrowRead: get_attestation_append_log returned non-array",
+      );
       return [];
     }
     // Decode each entry: convert digest to hex string
-    return result.map(entry => ({
+    return result.map((entry) => ({
       index: entry.index,
-      digest: entry.digest ? entry.digest.toString('hex') : '',
+      digest: entry.digest ? entry.digest.toString("hex") : "",
     }));
   } catch (err) {
     logger.warn(
       { invoiceId, errCode: err?.code },
-      'escrowRead: get_attestation_append_log call failed — returning empty array',
+      "escrowRead: get_attestation_append_log call failed — returning empty array",
     );
     return [];
   }
@@ -248,12 +397,19 @@ async function fetchAttestationAppendLog(invoiceId, adapter) {
  * @property {Object|null} funding_token - Token metadata (symbol, name, decimals).
  */
 async function readEscrowStateWithAttestations(invoiceId, options = {}) {
-  const { legalHoldAdapter, escrowAdapter, attestationAdapter, fundingAsset, tokenMetaAdapter } = options;
+  const {
+    legalHoldAdapter,
+    escrowAdapter,
+    attestationAdapter,
+    fundingAsset,
+    tokenMetaAdapter,
+    dbClient,
+  } = options;
 
   const { valid, reason } = validateInvoiceId(invoiceId);
   if (!valid) {
     const err = new Error(reason);
-    err.code = 'INVALID_INVOICE_ID';
+    err.code = "INVALID_INVOICE_ID";
     err.status = 400;
     throw err;
   }
@@ -262,12 +418,12 @@ async function readEscrowStateWithAttestations(invoiceId, options = {}) {
 
   // Fetch all data concurrently
   const [baseState, legalHold, attestations] = await Promise.all([
-    _fetchBaseEscrowState(safeId, escrowAdapter),
+    _fetchBaseEscrowState(safeId, escrowAdapter, { dbClient }),
     fetchLegalHold(safeId, legalHoldAdapter),
     fetchAttestationAppendLog(safeId, attestationAdapter),
   ]);
 
-  // Fetch token metadata if funding asset is provided
+  // Fetch token metadata if funding asset is provided (best-effort).
   let tokenMetadata = null;
   if (fundingAsset) {
     try {
@@ -280,7 +436,7 @@ async function readEscrowStateWithAttestations(invoiceId, options = {}) {
       // Log error but don't fail the entire request
       logger.warn(
         { invoiceId: safeId, asset: fundingAsset, error: error.message },
-        'escrowRead: Failed to fetch token metadata, continuing without it',
+        "escrowRead: Failed to fetch token metadata, continuing without it",
       );
     }
   }
@@ -294,56 +450,74 @@ async function readEscrowStateWithAttestations(invoiceId, options = {}) {
 }
 
 /**
- * Reads only the on-chain `funded_amount` for an invoice from the
- * LiquifactEscrow contract via {@link callSorobanContract}.
+ * Reads only the on-chain `funded_amount` for an invoice.
  *
  * This is a focused read used by the nightly reconciliation job, which only
  * needs the funded amount and not the full enriched escrow state (legal hold,
- * token metadata, attestations). It reuses the same validation and retry path
- * as the rest of the escrow read surface so behaviour stays consistent.
+ * token metadata, attestations). It reuses the same validation and
+ * projection-first ordering as the rest of the escrow read surface so
+ * behaviour stays consistent.
  *
  * @param {string} invoiceId - Invoice identifier (validated internally).
  * @param {object} [options={}]
  * @param {Function} [options.escrowAdapter] - Injected adapter
  *   `(invoiceId) => { fundedAmount } | number` for tests. Defaults to the
- *   production base-state stub.
- * @returns {Promise<number>} The on-chain funded amount as a finite number.
+ *   production projection-first base-state read.
+ * @param {import('knex').Knex} [options.dbClient=db] - Knex instance (tests).
+ * @returns {Promise<number>} The funded amount as a finite number. Falls back
+ *   to `0` when the projection, adapter, or RPC stub returns no data so the
+ *   reconciliation job never sees a fabricated value.
  * @throws {Error} With `code = 'INVALID_INVOICE_ID'` and `status = 400` when
- *   `invoiceId` is invalid. Soroban/transport errors propagate from
- *   {@link callSorobanContract} so callers can classify them as `error`.
+ *   `invoiceId` is invalid.
  */
 async function readFundedAmount(invoiceId, options = {}) {
-  const { escrowAdapter } = options;
+  const { escrowAdapter, dbClient } = options;
 
   const { valid, reason } = validateInvoiceId(invoiceId);
   if (!valid) {
     const err = new Error(reason);
-    err.code = 'INVALID_INVOICE_ID';
+    err.code = "INVALID_INVOICE_ID";
     err.status = 400;
     throw err;
   }
 
   const safeId = invoiceId.trim();
-  const baseState = await _fetchBaseEscrowState(safeId, escrowAdapter);
+  const baseState = await _fetchBaseEscrowState(safeId, escrowAdapter, {
+    dbClient,
+  });
 
   // Adapters may return either the full base-state object or a bare number.
   const raw =
-    baseState && typeof baseState === 'object' ? baseState.fundedAmount : baseState;
+    baseState && typeof baseState === "object"
+      ? baseState.fundedAmount
+      : baseState;
   const amount = Number(raw);
   return Number.isFinite(amount) ? amount : 0;
 }
 
 /**
- * Retrieves the escrow state from the projection or cache,
- * falling back to live read if necessary.
+ * Retrieves the escrow state from the cache or projection, falling back to a
+ * live RPC read if neither has data.
  *
- * @param {string} invoiceId - Invoice identifier
- * @returns {Promise<Object>} The escrow state
+ * Ordering (matches the docstring at the top of this module):
+ *   1. Redis cache (when enabled) — short-circuit on hit.
+ *   2. `escrow_event_projection` row (durable, written by the indexer).
+ *      Reuses {@link _readBaseStateFromProjection} via
+ *      {@link _fetchBaseEscrowState} so the projection shape and the
+ *      reconciliation-friendly shape stay in lock-step.
+ *   3. Live RPC stub — returns the neutral `not_found` envelope when neither
+ *      cache nor projection know about the invoice.
+ *
+ * @param {string} invoiceId - Invoice identifier.
+ * @param {object} [options={}]
+ * @param {import('knex').Knex} [options.dbClient=db] - Knex instance (tests).
+ * @returns {Promise<Object>} The escrow state.
  */
-async function getEscrowStateWithProjection(invoiceId) {
+async function getEscrowStateWithProjection(invoiceId, options = {}) {
   const safeId = invoiceId.trim();
+  const { dbClient } = options;
 
-  // Try cache first if enabled
+  // 1. Try cache first if enabled. Cache wins on hit.
   if (cache) {
     const cacheResult = await cache.getSummary(safeId);
     if (cacheResult.hit) {
@@ -351,54 +525,43 @@ async function getEscrowStateWithProjection(invoiceId) {
     }
   }
 
-  // Try projection table
-  const projection = await db('escrow_event_projection')
-    .where('invoice_id', safeId)
-    .first();
-
-  if (projection) {
-    let eventBody = {};
-    try {
-      eventBody = JSON.parse(projection.latest_event_body);
-    } catch (_e) {
-      // Fallback if not JSON
-    }
-
-    const state = {
-      invoiceId: safeId,
-      status: eventBody.status || projection.latest_event_type,
-      fundedAmount: eventBody.fundedAmount || 0,
-      latest_ledger_sequence: parseInt(projection.latest_ledger_sequence, 10),
-      latest_event_type: projection.latest_event_type,
-      fromProjection: true
-    };
-
-    // Update cache
+  // 2. Read from the projection table via the shared helper, so projection
+  //    shape stays consistent with readEscrowState / readFundedAmount /
+  //    readEscrowStateWithAttestations.
+  const projectionState = await _readBaseStateFromProjection(safeId, dbClient);
+  if (projectionState) {
     if (cache) {
-      await cache.setSummary(safeId, state, state.latest_ledger_sequence);
+      await cache.setSummary(
+        safeId,
+        projectionState,
+        projectionState.latest_ledger_sequence,
+      );
     }
-    return state;
+    return projectionState;
   }
 
-  // Fallback to live read
-  const baseState = await _fetchBaseEscrowState(safeId);
+  // 3. Fallback to live RPC read (neutral stub currently; real Soroban call
+  //    once the contract is deployed).
+  const baseState = await _fetchBaseEscrowState(safeId, undefined, { dbClient });
   const legalHold = await fetchLegalHold(safeId);
 
+  // Preserve the legacy `latest_event_type === 'live_read'` marker so callers
+  // and existing tests that branch on it keep working with the projection-first
+  // refactor.
   const state = {
     ...baseState,
     legal_hold: legalHold,
-    latest_event_type: 'live_read'
+    latest_event_type: baseState.latest_event_type || "live_read",
+    source: baseState.source || "rpc_stub",
   };
 
   if (cache) {
-    // For live reads, we might not know the exact ledger, so we omit it
+    // For live reads, we might not know the exact ledger, so we omit it.
     await cache.setSummary(safeId, state);
   }
 
   return state;
 }
-
-
 
 module.exports = {
   readEscrowState,

--- a/tests/escrow.attestations.test.js
+++ b/tests/escrow.attestations.test.js
@@ -22,46 +22,54 @@ jest.mock('../src/logger', () => ({
 }));
 
 // Stub the Knex default export with an in-memory store so we can drive the
-// projection-first path without a real database. Only the
-// `db('escrow_event_projection').where('invoice_id', id).first()` chain is
-// exercised here; Knex's full surface is not required.
-const projectionRows = new Map();
-function makeProjectionBuilder() {
-  const builder = {
-    _table: 'escrow_event_projection',
-    async first() {
-      return projectionRows.get(builder._whereId) || null;
-    },
-    where(fieldOrObj, value) {
-      builder._whereId = typeof fieldOrObj === 'string' ? String(value) : '';
-      return builder;
-    },
-  };
-  return builder;
-}
-const mockKnex = jest.fn((table) => {
-  if (table === 'escrow_event_projection') {
-    return makeProjectionBuilder();
+// projection-first path without a real database. The factory is fully
+// self-contained (no external references) so jest's mock-hoisting does not
+// trip on TDZ variables.
+jest.mock('../src/db/knex', () => {
+  const rows = new Map();
+  function makeBuilder(table) {
+    return {
+      _table: table,
+      _whereId: null,
+      where(field, value) {
+        if (typeof field === 'string') {
+          this._whereId = String(value);
+        }
+        return this;
+      },
+      async first() {
+        if (table !== 'escrow_event_projection') return null;
+        if (!this._whereId) return null;
+        return rows.get(this._whereId) || null;
+      },
+      async del() { rows.clear(); return 0; },
+      async insert(payload) {
+        if (table !== 'escrow_event_projection') return 0;
+        const entries = Array.isArray(payload) ? payload : [payload];
+        entries.forEach((entry) => {
+          if (entry && entry.invoice_id) rows.set(entry.invoice_id, entry);
+        });
+        return entries.length;
+      },
+    };
   }
-  // Other tables aren't exercised by the attestation read path; return a
-  // safe empty shape that resolves to null instead of throwing so the rest
-  // of the helper invocations stay quiet.
-  return {
-    _table: table,
-    where() { return this; },
-    async first() { return null; },
-  };
-});
-jest.mock('../src/db/knex', () => mockKnex);
+  return jest.fn((table) => makeBuilder(table));
+}, { virtual: true });
 
 const { readEscrowStateWithAttestations, fetchAttestationAppendLog, validateInvoiceId } = require('../src/services/escrowRead');
+// The mocked knex handle (see jest.mock above). Tests use it to seed/clear
+// the projection table through the same code path the production read uses.
+const db = require('../src/db/knex');
 
 // ── unit: escrowRead attestation service ──────────────────────────────────────
 
 describe('escrowRead attestation service', () => {
-  beforeEach(() => {
-    projectionRows.clear();
-    mockKnex.mockClear();
+  beforeEach(async () => {
+    // The mock factory is self-isolating: the in-memory rows map lives inside
+    // the factory closure. Clear both the call history and the rows so the
+    // projection state does not leak between tests.
+    jest.clearAllMocks();
+    await db('escrow_event_projection').del();
   });
   describe('fetchAttestationAppendLog', () => {
     it('returns array of attestation entries with hex digests', async () => {
@@ -143,7 +151,9 @@ describe('escrowRead attestation service', () => {
         attestationAdapter: mockAttestationAdapter,
       });
 
-      expect(result).toEqual({
+      // Use toMatchObject so additional fields added by `readEscrowStateWithAttestations`
+      // (e.g. `funding_token` for token-metadata enrichment, even when null) are tolerated.
+      expect(result).toMatchObject({
         invoiceId: 'inv_123',
         status: 'funded',
         fundedAmount: 1000,
@@ -153,6 +163,8 @@ describe('escrowRead attestation service', () => {
           { index: 1, digest: 'hexdigest2' },
         ],
       });
+      // The enrichments are best-effort and currently optional.
+      expect(result.funding_token === null || typeof result.funding_token === 'object').toBe(true);
     });
 
     it('validates invoiceId', async () => {
@@ -179,7 +191,8 @@ describe('escrowRead attestation service', () => {
     });
 
     it('reads base state from the projection when no adapter is injected', async () => {
-      projectionRows.set('inv_proj_att', {
+      await db('escrow_event_projection').del();
+      await db('escrow_event_projection').insert({
         invoice_id: 'inv_proj_att',
         latest_event_id: 'evt_p',
         latest_event_type: 'funded',
@@ -203,7 +216,7 @@ describe('escrowRead attestation service', () => {
     });
 
     it('falls through to the neutral RPC stub when projection is missing', async () => {
-      projectionRows.clear(); // safety
+      await db('escrow_event_projection').del();
       const result = await readEscrowStateWithAttestations('inv_unknown', {
         attestationAdapter: () => Promise.resolve([]),
       });
@@ -216,9 +229,6 @@ describe('escrowRead attestation service', () => {
       // The neutral stub must NOT fabricate funded/settled values.
       expect(result.fundedAmount).toBe(0);
     });
-  });
-
-  describe('validateInvoiceId', () => {
   });
 
   describe('validateInvoiceId', () => {

--- a/tests/escrow.attestations.test.js
+++ b/tests/escrow.attestations.test.js
@@ -21,11 +21,48 @@ jest.mock('../src/logger', () => ({
   info: jest.fn(),
 }));
 
+// Stub the Knex default export with an in-memory store so we can drive the
+// projection-first path without a real database. Only the
+// `db('escrow_event_projection').where('invoice_id', id).first()` chain is
+// exercised here; Knex's full surface is not required.
+const projectionRows = new Map();
+function makeProjectionBuilder() {
+  const builder = {
+    _table: 'escrow_event_projection',
+    async first() {
+      return projectionRows.get(builder._whereId) || null;
+    },
+    where(fieldOrObj, value) {
+      builder._whereId = typeof fieldOrObj === 'string' ? String(value) : '';
+      return builder;
+    },
+  };
+  return builder;
+}
+const mockKnex = jest.fn((table) => {
+  if (table === 'escrow_event_projection') {
+    return makeProjectionBuilder();
+  }
+  // Other tables aren't exercised by the attestation read path; return a
+  // safe empty shape that resolves to null instead of throwing so the rest
+  // of the helper invocations stay quiet.
+  return {
+    _table: table,
+    where() { return this; },
+    async first() { return null; },
+  };
+});
+jest.mock('../src/db/knex', () => mockKnex);
+
 const { readEscrowStateWithAttestations, fetchAttestationAppendLog, validateInvoiceId } = require('../src/services/escrowRead');
 
 // ── unit: escrowRead attestation service ──────────────────────────────────────
 
 describe('escrowRead attestation service', () => {
+  beforeEach(() => {
+    projectionRows.clear();
+    mockKnex.mockClear();
+  });
   describe('fetchAttestationAppendLog', () => {
     it('returns array of attestation entries with hex digests', async () => {
       const mockAdapter = jest.fn().mockResolvedValue([
@@ -140,6 +177,48 @@ describe('escrowRead attestation service', () => {
 
       expect(result.attestations).toEqual([]);
     });
+
+    it('reads base state from the projection when no adapter is injected', async () => {
+      projectionRows.set('inv_proj_att', {
+        invoice_id: 'inv_proj_att',
+        latest_event_id: 'evt_p',
+        latest_event_type: 'funded',
+        latest_ledger_sequence: '42',
+        latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 2500 }),
+      });
+
+      const result = await readEscrowStateWithAttestations('inv_proj_att', {
+        attestationAdapter: () => Promise.resolve([]),
+      });
+
+      expect(result).toMatchObject({
+        invoiceId: 'inv_proj_att',
+        status: 'funded',
+        fundedAmount: 2500,
+        attestations: [],
+        source: 'projection',
+        fromProjection: true,
+      });
+      expect(result.latest_ledger_sequence).toBe(42);
+    });
+
+    it('falls through to the neutral RPC stub when projection is missing', async () => {
+      projectionRows.clear(); // safety
+      const result = await readEscrowStateWithAttestations('inv_unknown', {
+        attestationAdapter: () => Promise.resolve([]),
+      });
+
+      expect(result).toMatchObject({
+        invoiceId: 'inv_unknown',
+        status: 'not_found',
+        fundedAmount: 0,
+      });
+      // The neutral stub must NOT fabricate funded/settled values.
+      expect(result.fundedAmount).toBe(0);
+    });
+  });
+
+  describe('validateInvoiceId', () => {
   });
 
   describe('validateInvoiceId', () => {

--- a/tests/escrow.read.test.js
+++ b/tests/escrow.read.test.js
@@ -20,6 +20,52 @@ jest.mock('../src/services/soroban', () => ({
   }),
 }));
 
+// The global jest setup mocks src/db/knex with a fake builder whose
+// `.first()` always returns the same canned row. That interferes with this
+// suite because the projection read path needs the seeded row to round-trip
+// through .insert() -> .where(invoice_id, ...).first(). Override the global
+// mock here with an in-memory store keyed by invoice_id. The factory is
+// fully self-contained (no external references) so jest's mock-hoisting
+// does not trip on TDZ variables. The mock also exposes `db.destroy()` so
+// the afterAll hook here does not throw on in-memory teardown.
+jest.mock('../src/db/knex', () => {
+  const rows = new Map();
+  const fakeDb = jest.fn((table) => ({
+    _table: table,
+    _whereId: null,
+    where(field, value) {
+      if (typeof field === 'string') {
+        this._whereId = String(value);
+      }
+      return this;
+    },
+    async first() {
+      if (!this._whereId) return null;
+      return rows.get(this._whereId) || null;
+    },
+    async del() {
+      rows.clear();
+      return 0;
+    },
+    async destroy() {
+      rows.clear();
+    },
+    async insert(payload) {
+      const entries = Array.isArray(payload) ? payload : [payload];
+      entries.forEach((entry) => {
+        if (entry && entry.invoice_id) {
+          rows.set(entry.invoice_id, entry);
+        }
+      });
+      return entries.length;
+    },
+  }));
+  fakeDb.destroy = async () => {
+    rows.clear();
+  };
+  return fakeDb;
+}, { virtual: true });
+
 describe('GET /api/escrow/:invoiceId', () => {
   let app;
   let cache;
@@ -47,7 +93,9 @@ describe('GET /api/escrow/:invoiceId', () => {
   it('returns 404 for unknown invoice', async () => {
     const res = await request(app).get('/api/escrow/unknown-inv');
     expect(res.status).toBe(404);
-    expect(res.body.error).toMatch(/No escrow contract mapping found/);
+    // Standardized envelope wraps route errors as `{message, code, details}`
+    expect(res.body.error.message).toMatch(/No escrow contract mapping found/);
+    expect(res.body.error.code).toBe('NOT_FOUND');
   });
 
   it('reads from projection table when cache misses', async () => {
@@ -68,7 +116,14 @@ describe('GET /api/escrow/:invoiceId', () => {
     expect(res.body.data.fundedAmount).toBe(5000);
     expect(res.body.data.latest_ledger_sequence).toBe(12345);
     expect(res.body.data.latest_event_type).toBe('funded');
-    expect(res.body.message).toMatch(/from event projection/);
+    expect(res.body.data.fromProjection).toBe(true);
+    // Standardized envelope: confirm success envelope shape (error=null,
+    // meta stamped with version+timestamp). The original `message` field is
+    // dropped by the wrapper; the data carries a `fromProjection` flag that
+    // is the contract here.
+    expect(res.body.error).toBeNull();
+    expect(res.body.meta).toBeDefined();
+    expect(res.body.meta.version).toBeDefined();
 
     // Verify it was cached
     if (cache) {
@@ -85,7 +140,8 @@ describe('GET /api/escrow/:invoiceId', () => {
     // values. The neutral envelope reports status='not_found' regardless.
     expect(res.body.data.status).toBe('not_found');
     expect(res.body.data.fundedAmount).toBe(0);
-    expect(res.body.message).toMatch(/live Soroban contract/);
+    expect(res.body.data.latest_event_type).toBe('live_read');
+    expect(res.body.error).toBeNull();
   });
 
   it('does NOT fabricate funded/settled state from the legacy fixture names', async () => {
@@ -100,7 +156,6 @@ describe('GET /api/escrow/:invoiceId', () => {
     expect(fundedRes.body.data.status).toBe('not_found');
     expect(fundedRes.body.data.fundedAmount).toBe(0);
     expect(fundedRes.body.data.latest_event_type).toBe('live_read');
-    expect(fundedRes.body.message).toMatch(/live Soroban contract/);
 
     const settledRes = await request(app).get('/api/escrow/settled_invoice');
     expect(settledRes.status).toBe(200);

--- a/tests/escrow.read.test.js
+++ b/tests/escrow.read.test.js
@@ -81,9 +81,81 @@ describe('GET /api/escrow/:invoiceId', () => {
   it('falls back to live read if projection misses', async () => {
     const res = await request(app).get('/api/escrow/inv-live-1');
     expect(res.status).toBe(200);
-    expect(res.body.data.status).toBe('not_found'); // Based on mock fallback logic
-    expect(res.body.data.latest_event_type).toBe('live_read');
+    // No projection seeded: the fallback RPC stub must NOT fabricate funded
+    // values. The neutral envelope reports status='not_found' regardless.
+    expect(res.body.data.status).toBe('not_found');
+    expect(res.body.data.fundedAmount).toBe(0);
     expect(res.body.message).toMatch(/live Soroban contract/);
+  });
+
+  it('does NOT fabricate funded/settled state from the legacy fixture names', async () => {
+    // Issue #354 regression: legacy keys used to return hardcoded funded/settled
+    // data. With the projection-first refactor, missing projection rows must
+    // fall through to the neutral stub (status='not_found', fundedAmount=0)
+    // rather than fabricate state the indexer has not yet recorded.
+    await db('escrow_event_projection').del();
+
+    const fundedRes = await request(app).get('/api/escrow/funded_invoice');
+    expect(fundedRes.status).toBe(200);
+    expect(fundedRes.body.data.status).toBe('not_found');
+    expect(fundedRes.body.data.fundedAmount).toBe(0);
+    expect(fundedRes.body.data.latest_event_type).toBe('live_read');
+    expect(fundedRes.body.message).toMatch(/live Soroban contract/);
+
+    const settledRes = await request(app).get('/api/escrow/settled_invoice');
+    expect(settledRes.status).toBe(200);
+    expect(settledRes.body.data.status).toBe('not_found');
+    expect(settledRes.body.data.fundedAmount).toBe(0);
+  });
+
+  it('treats malformed projection JSON as missing data (no crash)', async () => {
+    await db('escrow_event_projection').insert({
+      invoice_id: 'inv-bad-json',
+      latest_event_id: 'evt_bad',
+      latest_event_type: 'funded',
+      latest_ledger_sequence: 7,
+      latest_event_body: '{not json',
+      latest_observed_at: new Date(),
+    });
+
+    const res = await request(app).get('/api/escrow/inv-bad-json');
+    expect(res.status).toBe(200);
+    // Source still marked as projection (because a row exists) but funded
+    // amount gracefully falls back to 0.
+    expect(res.body.data.source).toBe('projection');
+    expect(res.body.data.fundedAmount).toBe(0);
+    expect(res.body.data.status).toBe('funded'); // falls back to event_type
+  });
+
+  it('serves projection as cache on second request', async () => {
+    await db('escrow_event_projection').insert({
+      invoice_id: 'inv-cache',
+      latest_event_id: 'evt_c',
+      latest_event_type: 'funded',
+      latest_ledger_sequence: 50,
+      latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 100 }),
+      latest_observed_at: new Date(),
+    });
+
+    const first = await request(app).get('/api/escrow/inv-cache');
+    expect(first.status).toBe(200);
+    expect(first.body.data.fundedAmount).toBe(100);
+
+    // The first call should have populated the cache. Don't reseed projection.
+    if (cache) {
+      const cached = await cache.getSummary('inv-cache', 51);
+      expect(cached.hit).toBe(true);
+      expect(cached.value.fundedAmount).toBe(100);
+    }
+  });
+
+  it('rejects an invalid invoiceId with INVALID_INVOICE_ID', async () => {
+    // /api/escrow/:invoiceId rejects obviously bad ids upstream. We sanity
+    // check here via the service helper since the route is gated by mapping.
+    const { validateInvoiceId } = require('../src/services/escrowRead');
+    expect(validateInvoiceId('').valid).toBe(false);
+    expect(validateInvoiceId('   ').valid).toBe(false);
+    expect(validateInvoiceId('bad id with spaces').valid).toBe(false);
   });
 
   it('invalidates cache on ledger gap', async () => {

--- a/tests/reconcileEscrow.test.js
+++ b/tests/reconcileEscrow.test.js
@@ -414,19 +414,34 @@ describe('RECONCILABLE_STATUSES', () => {
 describe('readFundedAmount', () => {
   const { readFundedAmount } = require('../src/services/escrowRead');
 
-  it('uses the production base-state stub when no adapter is injected', async () => {
-    // 'funded_invoice' is the stub fixture that reports fundedAmount 1000.
+  it('reads from the projection table when no adapter is injected', async () => {
+    // Seed a projection row for 'funded_invoice' — the read path now resolves
+    // funded_invoice through the projection table instead of any hardcoded
+    // fixture, so the value comes straight from event data.
+    dbState.firstResult = {
+      invoice_id: 'funded_invoice',
+      latest_event_id: 'evt_live_1',
+      latest_event_type: 'funded',
+      latest_ledger_sequence: 9001,
+      latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 1000 }),
+    };
+
     await expect(readFundedAmount('funded_invoice')).resolves.toBe(1000);
-    // Unknown id -> stub returns 0.
+  });
+
+  it('returns the neutral 0 when neither projection nor adapter has data', async () => {
+    dbState.firstResult = null; // no projection row
     await expect(readFundedAmount('some_other_invoice')).resolves.toBe(0);
   });
 
   it('accepts a bare numeric adapter return', async () => {
+    // Adapter short-circuits: the projection lookup must not run.
+    dbState.firstResult = { latest_event_body: JSON.stringify({ fundedAmount: 9999 }) };
     const amount = await readFundedAmount('inv_1', { escrowAdapter: () => Promise.resolve(750) });
     expect(amount).toBe(750);
   });
 
-  it('falls back to 0 for a non-finite on-chain value', async () => {
+  it('falls back to 0 for a non-finite adapter value', async () => {
     const amount = await readFundedAmount('inv_1', {
       escrowAdapter: () => Promise.resolve({ fundedAmount: 'not-a-number' }),
     });


### PR DESCRIPTION
Description
The escrow read service in [`src/services/escrowRead.js`](https://www.drips.network/wave/contributors/issues/src/services/escrowRead.js) resolves on-chain state via readEscrowState()/getEscrowStateWithProjection() with an optional Redis cache and a projection-table fallback — but for the funded_invoice and settled_invoice cases it currently returns hardcoded stub values rather than reading the projection written by the indexer ([`src/jobs/escrowIndexer.js`](https://www.drips.network/wave/contributors/issues/src/jobs/escrowIndexer.js)). Investors and the reconcile job therefore see fixture state for those invoices. This issue replaces the stubs with real projection reads.

Requirements and context
Repository scope: Liquifact/Liquifact-backend only.
Read funded_invoice/settled_invoice state from the escrow_event_projection table via [`src/db/knex.js`](https://www.drips.network/wave/contributors/issues/src/db/knex.js) instead of returning hardcoded objects, keeping the existing cache → projection → RPC fallback ordering.
Preserve the invoice-id validation regex and the legal-hold / attestation fields in the returned shape.
Keep token-metadata enrichment best-effort (warn-and-continue) as today; never fail the whole read on a metadata miss.
Ensure cached/projected decimals are not used for on-chain principal math (per the documented rule).
Suggested execution
Fork the repo and create a branch
git checkout -b feature/escrow-read-12-projection-reads
Implement changes
Write code in: [`src/services/escrowRead.js`](https://www.drips.network/wave/contributors/issues/src/services/escrowRead.js).
Write comprehensive tests in: [`tests/escrow.read.test.js`](https://www.drips.network/wave/contributors/issues/tests/escrow.read.test.js) and [`tests/escrow.attestations.test.js`](https://www.drips.network/wave/contributors/issues/tests/escrow.attestations.test.js).
Add documentation: update [`docs/escrow-integration-overview.md`](https://www.drips.network/wave/contributors/issues/docs/escrow-integration-overview.md).
Add JSDoc on the projection-read path.
Validate security: no fabricated state; decimals not used for math.
Test and commit
Test and commit
Run npm test and npm run lint.
Cover edge cases: projection present, projection missing (fallback), cache hit, metadata miss, invalid invoice id.
Include the full npm test output and a short security-notes section in the PR description.
Example commit message
feat(escrow-read): serve funded/settled state from the projection table instead of stubs

Guidelines
Minimum 95 percent test coverage for impacted modules.
Clear, reviewer-focused documentation.
Timeframe: 96 hours.
Community & contribution rewards
💬 Join the Liquifact community on Discord for questions, reviews, and faster merges: [https://discord.gg/JrGPH4V3](https://www.drips.network/external/https%3A%2F%2Fdiscord.gg%2FJrGPH4V3)
⭐ This is a GrantFox OSS / Official Campaign task and may be rewarded. When your PR is merged you'll be prompted to rate the project — if this issue and the maintainers helped you ship, we'd be grateful for a 5-star rating. Clear questions in Discord and tidy, well-tested PRs are the fastest path to a merge and a reward.


closes #354 