### PR TITLE
feat: accept Stellar contract addresses in SME auth validator

### DIFF
--- a/src/config/escrowMap.js
+++ b/src/config/escrowMap.js
@@ -31,7 +31,7 @@
 
 'use strict';
 
-const STELLAR_ADDRESS_RE = /^[CG][A-Z2-7]{55}$/;
+const { isValidStellarAddress } = require('../utils/stellarAddress');
 
 /**
  * Thrown when no active escrow mapping exists for an invoice ID.
@@ -95,7 +95,7 @@ function _parseConfig() {
     if (!m.invoiceId || typeof m.invoiceId !== 'string') {
       throw new EscrowMapConfigError('Each mapping must have a string invoiceId.');
     }
-    if (!m.escrowAddress || !STELLAR_ADDRESS_RE.test(m.escrowAddress)) {
+    if (!m.escrowAddress || !isValidStellarAddress(m.escrowAddress)) {
       throw new EscrowMapConfigError(
         `Mapping for ${m.invoiceId} has an invalid Stellar escrowAddress.`
       );
@@ -234,7 +234,7 @@ function resolveInvoiceByAddress(contractAddress) {
   }
 
   const address = String(contractAddress).trim();
-  if (!STELLAR_ADDRESS_RE.test(address)) {
+  if (!isValidStellarAddress(address)) {
     return null;
   }
 

--- a/src/config/escrowVersions.js
+++ b/src/config/escrowVersions.js
@@ -11,6 +11,7 @@
 
 const { callSorobanContract } = require('../services/soroban');
 const logger = require('../logger');
+const { isValidStellarContractAddress } = require('../utils/stellarAddress');
 
 /**
  * Known LiquifactEscrow deployments: semver -> SCHEMA_VERSION (u32).
@@ -25,19 +26,13 @@ const REGISTRY = {
 };
 
 /**
- * Stellar contract address pattern (C + 55 base-32 chars).
- * @type {RegExp}
- */
-const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;
-
-/**
  * Validates a Stellar contract address.
  *
  * @param {string} contractId
  * @returns {boolean}
  */
 function isValidContractId(contractId) {
-  return typeof contractId === 'string' && CONTRACT_ID_RE.test(contractId);
+  return isValidStellarContractAddress(contractId);
 }
 
 /**

--- a/src/middleware/smeAuth.js
+++ b/src/middleware/smeAuth.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const AppError = require('../errors/AppError');
-
-const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+const { isValidStellarAddress } = require('../utils/stellarAddress');
 
 /**
  * Middleware: verifies the authenticated user has a bound Stellar wallet address.
@@ -40,7 +39,7 @@ function authorizeSmeWallet(req, res, next) {
     }));
   }
 
-  if (!STELLAR_ADDRESS_RE.test(wallet)) {
+  if (!isValidStellarAddress(wallet)) {
     return next(new AppError({
       type: 'https://liquifact.com/probs/validation-error',
       title: 'Invalid Wallet Address',

--- a/src/routes/invest.js
+++ b/src/routes/invest.js
@@ -27,6 +27,7 @@ const { legalHoldGate } = require('../middleware/legalHoldGate');
 const { resolveEscrowAddress, EscrowNotFoundError } = require('../config/escrowMap');
 const { submitFundEscrow, EscrowSubmitError } = require('../services/escrowSubmit');
 const { persistCommitment } = require('../services/investorCommitment');
+const { listOpportunities } = require('../services/investService');
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { isValidStellarAddress } = require('../utils/stellarAddress');
 
@@ -97,7 +98,7 @@ router.post(
   '/fund-invoice',
   requireKycForFunding,
   idempotencyMiddleware,
-  asyncHandler(async (req, res, next) => {
+  asyncHandler(async (req, res) => {
     // 1. Input validation
     const validationErrors = validateFundInvoiceBody(req.body);
     if (validationErrors.length > 0) {
@@ -118,13 +119,17 @@ router.post(
     const gateHandler = legalHoldGate();
     await new Promise((resolve, reject) => {
       gateHandler(req, res, (err) => {
-        if (err) return reject(err);
+        if (err) {
+          return reject(err);
+        }
         resolve();
       });
     });
 
     // If the gate intercepted the response (e.g., returned a 423), stop execution processing immediately
-    if (res.headersSent) return;
+    if (res.headersSent) {
+      return;
+    }
 
     // 3. Resolve the escrow contract address
     let escrowAddress;

--- a/src/routes/invest.js
+++ b/src/routes/invest.js
@@ -28,14 +28,13 @@ const { resolveEscrowAddress, EscrowNotFoundError } = require('../config/escrowM
 const { submitFundEscrow, EscrowSubmitError } = require('../services/escrowSubmit');
 const { persistCommitment } = require('../services/investorCommitment');
 const idempotencyMiddleware = require('../middleware/idempotency');
+const { isValidStellarAddress } = require('../utils/stellarAddress');
 
 const router = express.Router();
 
 // ─── Validation helpers ───────────────────────────────────────────────────────
 
 const INVOICE_ID_RE = /^[a-zA-Z0-9_\-]{3,64}$/;
-const STELLAR_ADDRESS_RE = /^[CG][A-Z2-7]{55}$/;
-
 router.use(...authenticatedTenantStack);
 
 /**
@@ -57,7 +56,7 @@ function validateFundInvoiceBody(body) {
     errors.push('invoiceId must be an alphanumeric string (3-64 chars, hyphens/underscores allowed).');
   }
 
-  if (!investorAddress || !STELLAR_ADDRESS_RE.test(investorAddress)) {
+  if (!investorAddress || !isValidStellarAddress(investorAddress)) {
     errors.push('investorAddress must be a valid Stellar public key (G... or C...).');
   }
 

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -16,11 +16,9 @@
 'use strict';
 
 const db = require('../db/knex');
+const { isValidStellarAddress } = require('../utils/stellarAddress');
 
 const TABLE = 'investor_commitments';
-
-// Stellar public key: G or C followed by exactly 55 base-32 characters (A-Z2-7)
-const STELLAR_ADDRESS_RE = /^[CG][A-Z2-7]{55}$/;
 
 // Sane upper bound: 10^18 stroops (≈ 10 billion XLM — exceeds total supply)
 const MAX_STROOP_AMOUNT = 10n ** 18n;
@@ -109,7 +107,7 @@ function validateAddress(address) {
   if (!address || typeof address !== 'string') {
     return { valid: false, reason: 'invalid Stellar address: must be a non-empty string' };
   }
-  if (!STELLAR_ADDRESS_RE.test(address)) {
+  if (!isValidStellarAddress(address)) {
     return {
       valid: false,
       reason: 'invalid Stellar address: must start with G or C and be 56 base-32 characters',

--- a/src/services/tokenMeta.js
+++ b/src/services/tokenMeta.js
@@ -17,6 +17,10 @@
 const { createCacheStore } = require('./cacheStore');
 const { callSorobanContract } = require('./soroban');
 const logger = require('../logger');
+const {
+  isValidStellarAccountAddress,
+  isValidStellarContractAddress,
+} = require('../utils/stellarAddress');
 
 /**
  * Default TTL for token metadata cache in milliseconds (30 minutes).
@@ -52,20 +56,6 @@ const inFlightRequests = new Map();
  * @constant {RegExp}
  */
 const ASSET_CODE_PATTERN = /^[A-Z0-9]{1,12}$/;
-
-/**
- * Stellar public key pattern (G...).
- *
- * @constant {RegExp}
- */
-const STELLAR_PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/;
-
-/**
- * Soroban contract ID pattern (C...).
- *
- * @constant {RegExp}
- */
-const SOROBAN_CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
 
 /**
  * Generates a cache key for a token asset.
@@ -130,7 +120,7 @@ function validateAsset(asset) {
     if (typeof contractId !== 'string') {
       return { valid: false, reason: 'Contract ID must be a string' };
     }
-    if (!SOROBAN_CONTRACT_ID_PATTERN.test(contractId)) {
+    if (!isValidStellarContractAddress(contractId)) {
       return { valid: false, reason: 'Invalid Soroban contract ID format' };
     }
     if (issuer !== null && issuer !== undefined) {
@@ -144,7 +134,7 @@ function validateAsset(asset) {
     if (typeof issuer !== 'string') {
       return { valid: false, reason: 'Issuer must be a string' };
     }
-    if (!STELLAR_PUBLIC_KEY_PATTERN.test(issuer)) {
+    if (!isValidStellarAccountAddress(issuer)) {
       return { valid: false, reason: 'Invalid Stellar public key format for issuer' };
     }
   } else {

--- a/src/utils/stellarAddress.js
+++ b/src/utils/stellarAddress.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { StrKey } = require('@stellar/stellar-sdk');
+
+/**
+ * @fileoverview Shared Stellar StrKey address validation helpers.
+ *
+ * The Liquifact backend accepts two StrKey address families in different
+ * contexts:
+ * - Account public keys, which start with `G`
+ * - Soroban contract addresses, which start with `C`
+ *
+ * These helpers validate full StrKey values, not just a permissive prefix
+ * regex. That means the encoded payload and checksum must both be valid.
+ *
+ * @module utils/stellarAddress
+ */
+
+/**
+ * Returns whether a value is a valid Stellar account public key (`G...`).
+ *
+ * @param {unknown} value - Candidate account public key.
+ * @returns {boolean} `true` when the value is a well-formed `G...` address.
+ */
+function isValidStellarAccountAddress(value) {
+  return typeof value === 'string' && StrKey.isValidEd25519PublicKey(value);
+}
+
+/**
+ * Returns whether a value is a valid Stellar Soroban contract address (`C...`).
+ *
+ * @param {unknown} value - Candidate contract address.
+ * @returns {boolean} `true` when the value is a well-formed `C...` address.
+ */
+function isValidStellarContractAddress(value) {
+  return typeof value === 'string' && StrKey.isValidContract(value);
+}
+
+/**
+ * Returns whether a value is a valid Stellar StrKey address accepted by
+ * Liquifact in wallet/escrow contexts (`G...` account or `C...` contract).
+ *
+ * Example accepted values:
+ * - `GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
+ * - `CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
+ *
+ * Lowercase, wrong-length, whitespace-padded, mixed-prefix, and checksum-invalid
+ * strings are rejected.
+ *
+ * @param {unknown} value - Candidate Stellar account or contract address.
+ * @returns {boolean} `true` when the value is a well-formed `G...` or `C...` StrKey.
+ */
+function isValidStellarAddress(value) {
+  return isValidStellarAccountAddress(value) || isValidStellarContractAddress(value);
+}
+
+module.exports = {
+  isValidStellarAccountAddress,
+  isValidStellarContractAddress,
+  isValidStellarAddress,
+};

--- a/tests/middleware-security.test.js
+++ b/tests/middleware-security.test.js
@@ -1,11 +1,19 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');
+const { StrKey } = require('@stellar/stellar-sdk');
 
 const { createApp } = require('../src/index');
 const { parseBearerAuthorizationHeader, tokensMatch } = require('../src/middleware/auth');
+const {
+  isValidStellarAccountAddress,
+  isValidStellarContractAddress,
+  isValidStellarAddress,
+} = require('../src/utils/stellarAddress');
 
 const VALID_TOKEN = 'test-suite-token';
+const VALID_STELLAR_ACCOUNT = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 11));
+const VALID_STELLAR_CONTRACT = StrKey.encodeContract(Buffer.alloc(32, 12));
 
 /**
  * Build an Authorization header value for security middleware tests.
@@ -184,6 +192,31 @@ test('rate limiter state stays isolated between app instances', async () => {
   assert.equal(firstResponse.status, 200);
   assert.equal(limitedResponse.status, 429);
   assert.equal(isolatedResponse.status, 200);
+});
+
+test('stellar StrKey helper accepts valid account and contract addresses', () => {
+  assert.equal(isValidStellarAccountAddress(VALID_STELLAR_ACCOUNT), true);
+  assert.equal(isValidStellarContractAddress(VALID_STELLAR_CONTRACT), true);
+  assert.equal(isValidStellarAddress(VALID_STELLAR_ACCOUNT), true);
+  assert.equal(isValidStellarAddress(VALID_STELLAR_CONTRACT), true);
+});
+
+test('stellar StrKey helper rejects malformed, lowercase, and whitespace-padded values', () => {
+  const invalidValues = [
+    '',
+    null,
+    undefined,
+    VALID_STELLAR_ACCOUNT.toLowerCase(),
+    `${VALID_STELLAR_ACCOUNT} `,
+    VALID_STELLAR_ACCOUNT.slice(0, -1),
+    `X${VALID_STELLAR_ACCOUNT.slice(1)}`,
+    'G'.repeat(56),
+    'C'.repeat(56),
+  ];
+
+  for (const value of invalidValues) {
+    assert.equal(isValidStellarAddress(value), false);
+  }
 });
 
 test('auth parsing helpers normalize and compare tokens safely', () => {

--- a/tests/unit/smeAuth.test.js
+++ b/tests/unit/smeAuth.test.js
@@ -10,6 +10,7 @@
 
 const request = require('supertest');
 const express = require('express');
+const { StrKey } = require('@stellar/stellar-sdk');
 const { authorizeSmeWallet, verifyInvoiceOwner } = require('../../src/middleware/smeAuth');
 
 // ---------------------------------------------------------------------------
@@ -53,10 +54,10 @@ function injectUser(user) {
   };
 }
 
-// Valid Stellar address: G followed by 55 chars from [A-Z2-7]
-const VALID_WALLET = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
-const VALID_WALLET_2 = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
-const MALFORMED_WALLET = 'XBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'; // starts with X not G
+const VALID_WALLET = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 1));
+const VALID_WALLET_2 = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 2));
+const VALID_CONTRACT_ADDRESS = StrKey.encodeContract(Buffer.alloc(32, 3));
+const MALFORMED_WALLET = `X${VALID_WALLET.slice(1)}`; // starts with X not G/C
 const SHORT_WALLET = 'GABC2345'; // too short
 
 // ---------------------------------------------------------------------------
@@ -163,7 +164,7 @@ describe('authorizeSmeWallet — header spoofing rejection', () => {
 // ---------------------------------------------------------------------------
 
 describe('authorizeSmeWallet — Stellar address format validation', () => {
-  it('returns 400 when wallet does not start with G', async () => {
+  it('returns 400 when wallet does not start with G or C', async () => {
     const app = makeApp(
       injectUser({ id: 'user-001', walletAddress: MALFORMED_WALLET }),
       authorizeSmeWallet
@@ -202,7 +203,7 @@ describe('authorizeSmeWallet — Stellar address format validation', () => {
     expect(res.status).toBe(400);
   });
 
-  it('accepts a valid 56-character Stellar address starting with G', async () => {
+  it('accepts a valid Stellar account address starting with G', async () => {
     const app = makeApp(
       injectUser({ id: 'user-001', walletAddress: VALID_WALLET }),
       authorizeSmeWallet
@@ -212,14 +213,33 @@ describe('authorizeSmeWallet — Stellar address format validation', () => {
     expect(res.body.walletAddress).toBe(VALID_WALLET);
   });
 
-  it('accepts addresses with only uppercase letters and digits 2-7', async () => {
-    const validChars = 'G234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234567234567234567ABCDE';
+  it('accepts a valid Stellar contract address starting with C', async () => {
     const app = makeApp(
-      injectUser({ id: 'user-001', walletAddress: validChars }),
+      injectUser({ id: 'user-001', walletAddress: VALID_CONTRACT_ADDRESS }),
       authorizeSmeWallet
     );
     const res = await request(app).get('/test');
     expect(res.status).toBe(200);
+    expect(res.body.walletAddress).toBe(VALID_CONTRACT_ADDRESS);
+  });
+
+  it('returns 400 for wrong-length uppercase values that only look like StrKeys', async () => {
+    const almostValid = `${VALID_WALLET}A`;
+    const app = makeApp(
+      injectUser({ id: 'user-001', walletAddress: almostValid }),
+      authorizeSmeWallet
+    );
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for trailing whitespace on otherwise valid addresses', async () => {
+    const app = makeApp(
+      injectUser({ id: 'user-001', walletAddress: `${VALID_CONTRACT_ADDRESS} ` }),
+      authorizeSmeWallet
+    );
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(400);
   });
 });
 

--- a/wallet-auth.md
+++ b/wallet-auth.md
@@ -21,7 +21,14 @@ The binding is established using **Sign-In with Stellar (SIWS)**:
 
 The `authorizeSmeWallet` middleware ensures that:
 - The user is authenticated via JWT.
-- The user has a bound wallet address (either in their profile or provided via stub headers).
+- The user has a bound Stellar address in a valid StrKey format.
+
+Accepted address formats for SME authorization are:
+- `G...` Stellar account public keys
+- `C...` Soroban contract addresses
+
+The validator rejects malformed, lowercase, wrong-length, and whitespace-padded
+values.
 
 The `verifyInvoiceOwner` middleware ensures that:
 - The requested invoice belongs to the authenticated user (via `ownerId`) or their bound wallet (via `smeWallet`).
@@ -69,6 +76,6 @@ curl -X GET http://localhost:3001/api/sme/invoice/inv_123 \
 
 ## Security Notes
 
-- **Input Validation**: All wallet addresses are validated against Stellar's `G...` public key format.
+- **Input Validation**: All wallet addresses are validated as full Stellar StrKeys, accepting only valid `G...` account keys and `C...` contract addresses.
 - **Replay Protection**: Live SIWS implementation must use one-time nonces to prevent signature replay attacks.
 - **Privacy**: Only public keys are stored; private keys never leave the user's wallet.


### PR DESCRIPTION
Closes #423

---

## Summary
- accept valid Stellar C... contract addresses alongside G... account addresses in SME auth flows
- centralize Stellar StrKey validation in a shared helper and reuse it across related callers
- add regression coverage and wallet-auth documentation for accepted address formats and malformed-input rejection

## Testing
- not run (per request)
- not run lint (per request)
