### PR TITLE
fix: reconcile marketplace investable statuses with state machine 

### DIFF
--- a/docs/invoice-lifecycle-api.md
+++ b/docs/invoice-lifecycle-api.md
@@ -48,11 +48,42 @@ curl -X POST http://localhost:3001/api/invoices/inv-001/transition \
 
 ### States
 
-- **pending**: Initial state when invoice is created
-- **approved**: Invoice has been verified and approved
-- **linked_escrow**: Invoice is linked to an escrow contract (terminal state)
-- **rejected**: Invoice was rejected during verification (terminal state)
-- **cancelled**: Invoice was cancelled by user (terminal state)
+The platform recognises two overlapping state vocabularies that both live in
+`src/services/invoiceStateMachine.js` as the single authoritative source.
+
+#### Approval / escrow lifecycle (managed by the state machine)
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Initial state when invoice is created |
+| `approved` | Invoice has been verified and approved |
+| `linked_escrow` | Invoice is linked to an escrow contract (**terminal**) |
+| `rejected` | Invoice was rejected during verification (**terminal**) |
+| `cancelled` | Invoice was cancelled by user (**terminal**) |
+
+#### Funding-progress overlay (set by the investment/funding subsystem)
+
+| Status | Description | Investable? |
+|--------|-------------|-------------|
+| `pending_verification` | Awaiting KYC / compliance check | No |
+| `verified` | Passed compliance; open for investment | **Yes** |
+| `partially_funded` | Funding target partially met; still accepting commitments | **Yes** |
+| `funded` | Funding target fully met; no new commitments accepted | No |
+| `completed` | Invoice settled / matured | No |
+| `defaulted` | Issuer defaulted (**terminal**) | No |
+
+### Investable Statuses
+
+The marketplace and invest endpoints only surface invoices whose `status` is in
+the **investable set**: `verified` and `partially_funded`.  This set is defined
+once in `INVESTABLE_STATUSES` (exported from `invoiceStateMachine.js`) and
+consumed by `marketplaceService` and `investService` via a named import — there
+is no separate hardcoded array.
+
+**Security invariant**: no terminal lifecycle state (`linked_escrow`, `rejected`,
+`cancelled`, `defaulted`) can ever appear in `INVESTABLE_STATUSES`.  The test
+suite in `tests/marketplace.test.js` (section *"Status vocabulary alignment"*)
+enforces this property on every CI run.
 
 ### Valid Transitions
 

--- a/src/services/invoiceStateMachine.js
+++ b/src/services/invoiceStateMachine.js
@@ -14,15 +14,64 @@ const { invalidatePrefix } = require('../middleware/cache');
 
 
 /**
- * Valid invoice states in the lifecycle
+ * Valid invoice states in the approval/escrow lifecycle.
+ * These states govern the internal workflow (pending → approved → linked_escrow)
+ * and are managed exclusively by executeTransition().
  */
 const INVOICE_STATES = {
   PENDING: 'pending',
   APPROVED: 'approved',
   LINKED_ESCROW: 'linked_escrow',
-  REJECTED: 'rejected', // Terminal state
+  REJECTED: 'rejected',   // Terminal state
   CANCELLED: 'cancelled', // Terminal state
 };
+
+/**
+ * Full recognized state vocabulary across both the approval lifecycle and the
+ * funding-progress layer.  Any status value stored in the `invoices.status`
+ * column MUST appear here.  This is the single authoritative source — add new
+ * statuses here before using them anywhere else.
+ *
+ * Approval/escrow lifecycle (managed by the state machine):
+ *   pending, approved, linked_escrow, rejected, cancelled
+ *
+ * Funding-progress overlay (set by the investment/funding subsystem):
+ *   pending_verification – awaiting KYC / compliance check
+ *   verified             – passed compliance; open for investment
+ *   partially_funded     – funding target partially met; still accepting commitments
+ *   funded               – funding target fully met
+ *   completed            – invoice settled / matured
+ *   defaulted            – issuer defaulted; terminal
+ */
+const ALL_INVOICE_STATUSES = Object.freeze([
+  // Approval/escrow lifecycle
+  INVOICE_STATES.PENDING,
+  INVOICE_STATES.APPROVED,
+  INVOICE_STATES.LINKED_ESCROW,
+  INVOICE_STATES.REJECTED,
+  INVOICE_STATES.CANCELLED,
+  // Funding-progress overlay
+  'pending_verification',
+  'verified',
+  'partially_funded',
+  'funded',
+  'completed',
+  'defaulted',
+]);
+
+/**
+ * Statuses that make an invoice publicly visible in the marketplace and
+ * eligible for investor commitments.
+ *
+ * Business rule: an invoice is investable when it has passed compliance
+ * checks (`verified`) or is still accepting additional funding
+ * (`partially_funded`).  All other statuses are tenant-private and MUST NOT
+ * be exposed through marketplace/invest read endpoints.
+ *
+ * This constant is the single source of truth.  `marketplaceService` and
+ * `investService` import it directly; no separate literal array should exist.
+ */
+const INVESTABLE_STATUSES = Object.freeze(['verified', 'partially_funded']);
 
 /**
  * Valid state transitions
@@ -69,12 +118,27 @@ function normalizeTransitionReason(reason) {
 }
 
 /**
- * Validates if a state is a valid invoice state
- * 
- * @param {string} state State to validate
- * @returns {boolean} True if valid
+ * Validates whether a string is a recognized invoice status (approval or
+ * funding-progress vocabulary).
+ *
+ * @param {string} state - Status value to check.
+ * @returns {boolean} `true` when the value is in {@link ALL_INVOICE_STATUSES}.
  */
 function isValidState(state) {
+  return ALL_INVOICE_STATUSES.includes(state);
+}
+
+/**
+ * Validates whether a status belongs to the approval/escrow lifecycle managed
+ * by this state machine (i.e. is a key in {@link INVOICE_STATES}).
+ *
+ * Use this when you need to distinguish lifecycle states from funding-progress
+ * overlay values.
+ *
+ * @param {string} state - Status value to check.
+ * @returns {boolean} `true` when the value is a lifecycle state.
+ */
+function isLifecycleState(state) {
   return Object.values(INVOICE_STATES).includes(state);
 }
 
@@ -397,9 +461,12 @@ function canLinkToEscrow(invoice) {
 
 module.exports = {
   INVOICE_STATES,
+  ALL_INVOICE_STATUSES,
+  INVESTABLE_STATUSES,
   VALID_TRANSITIONS,
   TERMINAL_STATES,
   isValidState,
+  isLifecycleState,
   isTransitionAllowed,
   isTerminalState,
   getAllowedTransitions,

--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -2,6 +2,7 @@
 
 const db = require('../db/knex');
 const { encodeCursor, decodeCursor, CursorError } = require('../utils/cursorPagination');
+const { INVESTABLE_STATUSES } = require('./invoiceStateMachine');
 
 /**
  * Marketplace Service
@@ -61,13 +62,20 @@ const MARKETPLACE_QUERY_CONFIG = {
 };
 
 /**
- * Explicit visibility rules for marketplace listings.
+ * Public investable invoice statuses — derived from the authoritative
+ * {@link INVESTABLE_STATUSES} constant in `invoiceStateMachine`.
  *
- * Only these invoice statuses are considered publicly investable (i.e. appear
- * in the marketplace/invest listings).  Other statuses are tenant-private and
- * MUST NOT be exposed via read/list endpoints.
+ * Only invoices in one of these states are surfaced through the marketplace
+ * and invest endpoints.  All other states are tenant-private.
+ *
+ * **Do not add values here.**  To expand or change the investable set, update
+ * `INVESTABLE_STATUSES` in `src/services/invoiceStateMachine.js`.  This alias
+ * exists solely for backward-compatible named exports consumed by routes and
+ * other services.
+ *
+ * @type {readonly string[]}
  */
-const PUBLIC_INVESTABLE_INVOICE_STATUSES = Object.freeze(['verified', 'partially_funded']);
+const PUBLIC_INVESTABLE_INVOICE_STATUSES = INVESTABLE_STATUSES;
 
 /**
  * Applies shared filter conditions to a Knex query builder.

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -9,6 +9,7 @@
  * there so all callers continue to work without modification.
  */
 
+const { ALL_INVOICE_STATUSES } = require('../services/invoiceStateMachine');
 // ── Zod-backed invoice payload validator (re-export) ─────────────────────────
 
 const {
@@ -137,7 +138,7 @@ function validateMarketplaceQueryParams(query) {
   } = query;
 
   if (status !== undefined) {
-    const validStatuses = ['pending_verification', 'verified', 'funded', 'partially_funded', 'completed', 'defaulted'];
+    const validStatuses = ALL_INVOICE_STATUSES;
     if (validStatuses.includes(status)) {
       validatedParams.filters.status = status;
     } else {

--- a/tests/marketplace.test.js
+++ b/tests/marketplace.test.js
@@ -572,3 +572,89 @@ describe('validateMarketplaceQueryParams – cursor support', () => {
     }
   });
 });
+
+// ── Unit tests: status vocabulary alignment ──────────────────────────────────
+
+describe('Status vocabulary alignment – state machine vs marketplace', () => {
+  /**
+   * These tests enforce the contract that the marketplace visibility set is
+   * always a proper subset of the authoritative ALL_INVOICE_STATUSES from
+   * invoiceStateMachine.  If either constant drifts the suite fails
+   * immediately, making the misalignment impossible to ship silently.
+   */
+  const {
+    ALL_INVOICE_STATUSES,
+    INVESTABLE_STATUSES,
+  } = require('../src/services/invoiceStateMachine');
+  const { PUBLIC_INVESTABLE_INVOICE_STATUSES } = require('../src/services/marketplaceService');
+
+  it('ALL_INVOICE_STATUSES contains at least the legacy funding-progress vocabulary', () => {
+    // These are the statuses that existed in the validator before this change.
+    // Removing any of them from the state machine would be a breaking regression.
+    const requiredStatuses = [
+      'pending_verification',
+      'verified',
+      'partially_funded',
+      'funded',
+      'completed',
+      'defaulted',
+    ];
+    for (const s of requiredStatuses) {
+      expect(ALL_INVOICE_STATUSES).toContain(s);
+    }
+  });
+
+  it('ALL_INVOICE_STATUSES contains all lifecycle states from INVOICE_STATES', () => {
+    const { INVOICE_STATES } = require('../src/services/invoiceStateMachine');
+    for (const s of Object.values(INVOICE_STATES)) {
+      expect(ALL_INVOICE_STATUSES).toContain(s);
+    }
+  });
+
+  it('INVESTABLE_STATUSES is a non-empty frozen array', () => {
+    expect(Array.isArray(INVESTABLE_STATUSES)).toBe(true);
+    expect(INVESTABLE_STATUSES.length).toBeGreaterThan(0);
+    // Object.isFrozen checks the freeze applied in invoiceStateMachine
+    expect(Object.isFrozen(INVESTABLE_STATUSES)).toBe(true);
+  });
+
+  it('every status in INVESTABLE_STATUSES is a recognized state (subset of ALL_INVOICE_STATUSES)', () => {
+    for (const s of INVESTABLE_STATUSES) {
+      expect(ALL_INVOICE_STATUSES).toContain(s);
+    }
+  });
+
+  it('PUBLIC_INVESTABLE_INVOICE_STATUSES is the same reference as INVESTABLE_STATUSES (single source)', () => {
+    // The marketplace constant must be derived from — not a copy of — the
+    // state machine constant.  A value equality check is the minimum bar;
+    // identity equality (===) confirms no accidental re-freeze with new array.
+    expect(PUBLIC_INVESTABLE_INVOICE_STATUSES).toBe(INVESTABLE_STATUSES);
+  });
+
+  it('no terminal lifecycle state is investable', () => {
+    const { TERMINAL_STATES } = require('../src/services/invoiceStateMachine');
+    for (const s of TERMINAL_STATES) {
+      expect(INVESTABLE_STATUSES).not.toContain(s);
+    }
+  });
+
+  it('no non-public state (pending, approved, rejected, cancelled) is in INVESTABLE_STATUSES', () => {
+    const nonPublicStates = ['pending', 'approved', 'linked_escrow', 'rejected', 'cancelled', 'pending_verification', 'defaulted'];
+    for (const s of nonPublicStates) {
+      expect(INVESTABLE_STATUSES).not.toContain(s);
+    }
+  });
+
+  it('verified is in INVESTABLE_STATUSES', () => {
+    expect(INVESTABLE_STATUSES).toContain('verified');
+  });
+
+  it('partially_funded is in INVESTABLE_STATUSES', () => {
+    expect(INVESTABLE_STATUSES).toContain('partially_funded');
+  });
+
+  it('funded is NOT in INVESTABLE_STATUSES (fully funded invoices are no longer accepting commitments)', () => {
+    // Once fully funded, no additional investor commitments can be accepted.
+    expect(INVESTABLE_STATUSES).not.toContain('funded');
+  });
+});


### PR DESCRIPTION
closes #441 

- Add ALL_INVOICE_STATUSES and INVESTABLE_STATUSES constants to invoiceStateMachine.js as the single source of truth for the full status vocabulary and the public-investable subset respectively
- Add isLifecycleState() helper to distinguish approval-lifecycle states from funding-progress overlay states
- Broaden isValidState() to validate against ALL_INVOICE_STATUSES so funding-progress statuses (verified, partially_funded, etc.) are recognized across the system
- Derive PUBLIC_INVESTABLE_INVOICE_STATUSES in marketplaceService.js as a direct reference alias to INVESTABLE_STATUSES (same object, not a copy) eliminating the hardcoded ['verified', 'partially_funded'] array
- Replace hardcoded status list in validators.js with ALL_INVOICE_STATUSES import so validator vocabulary tracks the state machine automatically
- Add 'Status vocabulary alignment' test section to marketplace.test.js asserting subset invariant, identity reference, and security invariants (no terminal state investable, no non-public state investable)
- Update docs/invoice-lifecycle-api.md to document both state vocabularies in tables and reference the test enforcement of the security invariant