### PR TITLE
security: configurable upload size and server-side MIME re-validation for invoice files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ REDIS_ESCROW_LEDGER_GAP_THRESHOLD=3
 # BODY_LIMIT_URLENCODED=50kb
 # BODY_LIMIT_RAW=1mb
 # BODY_LIMIT_INVOICE=512kb
+# INVOICE_FILE_MAX_SIZE=5mb
 
 # Soroban escrow funding submission stub
 # Defaults to delegated mode; live signing/submission is disabled in code.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 | `BODY_LIMIT_URLENCODED` | size string | `50kb` | No | No | [`src/middleware/bodySizeLimits.js`](../src/middleware/bodySizeLimits.js) |
 | `BODY_LIMIT_RAW` | size string | `1mb` | No | No | [`src/middleware/bodySizeLimits.js`](../src/middleware/bodySizeLimits.js) |
 | `BODY_LIMIT_INVOICE` | size string | `512kb` | No | No | [`src/middleware/bodySizeLimits.js`](../src/middleware/bodySizeLimits.js), [`src/services/storage.js`](../src/services/storage.js) |
+| `INVOICE_FILE_MAX_SIZE` | size string | `5mb` | No | No | [`src/routes/invoiceFile.js`](../src/routes/invoiceFile.js) |
 | `ESCROW_SIGNING_MODE` | enum: `delegated`, `custodial`, `stubbed` | `stubbed` in code; `delegated` in template | No | No | [`src/services/escrowSubmit.js`](../src/services/escrowSubmit.js) |
 | `STELLAR_NETWORK_PASSPHRASE` | string | None in escrow submission | Required outside `stubbed` escrow mode | No | [`src/services/escrowSubmit.js`](../src/services/escrowSubmit.js) |
 | `NETWORK_PASSPHRASE` | string | `Test SDF Network ; September 2015` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/config/stellar.js`](../src/config/stellar.js) |

--- a/src/routes/invoiceFile.js
+++ b/src/routes/invoiceFile.js
@@ -10,6 +10,15 @@ const storageService = require('../services/storage');
 const logger = require('../logger');
 const router = express.Router();
 
+/** PDF magic bytes. */
+const PDF_MAGIC_BYTES = Buffer.from('%PDF');
+
+/**
+ * Configurable upload size limit from env, defaults to 5mb.
+ * @type {string}
+ */
+const UPLOAD_SIZE_LIMIT = process.env.INVOICE_FILE_MAX_SIZE || '5mb';
+
 /**
  * Computes the SHA-256 hash of a buffer.
  * @param {Buffer} buffer The input buffer.
@@ -17,6 +26,33 @@ const router = express.Router();
  */
 function computeHash(buffer) {
   return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+/**
+ * Validates file content against PDF magic bytes (%PDF).
+ * @param {Buffer} fileBuffer - The uploaded file buffer.
+ * @returns {boolean} True if file starts with PDF magic bytes.
+ */
+function validatePdfMagicBytes(fileBuffer) {
+  return Buffer.isBuffer(fileBuffer) &&
+    fileBuffer.length >= 4 &&
+    fileBuffer.slice(0, 4).equals(PDF_MAGIC_BYTES);
+}
+
+/**
+ * Validates that the declared MIME type matches the actual file content.
+ * @param {string} declaredType - The Content-Type from the request header.
+ * @param {Buffer} fileBuffer - The uploaded file buffer.
+ * @returns {{ valid: boolean, message?: string }} Validation result.
+ */
+function validateMimeType(declaredType, fileBuffer) {
+  if (!declaredType || !declaredType.includes('application/pdf')) {
+    return { valid: false, message: 'Content-Type must be application/pdf' };
+  }
+  if (!validatePdfMagicBytes(fileBuffer)) {
+    return { valid: false, message: 'File content does not match declared MIME type application/pdf' };
+  }
+  return { valid: true };
 }
 
 /**
@@ -49,17 +85,18 @@ router.post('/:id/presigned-upload', express.json(), async (req, res) => {
  * POST /api/invoices/:id/file
  * Upload PDF file for an invoice and persist it.
  */
-router.post('/:id/file', express.raw({ type: 'application/pdf', limit: '5mb' }), async (req, res) => {
+router.post('/:id/file', express.raw({ type: 'application/pdf', limit: UPLOAD_SIZE_LIMIT }), async (req, res) => {
   const { id } = req.params;
   if (!id || typeof id !== 'string' || id.trim() === '') {
     return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
   }
-  const contentType = req.headers['content-type'];
-  if (!contentType || !contentType.includes('application/pdf')) {
-    return res.status(400).json({ error: 'Bad Request', message: 'Content-Type must be application/pdf' });
-  }
   if (!req.body || !Buffer.isBuffer(req.body) || req.body.length === 0) {
     return res.status(400).json({ error: 'Bad Request', message: 'No file data provided' });
+  }
+  const contentType = req.headers['content-type'];
+  const mimeValidation = validateMimeType(contentType, req.body);
+  if (!mimeValidation.valid) {
+    return res.status(400).json({ error: 'Bad Request', message: mimeValidation.message });
   }
   const fileHash = computeHash(req.body);
   const fileSize = req.body.length;
@@ -132,7 +169,7 @@ router.get('/:id/file/verify', async (req, res) => {
  * POST /api/invoices/:id/file/verify
  * Verify integrity of a provided PDF against stored hash.
  */
-router.post('/:id/file/verify', express.raw({ type: 'application/pdf', limit: '5mb' }), async (req, res) => {
+router.post('/:id/file/verify', express.raw({ type: 'application/pdf', limit: UPLOAD_SIZE_LIMIT }), async (req, res) => {
   const { id } = req.params;
   if (!id || typeof id !== 'string' || id.trim() === '') {
     return res.status(400).json({ error: 'Bad Request', message: 'Invalid invoice ID' });
@@ -157,3 +194,6 @@ router.post('/:id/file/verify', express.raw({ type: 'application/pdf', limit: '5
 });
 
 module.exports = router;
+module.exports.validatePdfMagicBytes = validatePdfMagicBytes;
+module.exports.validateMimeType = validateMimeType;
+module.exports.UPLOAD_SIZE_LIMIT = UPLOAD_SIZE_LIMIT;

--- a/tests/invoiceFile.upload.test.js
+++ b/tests/invoiceFile.upload.test.js
@@ -1,0 +1,330 @@
+/**
+ * @fileoverview Tests for configurable upload size limit and server-side
+ * MIME re-validation on the invoice file upload route.
+ *
+ * Covers:
+ *   - validatePdfMagicBytes unit tests
+ *   - validateMimeType unit tests
+ *   - Config-driven size limit (env override)
+ *   - Magic-byte MIME rejection (mislabeled file)
+ *   - Valid PDF upload
+ *   - Oversized / at-limit files
+ *   - Edge cases
+ *
+ * @see src/routes/invoiceFile.js
+ */
+
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+const crypto = require('crypto');
+
+const {
+  validatePdfMagicBytes,
+  validateMimeType,
+  UPLOAD_SIZE_LIMIT: DEFAULT_LIMIT,
+} = require('../src/routes/invoiceFile');
+
+const invoiceFileRouter = require('../src/routes/invoiceFile');
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Unit: validatePdfMagicBytes
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('validatePdfMagicBytes()', () => {
+  it('returns true for buffer starting with %PDF', () => {
+    expect(validatePdfMagicBytes(Buffer.from('%PDF-1.4'))).toBe(true);
+  });
+
+  it('returns true for minimal valid PDF prefix', () => {
+    expect(validatePdfMagicBytes(Buffer.from('%PDF'))).toBe(true);
+  });
+
+  it('returns false for non-PDF content', () => {
+    expect(validatePdfMagicBytes(Buffer.from('not a pdf'))).toBe(false);
+  });
+
+  it('returns false for empty buffer', () => {
+    expect(validatePdfMagicBytes(Buffer.alloc(0))).toBe(false);
+  });
+
+  it('returns false for buffer shorter than 4 bytes', () => {
+    expect(validatePdfMagicBytes(Buffer.from('ABC'))).toBe(false);
+  });
+
+  it('returns false for null input', () => {
+    expect(validatePdfMagicBytes(null)).toBe(false);
+  });
+
+  it('returns false for undefined input', () => {
+    expect(validatePdfMagicBytes(undefined)).toBe(false);
+  });
+
+  it('returns false for non-Buffer input (string)', () => {
+    expect(validatePdfMagicBytes('%PDF-1.4')).toBe(false);
+  });
+
+  it('detects binary non-PDF content', () => {
+    const binary = Buffer.from([0x89, 0x50, 0x4E, 0x47]); // PNG magic
+    expect(validatePdfMagicBytes(binary)).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Unit: validateMimeType
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('validateMimeType()', () => {
+  it('returns valid for PDF content type with PDF magic bytes', () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 content');
+    const result = validateMimeType('application/pdf', pdfBuffer);
+    expect(result.valid).toBe(true);
+    expect(result.message).toBeUndefined();
+  });
+
+  it('rejects when content type is not application/pdf', () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 content');
+    const result = validateMimeType('text/html', pdfBuffer);
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe('Content-Type must be application/pdf');
+  });
+
+  it('rejects when content type is missing', () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 content');
+    const result = validateMimeType(null, pdfBuffer);
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe('Content-Type must be application/pdf');
+  });
+
+  it('rejects when file content lacks PDF magic bytes', () => {
+    const nonPdfBuffer = Buffer.from('not a pdf file');
+    const result = validateMimeType('application/pdf', nonPdfBuffer);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('does not match declared MIME type');
+  });
+
+  it('rejects empty buffer with PDF content type', () => {
+    const result = validateMimeType('application/pdf', Buffer.alloc(0));
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('does not match declared MIME type');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration: POST /api/invoices/:id/file
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/invoices/:id/file — upload route', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use('/api/invoices', invoiceFileRouter);
+  });
+
+  // ── Valid uploads ──────────────────────────────────────────────────────
+
+  it('uploads a valid PDF (with %PDF magic bytes)', async () => {
+    const pdfContent = Buffer.from('%PDF-1.4 valid document content');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_upload_001/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data).toHaveProperty('fileHash');
+    expect(res.body.data.fileHash).toHaveLength(64);
+    expect(res.body.data.fileSize).toBe(pdfContent.length);
+    expect(res.body.data.invoiceId).toBe('inv_upload_001');
+    expect(res.body.message).toBe('Invoice file uploaded successfully');
+  });
+
+  it('computes correct SHA-256 hash for uploaded PDF', async () => {
+    const pdfContent = Buffer.from('%PDF-1.4 hash check');
+    const expectedHash = crypto.createHash('sha256').update(pdfContent).digest('hex');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_upload_hash/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data.fileHash).toBe(expectedHash);
+  });
+
+  // ── MIME re-validation ─────────────────────────────────────────────────
+
+  it('rejects upload with wrong Content-Type header', async () => {
+    const pdfContent = Buffer.from('%PDF-1.4 content');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_bad_mime/file')
+      .set('Content-Type', 'text/html')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Bad Request');
+    expect(res.body.message).toBe('Content-Type must be application/pdf');
+  });
+
+  it('rejects mislabeled file — declares PDF but contains non-PDF bytes', async () => {
+    const nonPdfContent = Buffer.from('not a pdf document');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_mislabeled/file')
+      .set('Content-Type', 'application/pdf')
+      .send(nonPdfContent);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Bad Request');
+    expect(res.body.message).toContain('does not match declared MIME type');
+  });
+
+  it('rejects mislabeled binary file masquerading as PDF', async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+
+    const res = await request(app)
+      .post('/api/invoices/inv_png_as_pdf/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pngHeader);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Bad Request');
+    expect(res.body.message).toContain('does not match declared MIME type');
+  });
+
+  // ── Empty / missing data ──────────────────────────────────────────────
+
+  it('rejects empty file data', async () => {
+    const res = await request(app)
+      .post('/api/invoices/inv_empty/file')
+      .set('Content-Type', 'application/pdf')
+      .send(Buffer.alloc(0));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Bad Request');
+    expect(res.body.message).toBe('No file data provided');
+  });
+
+  // ── Invalid invoice ID ─────────────────────────────────────────────────
+
+  it('rejects invalid invoice ID', async () => {
+    const pdfContent = Buffer.from('%PDF-1.4 content');
+
+    const res = await request(app)
+      .post('/api/invoices/ /file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Bad Request');
+    expect(res.body.message).toBe('Invalid invoice ID');
+  });
+
+  // ── At-limit file ──────────────────────────────────────────────────────
+
+  it('accepts a file right at the default size limit', async () => {
+    const limitBytes = 5 * 1024 * 1024; // 5 MB default
+    const pdfContent = Buffer.alloc(limitBytes);
+    pdfContent.write('%PDF-1.4');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_at_limit/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data.fileSize).toBe(limitBytes);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Config-driven size limit (env override)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('config-driven upload size limit', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.resetModules();
+  });
+
+  it('UPLOAD_SIZE_LIMIT defaults to 5mb', () => {
+    delete process.env.INVOICE_FILE_MAX_SIZE;
+    const fresh = require('../src/routes/invoiceFile');
+    expect(fresh.UPLOAD_SIZE_LIMIT).toBe('5mb');
+  });
+
+  it('UPLOAD_SIZE_LIMIT reads from INVOICE_FILE_MAX_SIZE env var', () => {
+    process.env.INVOICE_FILE_MAX_SIZE = '1mb';
+    const fresh = require('../src/routes/invoiceFile');
+    expect(fresh.UPLOAD_SIZE_LIMIT).toBe('1mb');
+  });
+
+  it('UPLOAD_SIZE_LIMIT accepts custom size string from env', () => {
+    process.env.INVOICE_FILE_MAX_SIZE = '2kb';
+    const fresh = require('../src/routes/invoiceFile');
+    expect(fresh.UPLOAD_SIZE_LIMIT).toBe('2kb');
+  });
+
+  it('rejects upload when file exceeds env-configured limit', async () => {
+    process.env.INVOICE_FILE_MAX_SIZE = '1kb';
+    jest.resetModules();
+
+    const customRouter = require('../src/routes/invoiceFile');
+    const app = express();
+    app.use('/api/invoices', customRouter);
+
+    const pdfContent = Buffer.alloc(2048);
+    pdfContent.write('%PDF-1.4');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_oversized/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(413);
+  });
+
+  it('accepts upload when file is within env-configured limit', async () => {
+    process.env.INVOICE_FILE_MAX_SIZE = '10kb';
+    jest.resetModules();
+
+    const customRouter = require('../src/routes/invoiceFile');
+    const app = express();
+    app.use('/api/invoices', customRouter);
+
+    const pdfContent = Buffer.alloc(5 * 1024);
+    pdfContent.write('%PDF-1.4');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_within_limit/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('rejects upload at exactly the env-configured limit boundary (strictly over rejects)', async () => {
+    process.env.INVOICE_FILE_MAX_SIZE = '1kb';
+    jest.resetModules();
+
+    const customRouter = require('../src/routes/invoiceFile');
+    const app = express();
+    app.use('/api/invoices', customRouter);
+
+    // Send 1 byte over the limit
+    const pdfContent = Buffer.alloc(1025);
+    pdfContent.write('%PDF-1.4');
+
+    const res = await request(app)
+      .post('/api/invoices/inv_boundary/file')
+      .set('Content-Type', 'application/pdf')
+      .send(pdfContent);
+
+    expect(res.statusCode).toBe(413);
+  });
+});


### PR DESCRIPTION
Closes #455

## Summary

- **Configurable upload size limit**: Replaced hardcoded `'5mb'` with `UPLOAD_SIZE_LIMIT` read from `INVOICE_FILE_MAX_SIZE` env var (defaults to `'5mb'`)
- **Server-side MIME re-validation**: Added `validatePdfMagicBytes()` to verify PDF magic bytes (`%PDF`) from file content, and `validateMimeType()` to reject mismatches between declared Content-Type and actual file bytes
- **Updated routes**: Both POST `/file` (upload) and POST `/file/verify` use the configurable limit; upload route now rejects mislabeled files at the byte level
- **Documentation**: `.env.example` and `docs/configuration.md` updated with `INVOICE_FILE_MAX_SIZE`

## Tests

New `tests/invoiceFile.upload.test.js` with 30+ test cases covering:
- `validatePdfMagicBytes` unit tests (valid PDF, non-PDF, empty, short, null, binary)
- `validateMimeType` unit tests (valid, wrong type, missing type, wrong bytes, empty buffer)
- Integration: valid PDF upload, correct hash computation
- Integration: wrong Content-Type rejection
- Integration: mislabeled file (PDF content-type, non-PDF bytes) rejection  
- Integration: mislabeled binary file (PNG as PDF) rejection
- Integration: empty file rejection
- Integration: invalid invoice ID rejection
- Integration: at-limit file acceptance
- Config-driven env override: default, custom size, oversized rejection, within-limit acceptance, boundary rejection