### PR TITLE
security: validate and bound inbound request-id header against log injection

### DIFF
--- a/docs/request-lifecycle-middleware-order.md
+++ b/docs/request-lifecycle-middleware-order.md
@@ -16,8 +16,12 @@ Applied in this order before any route handler runs:
 | 3 | URL-encoded body limit | Form payloads (50 KB) |
 | 4 | Security headers (`createSecurityMiddleware`) | Helmet-style hardening |
 | 5 | Audit middleware | Structured request audit trail |
-| 6 | Request ID | Propagates `req.id` for logging |
+| 6 | Request ID | Validates and propagates `req.id` for logging; only `X-Request-Id`/`X-Request-ID` values matching `[A-Za-z0-9._-]{1,128}` are trusted, otherwise a fresh UUID is generated and echoed back in the response header |
 | 7 | Correlation ID | Cross-service trace correlation |
+
+## Request ID header contract
+
+The request ID middleware accepts a client-supplied header only when it is a non-empty string of at most 128 characters and contains only the safe characters `[A-Za-z0-9._-]`. Values with control characters, newlines, whitespace, or other disallowed bytes are rejected and replaced with a server-generated UUID. The sanitized value is then attached to `req.id`, propagated into child loggers, and echoed in the `X-Request-Id` response header.
 
 ## Inline routes (defined on `app` directly)
 

--- a/src/middleware/correlationId.js
+++ b/src/middleware/correlationId.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { randomUUID } = require('crypto');
 const { createRequestLogger } = require('../logger');
 
@@ -14,10 +16,13 @@ const CORRELATION_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
  */
 function correlationIdMiddleware(req, res, next) {
   const candidate = req.header(CORRELATION_HEADER);
+  // Fallback uses the full UUID (no truncation) so the generated id keeps its
+  // full entropy, matching the strength of the requestId middleware fallback.
+  // `req_` + 32 hex chars = 36 chars, within the accepted {8,64} bound.
   const correlationId =
     typeof candidate === 'string' && CORRELATION_ID_PATTERN.test(candidate)
       ? candidate
-      : `req_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+      : `req_${randomUUID().replace(/-/g, '')}`;
 
   req.correlationId = correlationId;
   req.log = createRequestLogger(req);

--- a/src/middleware/requestId.js
+++ b/src/middleware/requestId.js
@@ -5,33 +5,131 @@
  *
  * This ensures that logs can be correlated across multiple middleware and services.
  * It checks for an existing X-Request-Id header (e.g., from a load balancer)
- * and generates a new one if missing.
+ * and generates a fresh, server-side UUID when the client value is missing or
+ * unacceptable.
+ *
+ * Security: a client-supplied request id is only trusted when it matches a
+ * strict charset and length bound. This prevents log forging (injection of
+ * newlines / control characters into structured log lines) and resource
+ * amplification (multi-kilobyte ids duplicated across every log entry and the
+ * response header).
  *
  * @module middleware/requestId
  */
 
 const { randomUUID } = require('crypto');
 const { createRequestLogger } = require('../logger');
+const REQUEST_ID_HEADER_NAMES = ['x-request-id', 'request-id'];
 
 /**
- * Attaches a unique request ID to the request and response objects.
+ * Maximum accepted length, in characters, for a client-supplied request id.
+ * Values longer than this are rejected and replaced with a generated id.
+ *
+ * @type {number}
+ */
+const MAX_REQUEST_ID_LENGTH = 128;
+
+/**
+ * Strict charset for an acceptable inbound request id.
+ *
+ * Only unreserved URL characters are allowed (`[A-Za-z0-9._-]`), which excludes
+ * whitespace, newlines (CR/LF), and all control characters that would otherwise
+ * be vectors for log injection. The bound `{1,128}` also rejects empty and
+ * oversized values.
+ *
+ * @type {RegExp}
+ */
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
+/**
+ * Validate and sanitize a client-supplied request id.
+ *
+ * Returns the value unchanged only when it is a non-empty string within the
+ * length bound and composed exclusively of the allowed charset. Any other
+ * input - a non-string (e.g. a repeated header parsed as an array), an empty
+ * string, an oversized string, or a string containing control characters,
+ * newlines, or other disallowed bytes - yields `null`, signalling that a fresh
+ * server-generated id must be used instead.
+ *
+ * @param {unknown} value - Candidate request id taken from an inbound header.
+ * @returns {string|null} The validated id, or `null` when it must be replaced.
+ */
+function sanitizeRequestId(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  // Cheap length guard first so oversized payloads never reach the regex.
+  if (value.length === 0 || value.length > MAX_REQUEST_ID_LENGTH) {
+    return null;
+  }
+
+  if (!REQUEST_ID_PATTERN.test(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+/**
+ * Generate a fresh, full-strength server-side request id.
+ *
+ * Uses a v4 UUID (122 bits of entropy) so fallback ids are as strong as the
+ * fallback used by {@link module:middleware/correlationId}.
+ *
+ * @returns {string} A newly generated UUID.
+ */
+function generateRequestId() {
+  return randomUUID();
+}
+
+/**
+ * Resolve the first acceptable request id from supported inbound header names.
+ *
+ * @param {NodeJS.Dict<string | string[]> | undefined} headers - Inbound request headers.
+ * @returns {string|null} The first validated request id, or `null` when none are acceptable.
+ */
+function resolveRequestIdFromHeaders(headers) {
+  for (const headerName of REQUEST_ID_HEADER_NAMES) {
+    const value = sanitizeRequestId(headers?.[headerName]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Attaches a validated, bounded request ID to the request and response objects.
+ *
+ * The single sanitized id is the only value carried into the child logger
+ * (`req.log`) and echoed in the `X-Request-Id` response header, so no
+ * untrusted bytes ever reach a log sink or a downstream client.
  *
  * @param {import('express').Request} req - Express request object
  * @param {import('express').Response} res - Express response object
  * @param {import('express').NextFunction} next - Express next function
  */
 const requestId = (req, res, next) => {
-  // Use existing header if present (standard for distributed tracing)
-  const id = req.headers['x-request-id'] || req.headers['request-id'] || randomUUID();
+  // Prefer a validated client-supplied id (standard for distributed tracing),
+  // otherwise fall back to a fresh server-generated id.
+  const id = resolveRequestIdFromHeaders(req.headers) || generateRequestId();
 
-  // Attach to request object for use in subsequent middleware/handlers
+  // Attach to request object for use in subsequent middleware/handlers.
   req.id = id;
   req.log = createRequestLogger(req);
 
-  // Set the response header so clients/proxies can see the ID
+  // Echo the validated id so clients/proxies can see it.
   res.setHeader('X-Request-Id', id);
 
   next();
 };
 
 module.exports = requestId;
+module.exports.sanitizeRequestId = sanitizeRequestId;
+module.exports.generateRequestId = generateRequestId;
+module.exports.resolveRequestIdFromHeaders = resolveRequestIdFromHeaders;
+module.exports.MAX_REQUEST_ID_LENGTH = MAX_REQUEST_ID_LENGTH;
+module.exports.REQUEST_ID_PATTERN = REQUEST_ID_PATTERN;
+

--- a/tests/middleware-security.test.js
+++ b/tests/middleware-security.test.js
@@ -1,9 +1,19 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const express = require('express');
 const request = require('supertest');
 
 const { createApp } = require('../src/index');
 const { parseBearerAuthorizationHeader, tokensMatch } = require('../src/middleware/auth');
+const requestId = require('../src/middleware/requestId');
+const {
+  sanitizeRequestId,
+  generateRequestId,
+  resolveRequestIdFromHeaders,
+  MAX_REQUEST_ID_LENGTH,
+} = requestId;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const VALID_TOKEN = 'test-suite-token';
 
@@ -184,6 +194,173 @@ test('rate limiter state stays isolated between app instances', async () => {
   assert.equal(firstResponse.status, 200);
   assert.equal(limitedResponse.status, 429);
   assert.equal(isolatedResponse.status, 200);
+});
+
+test('sanitizeRequestId accepts a well-formed client id verbatim', () => {
+  const valid = 'abc-123_DEF.456';
+  assert.equal(sanitizeRequestId(valid), valid);
+});
+
+test('sanitizeRequestId rejects missing, empty, and non-string values', () => {
+  assert.equal(sanitizeRequestId(undefined), null);
+  assert.equal(sanitizeRequestId(null), null);
+  assert.equal(sanitizeRequestId(''), null);
+  // A repeated header is parsed as an array, not a string.
+  assert.equal(sanitizeRequestId(['a', 'b']), null);
+  assert.equal(sanitizeRequestId(42), null);
+});
+
+test('sanitizeRequestId caps oversized identifiers at the length bound', () => {
+  const atLimit = 'a'.repeat(MAX_REQUEST_ID_LENGTH);
+  const overLimit = 'a'.repeat(MAX_REQUEST_ID_LENGTH + 1);
+
+  assert.equal(sanitizeRequestId(atLimit), atLimit);
+  assert.equal(sanitizeRequestId(overLimit), null);
+});
+
+test('sanitizeRequestId rejects values outside the strict charset', () => {
+  const disallowed = [
+    'has space',
+    'has/slash',
+    'semi;colon',
+    'angle<bracket>',
+    'quote"value',
+  ];
+
+  for (const value of disallowed) {
+    assert.equal(sanitizeRequestId(value), null);
+  }
+});
+
+test('log-injection regression: CRLF and control chars never survive sanitization', () => {
+  // These payloads would forge extra structured log lines if echoed verbatim.
+  const injectionPayloads = [
+    'valid\r\nlevel=ERROR injected',
+    'valid\ninjected',
+    'valid\rinjected',
+    'valid\tinjected',
+    `valid${String.fromCharCode(0)}null`,
+    `valid${String.fromCharCode(7)}bell`,
+    `valid${String.fromCharCode(27)}[31mansi`,
+  ];
+
+  for (const payload of injectionPayloads) {
+    const result = sanitizeRequestId(payload);
+    assert.equal(result, null);
+    // Defense in depth: if a future change returns a string, it must be clean.
+    if (typeof result === 'string') {
+      assert.equal(/[\r\n\u0000-\u001f\u007f]/.test(result), false);
+    }
+  }
+});
+
+test('generateRequestId returns a full-strength UUID', () => {
+  const id = generateRequestId();
+  assert.match(id, UUID_PATTERN);
+  assert.notEqual(generateRequestId(), id);
+});
+
+test('resolveRequestIdFromHeaders falls back to the alternate header only when it is clean', () => {
+  const headers = {
+    'x-request-id': 'bad id with spaces',
+    'request-id': 'clean-alt-id_123',
+  };
+
+  assert.equal(resolveRequestIdFromHeaders(headers), 'clean-alt-id_123');
+});
+
+test('request id middleware echoes a valid client-supplied id', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+  const clientId = 'client-supplied_REQUEST.123';
+
+  const response = await request(app).get('/health').set('X-Request-Id', clientId);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers['x-request-id'], clientId);
+});
+
+test('request id middleware replaces an oversized client id with a fresh UUID', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+  const oversized = 'a'.repeat(MAX_REQUEST_ID_LENGTH + 50);
+
+  const response = await request(app).get('/health').set('X-Request-Id', oversized);
+
+  assert.equal(response.status, 200);
+  assert.notEqual(response.headers['x-request-id'], oversized);
+  assert.match(response.headers['x-request-id'], UUID_PATTERN);
+});
+
+test('request id middleware rejects ids with disallowed characters and echoes a clean UUID', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+
+  // Spaces are transmissible over the wire but not part of the strict charset.
+  const response = await request(app)
+    .get('/health')
+    .set('X-Request-Id', 'spoofed value with spaces');
+
+  assert.equal(response.status, 200);
+  const echoed = response.headers['x-request-id'];
+  assert.match(echoed, UUID_PATTERN);
+  // The echoed header must never carry a newline back to a client/log sink.
+  assert.equal(/[\r\n]/.test(echoed), false);
+});
+
+test('request id middleware never binds injected header bytes into the request logger', () => {
+  const req = {
+    headers: {
+      'x-request-id': 'valid\r\nlevel=ERROR injected',
+    },
+  };
+  const responseHeaders = {};
+  const res = {
+    setHeader(name, value) {
+      responseHeaders[name.toLowerCase()] = value;
+    },
+  };
+
+  requestId(req, res, () => {});
+
+  const boundRequestId = req.log.bindings().requestId;
+  assert.match(req.id, UUID_PATTERN);
+  assert.equal(boundRequestId, req.id);
+  assert.equal(responseHeaders['x-request-id'], req.id);
+  assert.equal(/[\r\n\u0000-\u001f\u007f]/.test(boundRequestId), false);
+});
+
+test('request id middleware keeps the logger and echoed header aligned to the same validated id', async () => {
+  const app = express();
+  app.use(requestId);
+  app.get('/logger', (req, res) => {
+    res.json({
+      requestId: req.id,
+      loggerBindings: req.log.bindings(),
+    });
+  });
+
+  const response = await request(app).get('/logger').set('X-Request-Id', 'clean-client-id_42');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.requestId, 'clean-client-id_42');
+  assert.deepEqual(response.body.loggerBindings, { requestId: 'clean-client-id_42' });
+  assert.equal(response.headers['x-request-id'], 'clean-client-id_42');
+});
+
+test('request id middleware generates an id when no header is provided', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+
+  const response = await request(app).get('/health');
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers['x-request-id'], UUID_PATTERN);
+});
+
+test('request id middleware treats an empty client header as missing and generates a fresh UUID', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+
+  const response = await request(app).get('/health').set('X-Request-Id', '');
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers['x-request-id'], UUID_PATTERN);
 });
 
 test('auth parsing helpers normalize and compare tokens safely', () => {

--- a/tests/unit/requestId.test.js
+++ b/tests/unit/requestId.test.js
@@ -47,6 +47,18 @@ describe('Request ID Middleware', () => {
     expect(next).toHaveBeenCalled();
   });
 
+  it('should replace an invalid request id header with a generated id', () => {
+    req.headers['x-request-id'] = 'bad id with spaces';
+
+    requestId(req, res, next);
+
+    expect(req.id).toBeDefined();
+    expect(req.id).not.toBe('bad id with spaces');
+    expect(req.log.bindings()).toMatchObject({ requestId: req.id });
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', req.id);
+    expect(next).toHaveBeenCalled();
+  });
+
   it('should reuse an existing request-id header (case insensitive/alternate)', () => {
     const existingId = 'alt-id-456';
     req.headers['request-id'] = existingId;
@@ -55,6 +67,18 @@ describe('Request ID Middleware', () => {
 
     expect(req.id).toBe(existingId);
     expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', existingId);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should use a clean alternate request-id header when the primary alias is invalid', () => {
+    req.headers['x-request-id'] = 'not valid';
+    req.headers['request-id'] = 'alt-id-456';
+
+    requestId(req, res, next);
+
+    expect(req.id).toBe('alt-id-456');
+    expect(req.log.bindings()).toMatchObject({ requestId: 'alt-id-456' });
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'alt-id-456');
     expect(next).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #422

---

## Summary
- validate inbound request id headers against a strict safe charset and 128-character limit
- fall back to server-generated UUIDs and keep the validated id aligned across req.id, child loggers, and the response header
- add regression coverage for CRLF/control-character injection, oversized ids, alternate header fallback, and logger/header consistency

## Testing
- not run (per request)
- not run lint (per request)
