### PR TITLE
Feature/kyc persistence and validation

### DIFF
--- a/docs/RFC7807-Error-Handling.md
+++ b/docs/RFC7807-Error-Handling.md
@@ -94,7 +94,7 @@ The following problem types are defined:
 
 ## API Examples
 
-### 1. Validation Error
+### 1. Validation Error (Request Body)
 
 **Request:**
 
@@ -112,11 +112,44 @@ HTTP/1.1 400 Bad Request
 Content-Type: application/problem+json
 
 {
-  "type": "https://liquifact.com/probs/validation-error",
+  "type": "https://liquifact.io/problems/validation-error",
   "title": "Validation Error",
   "status": 400,
-  "detail": "Amount and customer are required fields",
-  "instance": "/api/invoices"
+  "detail": "Request body contains invalid or missing fields.",
+  "fieldErrors": {
+    "amount": "amount is required",
+    "seller": "seller is required",
+    "currency": "currency is required",
+    "dueDate": "dueDate is required",
+    "buyer": "buyer is required"
+  }
+}
+```
+
+### 1b. Validation Error (Query Parameters)
+
+**Request:**
+
+```bash
+curl -X GET "http://localhost:3001/api/marketplace?yieldBpsMin=-100&status=invalid" \
+  -H "Authorization: Bearer your-token"
+```
+
+**Response:**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "https://liquifact.io/problems/validation-error",
+  "title": "Validation Error",
+  "status": 400,
+  "detail": "Query parameters contain invalid values.",
+  "fieldErrors": {
+    "yieldBpsMin": "yieldBpsMin must be a non-negative integer",
+    "status": "Invalid status. Must be one of: pending_verification, verified, funded, partially_funded, completed, defaulted"
+  }
 }
 ```
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -30,25 +30,16 @@ Invoice
 
 ### Database Schema
 
-A migration has been added to PostgreSQL:
+A migration has been added to create the `kyc_records` table:
 
 **File**: `src/db/migrations/20260425_add_kyc_status.js`
 
 **Changes**:
-- Adds `kycStatus` enum column (default: 'pending')
-- Adds `kycStatusUpdatedAt` timestamp
-- Adds `kycRecordId` foreign key reference
-- Adds indexes for filtering performance
+- Creates `kyc_records` table to store KYC status records keyed by `sme_id`.
+- Columns: `sme_id` (Primary Key), `status` (pending/verified/rejected/exempted), `provider_record_id`, `verified_at`, `updated_at`.
+- All mock verification functions (`verifySmeSafe`, `rejectSmeKyc`, `exemptSmeFromKyc`) and external provider lookups persist status updates directly to this table. This ensures KYC state survives process restarts and is shared across replicas.
 
-```sql
-ALTER TABLE invoices ADD COLUMN kycStatus kyc_status_enum DEFAULT 'pending' NOT NULL;
-ALTER TABLE invoices ADD COLUMN kycStatusUpdatedAt TIMESTAMP DEFAULT NOW();
-ALTER TABLE invoices ADD COLUMN kycRecordId VARCHAR(128);
-CREATE INDEX idx_kyc_status ON invoices(kycStatus);
-CREATE INDEX idx_kyc_status_date ON invoices(kycStatus, createdAt);
-```
-
-Run migration:
+Run migrations:
 ```bash
 npm run db:migrate
 ```

--- a/src/app.js
+++ b/src/app.js
@@ -217,9 +217,15 @@ function createApp() {
 
   // Invoices — GET (list)
   app.get('/api/invoices', async (req, res) => {
-    const { isValid, errors, validatedParams } = validateInvoiceQueryParams(req.query);
+    const { isValid, fieldErrors, validatedParams } = validateInvoiceQueryParams(req.query);
     if (!isValid) {
-      return res.status(400).json({ errors });
+      return res.status(400).json({
+        type: 'https://liquifact.io/problems/validation-error',
+        title: 'Validation Error',
+        status: 400,
+        detail: 'Query parameters contain invalid values.',
+        fieldErrors,
+      });
     }
     const invoices = await invoiceService.getInvoices(validatedParams);
     res.json({

--- a/src/routes/marketplace.js
+++ b/src/routes/marketplace.js
@@ -169,10 +169,16 @@ router.use(...authenticatedTenantStack);
  */
 router.get('/', async (req, res, next) => {
   try {
-    const { isValid, errors, validatedParams } = validateMarketplaceQueryParams(req.query);
+    const { isValid, fieldErrors, validatedParams } = validateMarketplaceQueryParams(req.query);
 
     if (!isValid) {
-      return res.status(400).json({ errors });
+      return res.status(400).json({
+        type: 'https://liquifact.io/problems/validation-error',
+        title: 'Validation Error',
+        status: 400,
+        detail: 'Query parameters contain invalid values.',
+        fieldErrors,
+      });
     }
 
     // Enforce explicit visibility rules; never allow clients to enumerate
@@ -183,9 +189,13 @@ router.get('/', async (req, res, next) => {
       !marketplaceService.PUBLIC_INVESTABLE_INVOICE_STATUSES.includes(validatedParams.filters.status)
     ) {
       return res.status(400).json({
-        errors: [
-          `Invalid status for marketplace. Must be one of: ${marketplaceService.PUBLIC_INVESTABLE_INVOICE_STATUSES.join(', ')}`,
-        ],
+        type: 'https://liquifact.io/problems/validation-error',
+        title: 'Validation Error',
+        status: 400,
+        detail: 'Query parameters contain invalid values.',
+        fieldErrors: {
+          status: `Invalid status for marketplace. Must be one of: ${marketplaceService.PUBLIC_INVESTABLE_INVOICE_STATUSES.join(', ')}`,
+        },
       });
     }
 
@@ -198,7 +208,15 @@ router.get('/', async (req, res, next) => {
     } catch (err) {
       // CursorError is a client error (malformed/tampered cursor) → 400
       if (err instanceof CursorError) {
-        return res.status(400).json({ errors: [err.message] });
+        return res.status(400).json({
+          type: 'https://liquifact.io/problems/validation-error',
+          title: 'Validation Error',
+          status: 400,
+          detail: 'Query parameters contain invalid values.',
+          fieldErrors: {
+            cursor: err.message,
+          },
+        });
       }
       throw err;
     }

--- a/src/services/kycService.js
+++ b/src/services/kycService.js
@@ -87,7 +87,7 @@ async function readKycRecord(smeId) {
   }
 
   const row = await db('kyc_records').where({ sme_id: smeId }).first();
-  if (!row) {
+  if (!row || !row.status) {
     return null;
   }
 
@@ -269,15 +269,24 @@ async function verifySmeSafe(smeId, options = {}) {
   }
 
   const recordId = options.recordId || `kyc_${smeId}_${Date.now()}`;
+  const verifiedAt = new Date().toISOString();
   const record = {
     smeId,
     status: KYC_STATUSES.VERIFIED,
     recordId,
-    verifiedAt: new Date().toISOString(),
-    createdAt: new Date().toISOString(),
+    verifiedAt,
+    createdAt: verifiedAt,
   };
 
   mockKycRecords.set(smeId, record);
+
+  // Persist to database
+  await persistKycRecord({
+    smeId,
+    status: KYC_STATUSES.VERIFIED,
+    providerRecordId: recordId,
+    verifiedAt,
+  });
 
   logger.info({ smeId, recordId }, 'SME marked as KYC verified');
 
@@ -312,6 +321,13 @@ async function rejectSmeKyc(smeId, reason = 'Manual rejection') {
 
   mockKycRecords.set(smeId, record);
 
+  // Persist to database
+  await persistKycRecord({
+    smeId,
+    status: KYC_STATUSES.REJECTED,
+    providerRecordId: recordId,
+  });
+
   logger.warn({ smeId, recordId, reason }, 'SME KYC rejected');
 
   return {
@@ -344,6 +360,13 @@ async function exemptSmeFromKyc(smeId, reason = 'Manual exemption') {
   };
 
   mockKycRecords.set(smeId, record);
+
+  // Persist to database
+  await persistKycRecord({
+    smeId,
+    status: KYC_STATUSES.EXEMPTED,
+    providerRecordId: recordId,
+  });
 
   logger.info({ smeId, recordId, reason }, 'SME exempted from KYC');
 

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -29,10 +29,10 @@ const VALID_CURRENCIES = new Set(SUPPORTED_CURRENCIES);
  * Validates `GET /api/invoices` query parameters.
  *
  * @param {Object} query - The Express `req.query` object.
- * @returns {{ isValid: boolean, errors: string[], validatedParams: Object }}
+ * @returns {{ isValid: boolean, fieldErrors: Object.<string, string>, validatedParams: Object }}
  */
 function validateInvoiceQueryParams(query) {
-  const errors = [];
+  const fieldErrors = {};
   const validatedParams = { filters: {}, sorting: {} };
 
   const { status, smeId, buyerId, dateFrom, dateTo, sortBy, order } = query;
@@ -42,7 +42,7 @@ function validateInvoiceQueryParams(query) {
     if (validStatuses.includes(status)) {
       validatedParams.filters.status = status;
     } else {
-      errors.push(`Invalid status. Must be one of: ${validStatuses.join(', ')}`);
+      fieldErrors.status = `Invalid status. Must be one of: ${validStatuses.join(', ')}`;
     }
   }
 
@@ -50,7 +50,7 @@ function validateInvoiceQueryParams(query) {
     if (typeof smeId === 'string' && smeId.trim().length > 0) {
       validatedParams.filters.smeId = smeId;
     } else {
-      errors.push('Invalid smeId format');
+      fieldErrors.smeId = 'Invalid smeId format';
     }
   }
 
@@ -58,7 +58,7 @@ function validateInvoiceQueryParams(query) {
     if (typeof buyerId === 'string' && buyerId.trim().length > 0) {
       validatedParams.filters.buyerId = buyerId;
     } else {
-      errors.push('Invalid buyerId format');
+      fieldErrors.buyerId = 'Invalid buyerId format';
     }
   }
 
@@ -67,7 +67,7 @@ function validateInvoiceQueryParams(query) {
     if (dateRegex.test(dateFrom) && !isNaN(Date.parse(dateFrom))) {
       validatedParams.filters.dateFrom = dateFrom;
     } else {
-      errors.push('Invalid dateFrom format. Use YYYY-MM-DD');
+      fieldErrors.dateFrom = 'Invalid dateFrom format. Use YYYY-MM-DD';
     }
   }
 
@@ -75,7 +75,7 @@ function validateInvoiceQueryParams(query) {
     if (dateRegex.test(dateTo) && !isNaN(Date.parse(dateTo))) {
       validatedParams.filters.dateTo = dateTo;
     } else {
-      errors.push('Invalid dateTo format. Use YYYY-MM-DD');
+      fieldErrors.dateTo = 'Invalid dateTo format. Use YYYY-MM-DD';
     }
   }
 
@@ -84,7 +84,7 @@ function validateInvoiceQueryParams(query) {
     if (validSortFields.includes(sortBy)) {
       validatedParams.sorting.sortBy = sortBy;
     } else {
-      errors.push(`Invalid sortBy. Must be one of: ${validSortFields.join(', ')}`);
+      fieldErrors.sortBy = `Invalid sortBy. Must be one of: ${validSortFields.join(', ')}`;
     }
   }
 
@@ -93,11 +93,11 @@ function validateInvoiceQueryParams(query) {
     if (['asc', 'desc'].includes(lowerOrder)) {
       validatedParams.sorting.order = lowerOrder;
     } else {
-      errors.push('Invalid order. Must be "asc" or "desc"');
+      fieldErrors.order = 'Invalid order. Must be "asc" or "desc"';
     }
   }
 
-  return { isValid: errors.length === 0, errors, validatedParams };
+  return { isValid: Object.keys(fieldErrors).length === 0, fieldErrors, validatedParams };
 }
 
 // ── Marketplace query-param validator ────────────────────────────────────────
@@ -115,10 +115,10 @@ function validateInvoiceQueryParams(query) {
  * from the route layer.
  *
  * @param {Object} query - The Express query object.
- * @returns {{ isValid: boolean, errors: string[], validatedParams: Object }}
+ * @returns {{ isValid: boolean, fieldErrors: Object.<string, string>, validatedParams: Object }}
  */
 function validateMarketplaceQueryParams(query) {
-  const errors = [];
+  const fieldErrors = {};
   const validatedParams = { filters: {}, sorting: {}, pagination: {} };
 
   const {
@@ -141,19 +141,19 @@ function validateMarketplaceQueryParams(query) {
     if (validStatuses.includes(status)) {
       validatedParams.filters.status = status;
     } else {
-      errors.push(`Invalid status. Must be one of: ${validStatuses.join(', ')}`);
+      fieldErrors.status = `Invalid status. Must be one of: ${validStatuses.join(', ')}`;
     }
   }
 
   if (yieldBpsMin !== undefined) {
     const val = parseInt(yieldBpsMin, 10);
     if (!isNaN(val) && val >= 0) { validatedParams.filters.yieldBpsMin = val; }
-    else { errors.push('yieldBpsMin must be a non-negative integer'); }
+    else { fieldErrors.yieldBpsMin = 'yieldBpsMin must be a non-negative integer'; }
   }
   if (yieldBpsMax !== undefined) {
     const val = parseInt(yieldBpsMax, 10);
     if (!isNaN(val) && val >= 0) { validatedParams.filters.yieldBpsMax = val; }
-    else { errors.push('yieldBpsMax must be a non-negative integer'); }
+    else { fieldErrors.yieldBpsMax = 'yieldBpsMax must be a non-negative integer'; }
   }
 
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
@@ -161,38 +161,38 @@ function validateMarketplaceQueryParams(query) {
     if (dateRegex.test(maturityDateFrom) && !isNaN(Date.parse(maturityDateFrom))) {
       validatedParams.filters.maturityDateFrom = maturityDateFrom;
     } else {
-      errors.push('Invalid maturityDateFrom format. Use YYYY-MM-DD');
+      fieldErrors.maturityDateFrom = 'Invalid maturityDateFrom format. Use YYYY-MM-DD';
     }
   }
   if (maturityDateTo !== undefined) {
     if (dateRegex.test(maturityDateTo) && !isNaN(Date.parse(maturityDateTo))) {
       validatedParams.filters.maturityDateTo = maturityDateTo;
     } else {
-      errors.push('Invalid maturityDateTo format. Use YYYY-MM-DD');
+      fieldErrors.maturityDateTo = 'Invalid maturityDateTo format. Use YYYY-MM-DD';
     }
   }
 
   if (fundedRatioMin !== undefined) {
     const val = parseFloat(fundedRatioMin);
     if (!isNaN(val) && val >= 0 && val <= 100) { validatedParams.filters.fundedRatioMin = val; }
-    else { errors.push('fundedRatioMin must be a number between 0 and 100'); }
+    else { fieldErrors.fundedRatioMin = 'fundedRatioMin must be a number between 0 and 100'; }
   }
   if (fundedRatioMax !== undefined) {
     const val = parseFloat(fundedRatioMax);
     if (!isNaN(val) && val >= 0 && val <= 100) { validatedParams.filters.fundedRatioMax = val; }
-    else { errors.push('fundedRatioMax must be a number between 0 and 100'); }
+    else { fieldErrors.fundedRatioMax = 'fundedRatioMax must be a number between 0 and 100'; }
   }
 
   if (sortBy !== undefined) {
     const validSortFields = ['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at'];
     if (validSortFields.includes(sortBy)) { validatedParams.sorting.sortBy = sortBy; }
-    else { errors.push(`Invalid sortBy. Must be one of: ${validSortFields.join(', ')}`); }
+    else { fieldErrors.sortBy = `Invalid sortBy. Must be one of: ${validSortFields.join(', ')}`; }
   }
 
   if (order !== undefined) {
     const lowerOrder = order.toLowerCase();
     if (['asc', 'desc'].includes(lowerOrder)) { validatedParams.sorting.order = lowerOrder; }
-    else { errors.push('Invalid order. Must be "asc" or "desc"'); }
+    else { fieldErrors.order = 'Invalid order. Must be "asc" or "desc"'; }
   }
 
   // Validate cursor (opaque base64url.signature string)
@@ -200,7 +200,7 @@ function validateMarketplaceQueryParams(query) {
     if (typeof cursor === 'string' && cursor.length > 0 && cursor.length <= 2048) {
       validatedParams.pagination.cursor = cursor;
     } else {
-      errors.push('cursor must be a non-empty string (max 2048 chars)');
+      fieldErrors.cursor = 'cursor must be a non-empty string (max 2048 chars)';
     }
   }
 
@@ -210,16 +210,16 @@ function validateMarketplaceQueryParams(query) {
     if (!isNaN(val) && val >= 1) {
       validatedParams.pagination.page = val;
     } else {
-      errors.push('page must be an integer >= 1');
+      fieldErrors.page = 'page must be an integer >= 1';
     }
   }
   if (limit !== undefined) {
     const val = parseInt(limit, 10);
     if (!isNaN(val) && val >= 1 && val <= 100) { validatedParams.pagination.limit = val; }
-    else { errors.push('limit must be an integer between 1 and 100'); }
+    else { fieldErrors.limit = 'limit must be an integer between 1 and 100'; }
   }
 
-  return { isValid: errors.length === 0, errors, validatedParams };
+  return { isValid: Object.keys(fieldErrors).length === 0, fieldErrors, validatedParams };
 }
 
 // ── Exports ───────────────────────────────────────────────────────────────────

--- a/tests/kycService.persistence.test.js
+++ b/tests/kycService.persistence.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/**
+ * KYC Service Persistence Tests
+ * 
+ * Verifies that KYC statuses are correctly saved to and retrieved from the database,
+ * ensuring they survive service restarts and are idempotent.
+ */
+
+const knex = jest.requireActual('knex');
+const knexConfig = require('../knexfile').test;
+const realDb = knex(knexConfig);
+
+const mockDb = require('../src/db/knex');
+const kycService = require('../src/services/kycService');
+const migration = require('../src/db/migrations/20260425_add_kyc_status');
+
+describe('KYC Service Database Persistence', () => {
+  let originalMockImpl;
+
+  beforeAll(async () => {
+    // Save original mock implementation
+    originalMockImpl = mockDb.getMockImplementation();
+
+    // Delegate mock Knex calls to the real Knex instance
+    mockDb.mockImplementation((table) => realDb(table));
+    mockDb.raw = realDb.raw;
+    mockDb.schema = realDb.schema;
+    mockDb.migrate = realDb.migrate;
+
+    // Run the KYC status table migration on the real DB
+    await migration.up(realDb);
+  });
+
+  afterAll(async () => {
+    // Restore the original mock implementation for other tests
+    mockDb.mockImplementation(originalMockImpl);
+    
+    // Close the real database connection
+    await realDb.destroy();
+  });
+
+  beforeEach(async () => {
+    // Clean database records and reset mock state before each test
+    await realDb('kyc_records').del();
+    kycService.resetMockRecords();
+  });
+
+  it('should return pending status for an unknown SME', async () => {
+    const result = await kycService.getKycStatus('unknown_sme');
+    expect(result.status).toBe(kycService.KYC_STATUSES.PENDING);
+  });
+
+  it('should persist verification status to the database', async () => {
+    const smeId = 'sme_persist_01';
+    const verifyResult = await kycService.verifySmeSafe(smeId);
+    expect(verifyResult.status).toBe(kycService.KYC_STATUSES.VERIFIED);
+
+    // Verify it is in the database
+    const dbRecord = await realDb('kyc_records').where({ sme_id: smeId }).first();
+    expect(dbRecord).toBeDefined();
+    expect(dbRecord.status).toBe(kycService.KYC_STATUSES.VERIFIED);
+    expect(dbRecord.provider_record_id).toBe(verifyResult.recordId);
+  });
+
+  it('should survive a restart (clearing mock store does not lose KYC status)', async () => {
+    const smeId = 'sme_restart_01';
+    
+    // 1. Verify SME (marks in DB and mock store)
+    await kycService.verifySmeSafe(smeId);
+    
+    // 2. Clear mock in-memory store to simulate process restart
+    kycService.resetMockRecords();
+    
+    // 3. Status should still be retrieved from DB
+    const result = await kycService.getKycStatus(smeId);
+    expect(result.status).toBe(kycService.KYC_STATUSES.VERIFIED);
+    expect(result.recordId).toBeDefined();
+  });
+
+  it('should persist reject status to the database', async () => {
+    const smeId = 'sme_reject_01';
+    const rejectResult = await kycService.rejectSmeKyc(smeId, 'High-risk business');
+    expect(rejectResult.status).toBe(kycService.KYC_STATUSES.REJECTED);
+
+    // Verify it is in the database
+    const dbRecord = await realDb('kyc_records').where({ sme_id: smeId }).first();
+    expect(dbRecord).toBeDefined();
+    expect(dbRecord.status).toBe(kycService.KYC_STATUSES.REJECTED);
+
+    // Verify subsequent lookup gets rejection
+    kycService.resetMockRecords();
+    const lookup = await kycService.getKycStatus(smeId);
+    expect(lookup.status).toBe(kycService.KYC_STATUSES.REJECTED);
+  });
+
+  it('should persist exemption status to the database', async () => {
+    const smeId = 'sme_exempt_01';
+    const exemptResult = await kycService.exemptSmeFromKyc(smeId, 'Government entity');
+    expect(exemptResult.status).toBe(kycService.KYC_STATUSES.EXEMPTED);
+
+    // Verify it is in the database
+    const dbRecord = await realDb('kyc_records').where({ sme_id: smeId }).first();
+    expect(dbRecord).toBeDefined();
+    expect(dbRecord.status).toBe(kycService.KYC_STATUSES.EXEMPTED);
+
+    // Verify subsequent lookup gets exemption
+    kycService.resetMockRecords();
+    const lookup = await kycService.getKycStatus(smeId);
+    expect(lookup.status).toBe(kycService.KYC_STATUSES.EXEMPTED);
+  });
+
+  it('should be idempotent (re-verifying a verified SME is safe and updates the record)', async () => {
+    const smeId = 'sme_idempotent_01';
+    
+    // First verification
+    const res1 = await kycService.verifySmeSafe(smeId);
+    const dbRecord1 = await realDb('kyc_records').where({ sme_id: smeId }).first();
+    
+    // Second verification
+    const res2 = await kycService.verifySmeSafe(smeId);
+    const dbRecord2 = await realDb('kyc_records').where({ sme_id: smeId }).first();
+
+    expect(res1.status).toBe(kycService.KYC_STATUSES.VERIFIED);
+    expect(res2.status).toBe(kycService.KYC_STATUSES.VERIFIED);
+    
+    // Verify records got updated/saved without throwing duplicate key errors
+    expect(dbRecord2.sme_id).toBe(dbRecord1.sme_id);
+    expect(dbRecord2.status).toBe(dbRecord1.status);
+  });
+});

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -191,7 +191,8 @@ describe('Marketplace API', () => {
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(res.status).toBe(400);
-      expect(res.body.errors).toBeDefined();
+      expect(res.body.fieldErrors).toBeDefined();
+      expect(res.body.fieldErrors.status).toBeDefined();
     });
   });
 
@@ -323,8 +324,8 @@ describe('Marketplace API', () => {
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(res.status).toBe(400);
-      expect(res.body.errors).toBeDefined();
-      expect(res.body.errors.length).toBeGreaterThan(0);
+      expect(res.body.fieldErrors).toBeDefined();
+      expect(res.body.fieldErrors.cursor).toBeDefined();
     });
 
     it('returns 400 for a base64-valid but tampered cursor', async () => {
@@ -337,7 +338,7 @@ describe('Marketplace API', () => {
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(res.status).toBe(400);
-      expect(res.body.errors[0]).toMatch(/signature/i);
+      expect(res.body.fieldErrors.cursor).toMatch(/signature/i);
     });
 
     it('returns 400 when cursor sort field does not match requested sortBy', async () => {
@@ -349,7 +350,7 @@ describe('Marketplace API', () => {
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(res.status).toBe(400);
-      expect(res.body.errors[0]).toMatch(/sort field/i);
+      expect(res.body.fieldErrors.cursor).toMatch(/sort field/i);
     });
 
     it('data length equals limit when hasMore=true', async () => {
@@ -376,8 +377,8 @@ describe('Marketplace API', () => {
         .set('Authorization', `Bearer ${tokenA}`);
 
       expect(res.status).toBe(400);
-      expect(res.body.errors).toBeDefined();
-      expect(res.body.errors.length).toBeGreaterThan(0);
+      expect(res.body.fieldErrors).toBeDefined();
+      expect(res.body.fieldErrors.yieldBpsMin).toBeDefined();
     });
 
     it('returns 400 for fundedRatioMin > 100', async () => {
@@ -543,23 +544,23 @@ describe('validateMarketplaceQueryParams – cursor support', () => {
   });
 
   it('rejects an empty cursor string', () => {
-    const { isValid, errors } = validateMarketplaceQueryParams({ cursor: '' });
+    const { isValid, fieldErrors } = validateMarketplaceQueryParams({ cursor: '' });
     expect(isValid).toBe(false);
-    expect(errors[0]).toMatch(/cursor/i);
+    expect(fieldErrors.cursor).toMatch(/cursor/i);
   });
 
   it('rejects a cursor over 2048 characters', () => {
-    const { isValid, errors } = validateMarketplaceQueryParams({
+    const { isValid, fieldErrors } = validateMarketplaceQueryParams({
       cursor: 'a'.repeat(2049),
     });
     expect(isValid).toBe(false);
-    expect(errors[0]).toMatch(/cursor/i);
+    expect(fieldErrors.cursor).toMatch(/cursor/i);
   });
 
   it('still validates page when no cursor', () => {
-    const { isValid, errors } = validateMarketplaceQueryParams({ page: '0' });
+    const { isValid, fieldErrors } = validateMarketplaceQueryParams({ page: '0' });
     expect(isValid).toBe(false);
-    expect(errors[0]).toMatch(/page/i);
+    expect(fieldErrors.page).toMatch(/page/i);
   });
 
   it('accepts all valid sort fields', () => {

--- a/tests/unit/validators.test.js
+++ b/tests/unit/validators.test.js
@@ -13,7 +13,7 @@ describe('Validators Utility', () => {
       const query = { status: 'invalid' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('Invalid status. Must be one of: paid, pending, overdue');
+      expect(result.fieldErrors.status).toBe('Invalid status. Must be one of: paid, pending, overdue');
     });
 
     it('should validate valid SME ID', () => {
@@ -34,7 +34,7 @@ describe('Validators Utility', () => {
       const query = { buyerId: '' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('Invalid buyerId format');
+      expect(result.fieldErrors.buyerId).toBe('Invalid buyerId format');
     });
 
     it('should validate valid dates', () => {
@@ -49,13 +49,14 @@ describe('Validators Utility', () => {
       const query = { dateFrom: '01-01-2023' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('Invalid dateFrom format. Use YYYY-MM-DD');
+      expect(result.fieldErrors.dateFrom).toBe('Invalid dateFrom format. Use YYYY-MM-DD');
     });
 
     it('should reject logically invalid dates', () => {
       const query = { dateFrom: '2023-13-01' }; // Invalid month
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.dateFrom).toBe('Invalid dateFrom format. Use YYYY-MM-DD');
     });
 
     it('should validate sorting parameters', () => {
@@ -70,21 +71,23 @@ describe('Validators Utility', () => {
       const query = { sortBy: 'unsupported' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('Invalid sortBy. Must be one of: amount, date');
+      expect(result.fieldErrors.sortBy).toBe('Invalid sortBy. Must be one of: amount, date');
     });
 
     it('should reject invalid order', () => {
       const query = { order: 'sideways' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('Invalid order. Must be "asc" or "desc"');
+      expect(result.fieldErrors.order).toBe('Invalid order. Must be "asc" or "desc"');
     });
 
     it('should handle multiple errors', () => {
       const query = { status: 'none', sortBy: 'unknown' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.errors.length).toBe(2);
+      expect(Object.keys(result.fieldErrors).length).toBe(2);
+      expect(result.fieldErrors.status).toBeDefined();
+      expect(result.fieldErrors.sortBy).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Overview
This PR addresses database persistence for KYC status records and standardizes query parameter validation errors to match the RFC 7807 problem json structure.

## Issues Solved
- **Persist KYC status records to the database**
closes #350 
  - Verification state (verify, reject, exempt) now correctly persists in the `kyc_records` table, enabling them to survive restarts and replicas.
  - Public API contracts and gating middleware rules remain fully preserved.
  - Mock and external-provider toggling behavior works unchanged.
  - Verification, rejection, and exemption transitions are fully auditable and idempotent.
- **Standardize query-param validator errors to RFC 7807**
closes #370 
  - Query parameters validators (`validateInvoiceQueryParams`, `validateMarketplaceQueryParams`) now return a flat key-value dictionary `fieldErrors` mapping the invalid parameters to their error messages.
  - Consuming endpoints (`GET /api/invoices`, `GET /api/marketplace`) have been updated to emit standard RFC 7807 problem JSON responses containing the detailed `fieldErrors`.
  - Visibility status filter checks and cursor check failures have also been standardized to this format.

---

## Security Notes
1. **Tenant Isolation & Anti-Spoofing**: Verified that the JWT authenticated principal (`req.user.smeId`) remains the sole authority for SME identity resolution during gating. Parameter injection or body spoofing attempts are ignored.
2. **Safe Database Reads**: The database helper functions check that a retrieved record contains a valid state status (`row.status`) to prevent mock environment/testing side-effects.
3. **No Information Leakage**: Standardized validation errors map query fields strictly to custom validation details without disclosing internal database details, stack traces, or server secrets.

---

## Automated Test Execution & Output
We ran the validation, validators, gating, and persistence tests:
```bash
npx jest tests/kyc.gating.test.js tests/kycService.persistence.test.js tests/unit/validators.test.js tests/marketplace.test.js tests/validation.test.js --runInBand --forceExit
```

### Full Output:
```text
PASS  tests/kycService.persistence.test.js
  KYC Service Database Persistence
    ✓ should return pending status for an unknown SME (10 ms)
    ✓ should persist verification status to the database (15 ms)
    ✓ should survive a restart (clearing mock store does not lose KYC status) (11 ms)
    ✓ should persist reject status to the database (8 ms)
    ✓ should persist exemption status to the database (12 ms)
    ✓ should be idempotent (re-verifying a verified SME is safe and updates the record) (21 ms)

PASS  tests/kyc.gating.test.js
PASS  tests/marketplace.test.js
PASS  tests/validation.test.js
PASS  tests/unit/validators.test.js

Test Suites: 5 passed, 5 total
Tests:       166 passed, 166 total
Snapshots:   0 total
Time:        6.097 s
```

### Linting Output:
```bash
npx eslint src/services/kycService.js src/utils/validators.js src/app.js src/routes/marketplace.js tests/kycService.persistence.test.js
```
*Output was clean with 0 warnings and 0 errors.*