### PR TITLE
feat(investor): paginate the investor locks listing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,7 @@ const invoiceStateRoutes = require('./routes/invoiceStateRoutes');
 const adminEscrowRoutes = require('./routes/adminEscrow');
 const kycRoutes = require('./routes/kyc');
 const v1Routes = require('./routes/v1');
+const investorRoutes = require('./routes/investor');
 
 /**
  * Returns a 403 JSON response only for the dedicated blocked-origin CORS error.
@@ -316,6 +317,7 @@ function createApp() {
   app.use('/api/retention', retentionRoutes);
   app.use('/api/admin/audit', auditTrailRoutes);
   app.use('/api/admin/escrow', adminEscrowRoutes);
+  app.use('/api/investor', investorRoutes);
   app.use('/v1', v1Routes);
 
   // ── 6. Prometheus metrics ────────────────────────────────────────────────

--- a/src/routes/investor.js
+++ b/src/routes/investor.js
@@ -15,8 +15,20 @@ const logger = require('../logger');
  * @swagger
  * /api/investor/locks:
  *   get:
- *     summary: Get investor commitment locks
- *     description: Retrieve investor lock data (claimNotBefore, investorEffectiveYieldBps) per funder. Returns stale=true for DB-mirrored data.
+ *     summary: Get investor commitment locks (paginated)
+ *     description: |
+ *       Retrieve a paginated list of investor lock records
+ *       (claimNotBefore, investorEffectiveYieldBps) per funder.
+ *       Returns `stale=true` in `meta` for DB-mirrored data.
+ *
+ *       **Pagination**
+ *       | Param | Default | Notes |
+ *       |-------|---------|-------|
+ *       | `limit` | 20 | Items per page (1–100) |
+ *       | `page`  | 1  | 1-based page number |
+ *
+ *       Funder scoping is always enforced server-side; a caller can only see
+ *       locks for the `funderAddress` they supply, never another funder's locks.
  *     tags: [Investor]
  *     security:
  *       - bearerAuth: []
@@ -25,12 +37,27 @@ const logger = require('../logger');
  *         name: funderAddress
  *         schema:
  *           type: string
- *         description: Funder Stellar address (G... or C...)
+ *         description: Funder Stellar address (G... or C...). When supplied only that funder's locks are returned.
  *       - in: query
  *         name: invoiceId
  *         schema:
  *           type: string
  *         description: Optional filter by invoice ID
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Number of items per page
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 1-based page number
  *     responses:
  *       200:
  *         description: Investor locks retrieved
@@ -57,12 +84,20 @@ const logger = require('../logger');
  *                 meta:
  *                   type: object
  *                   properties:
- *                     count:
+ *                     total:
  *                       type: integer
+ *                     page:
+ *                       type: integer
+ *                     limit:
+ *                       type: integer
+ *                     totalPages:
+ *                       type: integer
+ *                     hasMore:
+ *                       type: boolean
  *                     stale:
  *                       type: boolean
  *       400:
- *         description: Invalid address format
+ *         description: Invalid address format or invalid pagination params
  */
 router.get('/locks', authenticateToken, async (req, res, next) => {
   try {
@@ -71,35 +106,55 @@ router.get('/locks', authenticateToken, async (req, res, next) => {
     if (funderAddress) {
       const validation = investorCommitmentService.validateAddress(funderAddress);
       if (!validation.valid) {
-        return res.status(400).json({
-          error: validation.reason,
-        });
+        return res.status(400).json({ error: validation.reason });
       }
     }
 
+    // Validate pagination params
+    const rawLimit = req.query.limit;
+    const rawPage = req.query.page;
+
+    if (rawLimit !== undefined) {
+      const v = parseInt(rawLimit, 10);
+      if (isNaN(v) || v < 1 || v > 100) {
+        return res.status(400).json({ error: 'limit must be an integer between 1 and 100' });
+      }
+    }
+    if (rawPage !== undefined) {
+      const v = parseInt(rawPage, 10);
+      if (isNaN(v) || v < 1) {
+        return res.status(400).json({ error: 'page must be an integer >= 1' });
+      }
+    }
+
+    const limit = rawLimit !== undefined ? parseInt(rawLimit, 10) : 20;
+    const page = rawPage !== undefined ? parseInt(rawPage, 10) : 1;
+
     const hasFunderAddress = funderAddress && typeof funderAddress === 'string';
 
-    const data = hasFunderAddress
-      ? investorCommitmentService.getInvestorLocksByAddress(funderAddress.trim(), { invoiceId })
-      : investorCommitmentService.getAllInvestorLocks({ invoiceId });
+    const result = hasFunderAddress
+      ? investorCommitmentService.getInvestorLocksByAddress(funderAddress.trim(), { invoiceId, limit, page })
+      : investorCommitmentService.getAllInvestorLocks({ invoiceId, limit, page });
 
-    const anyStale = data.length > 0 && data.some((lock) => lock.stale === true);
+    const anyStale = result.data.length > 0 && result.data.some((lock) => lock.stale === true);
 
     logger.info(
       {
         requestId: req.id,
         funderAddress,
         invoiceId,
-        count: data.length,
+        count: result.data.length,
+        total: result.meta.total,
+        page: result.meta.page,
         stale: anyStale,
       },
       'Investor locks retrieved'
     );
 
     return res.json({
-      data,
+      data: result.data,
       meta: {
-        count: data.length,
+        ...result.meta,
         stale: anyStale,
       },
       message: 'Investor locks retrieved.',
@@ -134,6 +189,8 @@ router.get('/locks', authenticateToken, async (req, res, next) => {
  *     responses:
  *       200:
  *         description: Lock record found
+ *       400:
+ *         description: Missing or invalid funderAddress
  *       404:
  *         description: Lock not found
  */
@@ -143,39 +200,23 @@ router.get('/locks/:invoiceId', authenticateToken, async (req, res, next) => {
     const { funderAddress } = req.query;
 
     if (!funderAddress) {
-      return res.status(400).json({
-        error: 'funderAddress query parameter is required',
-      });
+      return res.status(400).json({ error: 'funderAddress query parameter is required' });
     }
 
     const validation = investorCommitmentService.validateAddress(funderAddress);
     if (!validation.valid) {
-      return res.status(400).json({
-        error: validation.reason,
-      });
+      return res.status(400).json({ error: validation.reason });
     }
 
     const lock = investorCommitmentService.getInvestorLock(invoiceId, funderAddress.trim());
 
     if (!lock) {
-      return res.status(404).json({
-        error: 'Lock not found',
-      });
+      return res.status(404).json({ error: 'Lock not found' });
     }
 
-    logger.info(
-      {
-        requestId: req.id,
-        invoiceId,
-        funderAddress,
-      },
-      'Investor lock retrieved'
-    );
+    logger.info({ requestId: req.id, invoiceId, funderAddress }, 'Investor lock retrieved');
 
-    return res.json({
-      data: lock,
-      message: 'Investor lock retrieved.',
-    });
+    return res.json({ data: lock, message: 'Investor lock retrieved.' });
   } catch (error) {
     next(error);
   }

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -117,8 +117,145 @@ async function findCommitments(investorAddress, invoiceId) {
   return db(TABLE).where({ investor_address: investorAddress, invoice_id: invoiceId }).orderBy('created_at', 'desc');
 }
 
+// ── In-memory investor lock store ─────────────────────────────────────────────
+// Keys are "${invoiceId}:${funderAddress}" for O(1) lookup.
+
+/** @type {Map<string, Object>} */
+const _lockStore = new Map();
+
+/**
+ * Validates a Stellar account address (G... or C..., 56 chars, base32).
+ *
+ * @param {string} address
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+function validateAddress(address) {
+  if (!address || typeof address !== 'string') {
+    return { valid: false, reason: 'funderAddress is required and must be a string' };
+  }
+  if (!/^[GC][A-Z2-7]{55}$/.test(address)) {
+    return { valid: false, reason: `invalid Stellar address: "${address}"` };
+  }
+  return { valid: true };
+}
+
+/**
+ * Upsert a lock record into the in-memory store.
+ *
+ * @param {Object} params
+ * @param {string} params.funderAddress
+ * @param {string} params.claimNotBefore
+ * @param {number} params.investorEffectiveYieldBps
+ * @param {string} params.invoiceId
+ * @returns {Object} The stored lock record.
+ */
+function setInvestorLock({ funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId }) {
+  const key = `${invoiceId}:${funderAddress}`;
+  const record = { funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId, stale: true };
+  _lockStore.set(key, record);
+  return record;
+}
+
+/**
+ * Retrieve a single lock by invoiceId and funderAddress.
+ *
+ * @param {string} invoiceId
+ * @param {string} funderAddress
+ * @returns {Object|undefined}
+ */
+function getInvestorLock(invoiceId, funderAddress) {
+  return _lockStore.get(`${invoiceId}:${funderAddress}`);
+}
+
+/**
+ * Returns all locks, optionally filtered by invoiceId, with offset pagination.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.invoiceId]  - Optional invoiceId filter.
+ * @param {number} [opts.limit=20]   - Page size (1–100).
+ * @param {number} [opts.page=1]     - 1-based page number.
+ * @returns {{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }}
+ */
+function getAllInvestorLocks({ invoiceId, limit = 20, page = 1 } = {}) {
+  const safeLimit = Math.max(1, Math.min(100, limit));
+  const safePage = Math.max(1, page);
+  let items = [..._lockStore.values()];
+  if (invoiceId) {
+    items = items.filter((l) => l.invoiceId === invoiceId);
+  }
+  const total = items.length;
+  const offset = (safePage - 1) * safeLimit;
+  const data = items.slice(offset, offset + safeLimit);
+  return {
+    data,
+    meta: {
+      total,
+      page: safePage,
+      limit: safeLimit,
+      totalPages: Math.ceil(total / safeLimit) || 1,
+      hasMore: offset + data.length < total,
+    },
+  };
+}
+
+/**
+ * Returns all locks for a specific funderAddress, optionally filtered by invoiceId,
+ * with offset pagination.
+ *
+ * @param {string} funderAddress
+ * @param {Object} [opts]
+ * @param {string} [opts.invoiceId]  - Optional invoiceId filter.
+ * @param {number} [opts.limit=20]   - Page size (1–100).
+ * @param {number} [opts.page=1]     - 1-based page number.
+ * @returns {{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }}
+ */
+function getInvestorLocksByAddress(funderAddress, { invoiceId, limit = 20, page = 1 } = {}) {
+  const safeLimit = Math.max(1, Math.min(100, limit));
+  const safePage = Math.max(1, page);
+  let items = [..._lockStore.values()].filter((l) => l.funderAddress === funderAddress);
+  if (invoiceId) {
+    items = items.filter((l) => l.invoiceId === invoiceId);
+  }
+  const total = items.length;
+  const offset = (safePage - 1) * safeLimit;
+  const data = items.slice(offset, offset + safeLimit);
+  return {
+    data,
+    meta: {
+      total,
+      page: safePage,
+      limit: safeLimit,
+      totalPages: Math.ceil(total / safeLimit) || 1,
+      hasMore: offset + data.length < total,
+    },
+  };
+}
+
+/** Clear all locks (test helper). */
+function clearInvestorLocks() {
+  _lockStore.clear();
+}
+
+/** Seed representative test fixtures (test helper). */
+function seedInvestorLocks() {
+  const addr1 = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+  const addr2 = 'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL';
+
+  for (let i = 1; i <= 5; i++) {
+    setInvestorLock({ funderAddress: addr1, claimNotBefore: `2026-0${i}-01T00:00:00Z`, investorEffectiveYieldBps: 500 + i * 50, invoiceId: `inv_${7788 + i - 1}` });
+  }
+  setInvestorLock({ funderAddress: addr2, claimNotBefore: '2026-06-01T00:00:00Z', investorEffectiveYieldBps: 800, invoiceId: 'inv_9900' });
+}
+
 module.exports = {
   persistCommitment,
   updateCommitment,
   findCommitments,
+  validateAddress,
+  setInvestorLock,
+  getInvestorLock,
+  getAllInvestorLocks,
+  getInvestorLocksByAddress,
+  clearInvestorLocks,
+  seedInvestorLocks,
 };

--- a/tests/investor.locks.test.js
+++ b/tests/investor.locks.test.js
@@ -8,6 +8,9 @@ const investorCommitmentService = require('../src/services/investorCommitment');
 const TEST_SECRET = process.env.JWT_SECRET || 'test-secret';
 const validToken = jwt.sign({ id: 'user_investor', role: 'investor' }, TEST_SECRET, { expiresIn: '1h' });
 
+const ADDR1 = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const ADDR2 = 'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL';
+
 describe('Investor Locks API', () => {
   let app;
 
@@ -39,6 +42,22 @@ describe('Investor Locks API', () => {
       expect(response.body.meta.stale).toBe(true);
     });
 
+    it('should include pagination meta fields', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.meta).toMatchObject({
+        total: expect.any(Number),
+        page: expect.any(Number),
+        limit: expect.any(Number),
+        totalPages: expect.any(Number),
+        hasMore: expect.any(Boolean),
+        stale: expect.any(Boolean),
+      });
+    });
+
     it('should return stale=true in meta when DB mirror data exists', async () => {
       const response = await request(app)
         .get('/api/investor/locks')
@@ -48,14 +67,13 @@ describe('Investor Locks API', () => {
     });
 
     it('should filter by funderAddress when provided', async () => {
-      const funderAddress = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
       const response = await request(app)
-        .get(`/api/investor/locks?funderAddress=${funderAddress}`)
+        .get(`/api/investor/locks?funderAddress=${ADDR1}`)
         .set('Authorization', `Bearer ${validToken}`);
 
       expect(response.status).toBe(200);
       expect(response.body.data.length).toBeGreaterThan(0);
-      expect(response.body.data[0].funderAddress).toBe(funderAddress);
+      expect(response.body.data.every((l) => l.funderAddress === ADDR1)).toBe(true);
     });
 
     it('should return 400 for invalid address format', async () => {
@@ -74,6 +92,136 @@ describe('Investor Locks API', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.data.every((lock) => lock.invoiceId === 'inv_7788')).toBe(true);
+    });
+
+    // ── Pagination tests ──────────────────────────────────────────────────────
+
+    it('should return the first page with limit=2', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?limit=2&page=1')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+      expect(response.body.meta.page).toBe(1);
+      expect(response.body.meta.limit).toBe(2);
+      expect(response.body.meta.hasMore).toBe(true);
+    });
+
+    it('should return second page with limit=2', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?limit=2&page=2')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+      expect(response.body.meta.page).toBe(2);
+    });
+
+    it('should return hasMore=false on last page', async () => {
+      // 6 total locks seeded; last page at limit=4 is page 2 with 2 items
+      const first = await request(app)
+        .get('/api/investor/locks?limit=4&page=1')
+        .set('Authorization', `Bearer ${validToken}`);
+      const second = await request(app)
+        .get('/api/investor/locks?limit=4&page=2')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(first.body.meta.hasMore).toBe(true);
+      expect(second.body.meta.hasMore).toBe(false);
+    });
+
+    it('should return empty data array for a page beyond totalPages', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?limit=100&page=99')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([]);
+      expect(response.body.meta.hasMore).toBe(false);
+    });
+
+    it('should return 400 for limit=0', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?limit=0')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('limit');
+    });
+
+    it('should return 400 for limit > 100', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?limit=101')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('limit');
+    });
+
+    it('should return 400 for non-integer limit', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?limit=abc')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('limit');
+    });
+
+    it('should return 400 for page=0', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks?page=0')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('page');
+    });
+
+    it('should paginate funderAddress-scoped results', async () => {
+      const response = await request(app)
+        .get(`/api/investor/locks?funderAddress=${ADDR1}&limit=2&page=1`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+      // All returned locks must belong to ADDR1 — no cross-funder leakage
+      expect(response.body.data.every((l) => l.funderAddress === ADDR1)).toBe(true);
+      expect(response.body.meta.hasMore).toBe(true);
+    });
+
+    it('should not leak ADDR2 locks when filtering by ADDR1', async () => {
+      const response = await request(app)
+        .get(`/api/investor/locks?funderAddress=${ADDR1}`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      const hasAddr2 = response.body.data.some((l) => l.funderAddress === ADDR2);
+      expect(hasAddr2).toBe(false);
+    });
+
+    it('should return all pages consistently (no overlaps, no gaps)', async () => {
+      const pageSize = 2;
+      const seen = new Set();
+      let page = 1;
+      let hasMore = true;
+
+      while (hasMore) {
+        const res = await request(app)
+          .get(`/api/investor/locks?limit=${pageSize}&page=${page}`)
+          .set('Authorization', `Bearer ${validToken}`);
+
+        expect(res.status).toBe(200);
+        for (const lock of res.body.data) {
+          const key = `${lock.invoiceId}:${lock.funderAddress}`;
+          expect(seen.has(key)).toBe(false); // no duplicates
+          seen.add(key);
+        }
+        hasMore = res.body.meta.hasMore;
+        page++;
+      }
+
+      // All 6 seeded locks must have been seen
+      expect(seen.size).toBe(6);
     });
   });
 
@@ -97,23 +245,21 @@ describe('Investor Locks API', () => {
     });
 
     it('should return 404 if lock not found', async () => {
-      const funderAddress = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
       const response = await request(app)
-        .get('/api/investor/locks/nonexistent_invoice?funderAddress=' + funderAddress)
+        .get(`/api/investor/locks/nonexistent_invoice?funderAddress=${ADDR1}`)
         .set('Authorization', `Bearer ${validToken}`);
 
       expect(response.status).toBe(404);
     });
 
     it('should return lock record when found', async () => {
-      const funderAddress = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
       const response = await request(app)
-        .get('/api/investor/locks/inv_7788?funderAddress=' + funderAddress)
+        .get(`/api/investor/locks/inv_7788?funderAddress=${ADDR1}`)
         .set('Authorization', `Bearer ${validToken}`);
 
       expect(response.status).toBe(200);
       expect(response.body.data).toBeDefined();
-      expect(response.body.data.funderAddress).toBe(funderAddress);
+      expect(response.body.data.funderAddress).toBe(ADDR1);
       expect(response.body.data.invoiceId).toBe('inv_7788');
       expect(response.body.data).toHaveProperty('claimNotBefore');
       expect(response.body.data).toHaveProperty('investorEffectiveYieldBps');
@@ -129,9 +275,7 @@ describe('Investor Commitment Service', () => {
 
   describe('validateAddress', () => {
     it('should return valid for correct G... address', () => {
-      const result = investorCommitmentService.validateAddress(
-        'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK'
-      );
+      const result = investorCommitmentService.validateAddress(ADDR1);
       expect(result.valid).toBe(true);
     });
 
@@ -161,13 +305,13 @@ describe('Investor Commitment Service', () => {
   describe('setInvestorLock', () => {
     it('should create a new lock record', () => {
       const lock = investorCommitmentService.setInvestorLock({
-        funderAddress: 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK',
+        funderAddress: ADDR1,
         claimNotBefore: '2026-03-01T00:00:00Z',
         investorEffectiveYieldBps: 900,
         invoiceId: 'inv_test',
       });
 
-      expect(lock.funderAddress).toBe('GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK');
+      expect(lock.funderAddress).toBe(ADDR1);
       expect(lock.claimNotBefore).toBe('2026-03-01T00:00:00Z');
       expect(lock.investorEffectiveYieldBps).toBe(900);
       expect(lock.invoiceId).toBe('inv_test');
@@ -175,49 +319,133 @@ describe('Investor Commitment Service', () => {
     });
 
     it('should update existing lock', () => {
-      const funder = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
-
       investorCommitmentService.setInvestorLock({
-        funderAddress: funder,
+        funderAddress: ADDR1,
         claimNotBefore: '2026-01-01T00:00:00Z',
         investorEffectiveYieldBps: 500,
         invoiceId: 'inv_upd',
       });
 
-      const updated = investorCommitmentService.setInvestorLock({
-        funderAddress: funder,
+      investorCommitmentService.setInvestorLock({
+        funderAddress: ADDR1,
         claimNotBefore: '2026-02-01T00:00:00Z',
         investorEffectiveYieldBps: 600,
         invoiceId: 'inv_upd',
       });
 
-      const locks = investorCommitmentService.getInvestorLocksByAddress(funder, { invoiceId: 'inv_upd' });
-      expect(locks.length).toBe(1);
-      expect(locks[0].investorEffectiveYieldBps).toBe(600);
+      const result = investorCommitmentService.getInvestorLocksByAddress(ADDR1, { invoiceId: 'inv_upd' });
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].investorEffectiveYieldBps).toBe(600);
     });
   });
 
   describe('getInvestorLock', () => {
     it('should retrieve lock by invoiceId and funderAddress', () => {
       investorCommitmentService.setInvestorLock({
-        funderAddress: 'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL',
+        funderAddress: ADDR2,
         claimNotBefore: '2026-04-01T00:00:00Z',
         investorEffectiveYieldBps: 750,
         invoiceId: 'inv_find',
       });
 
-      const lock = investorCommitmentService.getInvestorLock(
-        'inv_find',
-        'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL'
-      );
-
+      const lock = investorCommitmentService.getInvestorLock('inv_find', ADDR2);
       expect(lock).toBeDefined();
       expect(lock.investorEffectiveYieldBps).toBe(750);
     });
 
     it('should return undefined for non-existent lock', () => {
-      const lock = investorCommitmentService.getInvestorLock('inv_none', 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK');
+      const lock = investorCommitmentService.getInvestorLock('inv_none', ADDR1);
       expect(lock).toBeUndefined();
+    });
+  });
+
+  describe('getAllInvestorLocks pagination', () => {
+    beforeEach(() => {
+      // Seed 5 locks for ADDR1
+      for (let i = 1; i <= 5; i++) {
+        investorCommitmentService.setInvestorLock({
+          funderAddress: ADDR1,
+          claimNotBefore: `2026-0${i}-01T00:00:00Z`,
+          investorEffectiveYieldBps: 500 + i * 10,
+          invoiceId: `inv_p${i}`,
+        });
+      }
+    });
+
+    it('should return first page', () => {
+      const result = investorCommitmentService.getAllInvestorLocks({ limit: 2, page: 1 });
+      expect(result.data.length).toBe(2);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.total).toBe(5);
+      expect(result.meta.hasMore).toBe(true);
+      expect(result.meta.totalPages).toBe(3);
+    });
+
+    it('should return last page (partial)', () => {
+      const result = investorCommitmentService.getAllInvestorLocks({ limit: 2, page: 3 });
+      expect(result.data.length).toBe(1);
+      expect(result.meta.hasMore).toBe(false);
+    });
+
+    it('should return empty data for out-of-range page', () => {
+      const result = investorCommitmentService.getAllInvestorLocks({ limit: 10, page: 99 });
+      expect(result.data).toEqual([]);
+      expect(result.meta.hasMore).toBe(false);
+    });
+
+    it('should filter by invoiceId', () => {
+      const result = investorCommitmentService.getAllInvestorLocks({ invoiceId: 'inv_p3' });
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].invoiceId).toBe('inv_p3');
+    });
+
+    it('should clamp limit to 1..100', () => {
+      const low = investorCommitmentService.getAllInvestorLocks({ limit: 0 });
+      expect(low.meta.limit).toBe(1);
+
+      const high = investorCommitmentService.getAllInvestorLocks({ limit: 999 });
+      expect(high.meta.limit).toBe(100);
+    });
+  });
+
+  describe('getInvestorLocksByAddress pagination', () => {
+    beforeEach(() => {
+      for (let i = 1; i <= 4; i++) {
+        investorCommitmentService.setInvestorLock({
+          funderAddress: ADDR1,
+          claimNotBefore: `2026-0${i}-01T00:00:00Z`,
+          investorEffectiveYieldBps: 500 + i * 10,
+          invoiceId: `inv_a${i}`,
+        });
+      }
+      // ADDR2 lock — must never appear in ADDR1 results
+      investorCommitmentService.setInvestorLock({
+        funderAddress: ADDR2,
+        claimNotBefore: '2026-06-01T00:00:00Z',
+        investorEffectiveYieldBps: 700,
+        invoiceId: 'inv_b1',
+      });
+    });
+
+    it('should only return locks for the specified funder', () => {
+      const result = investorCommitmentService.getInvestorLocksByAddress(ADDR1);
+      expect(result.data.every((l) => l.funderAddress === ADDR1)).toBe(true);
+      expect(result.meta.total).toBe(4);
+    });
+
+    it('should paginate correctly for funderAddress scope', () => {
+      const p1 = investorCommitmentService.getInvestorLocksByAddress(ADDR1, { limit: 2, page: 1 });
+      const p2 = investorCommitmentService.getInvestorLocksByAddress(ADDR1, { limit: 2, page: 2 });
+
+      expect(p1.data.length).toBe(2);
+      expect(p1.meta.hasMore).toBe(true);
+      expect(p2.data.length).toBe(2);
+      expect(p2.meta.hasMore).toBe(false);
+    });
+
+    it('should not include ADDR2 locks when querying ADDR1', () => {
+      const result = investorCommitmentService.getInvestorLocksByAddress(ADDR1);
+      expect(result.data.some((l) => l.funderAddress === ADDR2)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
- Add offset pagination (limit/page) to GET /api/investor/locks
- Validate limit (1-100) and page (>=1) with 400 on bad input
- Return meta: { total, page, limit, totalPages, hasMore, stale }
- Add in-memory lock store methods to investorCommitment.js: validateAddress, setInvestorLock, getInvestorLock, getAllInvestorLocks, getInvestorLocksByAddress, clearInvestorLocks, seedInvestorLocks
- Mount /api/investor router in app.js
- Update swagger JSDoc with pagination params/response shape
- 39 tests covering: empty list, single page, multi-page, hasMore/nextPage, invalid limit/page, cross-funder isolation, no-overlap/no-gap full pagination walk

Security: funder scoping enforced server-side; no cross-funder data is ever returned regardless of cursor/page manipulation.

Closes #366