### PR TITLE
fix(sanitization): avoid shadowing Express query getter

### DIFF
--- a/docs/request-lifecycle-middleware-order.md
+++ b/docs/request-lifecycle-middleware-order.md
@@ -23,6 +23,16 @@ Applied in this order before any route handler runs:
 
 The request ID middleware accepts a client-supplied header only when it is a non-empty string of at most 128 characters and contains only the safe characters `[A-Za-z0-9._-]`. Values with control characters, newlines, whitespace, or other disallowed bytes are rejected and replaced with a server-generated UUID. The sanitized value is then attached to `req.id`, propagated into child loggers, and echoed in the `X-Request-Id` response header.
 
+## Input sanitization contract
+
+The input sanitization middleware normalizes request bodies, route params, and
+query values before downstream handlers consume them. Express 5 exposes
+`req.query` as a getter-only framework property, so the middleware sanitizes
+query values by wrapping the app-level query parser instead of installing an own
+`query` property on each request. Route params remain guarded with a sanitized
+request-owned accessor because Express can assign `req.params` after global
+middleware runs during route matching.
+
 ## Inline routes (defined on `app` directly)
 
 Health probes (`/health`, `/healthz`, `/ready`, `/readyz`), API info (`/api`),

--- a/src/middleware/sanitizeInput.js
+++ b/src/middleware/sanitizeInput.js
@@ -1,10 +1,14 @@
 const { sanitizeValue } = require('../utils/sanitization');
 
+const QUERY_PARSER_SANITIZED = Symbol('liquifact.queryParserSanitized');
+
 /**
  * Express middleware that sanitizes common user-supplied input containers.
  *
- * The middleware mutates request references with sanitized copies so downstream
- * handlers always receive normalized values.
+ * The middleware avoids shadowing framework-owned accessors such as Express 5's
+ * getter-only `req.query`. Query values are sanitized by wrapping the app query
+ * parser, while request-owned fields use guarded accessors so later framework
+ * assignments are sanitized before handlers read them.
  *
  * @param {import('express').Request} req Express request.
  * @param {import('express').Response} _res Express response.
@@ -12,55 +16,220 @@ const { sanitizeValue } = require('../utils/sanitization');
  * @returns {void}
  */
 function sanitizeInput(req, _res, next) {
-  req.body = sanitizeValue(req.body);
-
-  let sanitizedQuery = sanitizeValue(req.query);
-  Object.defineProperty(req, 'query', {
-    configurable: true,
-    enumerable: true,
-    /**
-     * Gets the sanitized query object.
-     *
-     * @returns {object} Sanitized query object.
-     */
-    get() {
-      return sanitizedQuery;
-    },
-    /**
-     * Re-sanitizes the query object when Express reassigns it.
-     *
-     * @param {object} value New query object.
-     * @returns {void}
-     */
-    set(value) {
-      sanitizedQuery = sanitizeValue(value);
-    },
-  });
-
-  let sanitizedParams = sanitizeValue(req.params);
-  Object.defineProperty(req, 'params', {
-    configurable: true,
-    enumerable: true,
-    /**
-     * Gets sanitized route params.
-     *
-     * @returns {object} Sanitized params.
-     */
-    get() {
-      return sanitizedParams;
-    },
-    /**
-     * Re-sanitizes route params when Express updates them.
-     *
-     * @param {object} value New params object.
-     * @returns {void}
-     */
-    set(value) {
-      sanitizedParams = sanitizeValue(value);
-    },
-  });
+  assignSanitizedValue(req, 'body');
+  sanitizeQuery(req);
+  installSanitizedAccessor(req, 'params');
 
   next();
+}
+
+/**
+ * Sanitizes a request field by assigning a sanitized copy when possible.
+ *
+ * @param {object} req Express request or request-like object.
+ * @param {string} field Field name.
+ * @returns {void}
+ */
+function assignSanitizedValue(req, field) {
+  const sanitizedValue = sanitizeValue(readRequestField(req, field));
+
+  try {
+    req[field] = sanitizedValue;
+  } catch (_error) {
+    defineSanitizedFallback(req, `sanitized${capitalize(field)}`, sanitizedValue);
+  }
+}
+
+/**
+ * Sanitizes query values without redefining Express 5's getter-only `req.query`.
+ *
+ * Express 5 reparses query strings through the app-level parser whenever
+ * `req.query` is read. Wrapping that parser keeps downstream reads sanitized and
+ * avoids installing an own `query` property on the request. Plain request-like
+ * test doubles still receive a guarded accessor so reassignment stays sanitized.
+ *
+ * @param {import('express').Request|object} req Express request or test double.
+ * @returns {void}
+ */
+function sanitizeQuery(req) {
+  const descriptor = findPropertyDescriptor(req, 'query');
+
+  if (isGetterOnlyPrototypeProperty(req, descriptor) && wrapExpressQueryParser(req)) {
+    defineSanitizedFallback(req, 'sanitizedQuery', readRequestField(req, 'query'));
+    return;
+  }
+
+  if (isGetterOnlyPrototypeProperty(req, descriptor)) {
+    defineSanitizedFallback(req, 'sanitizedQuery', sanitizeValue(readRequestField(req, 'query')));
+    return;
+  }
+
+  installSanitizedAccessor(req, 'query');
+}
+
+/**
+ * Installs a guarded accessor for request-owned fields that can be reassigned
+ * later by Express, such as `req.params` during route matching.
+ *
+ * @param {object} req Express request or request-like object.
+ * @param {string} field Field name.
+ * @returns {void}
+ */
+function installSanitizedAccessor(req, field) {
+  let sanitizedValue = sanitizeValue(readRequestField(req, field));
+  const descriptor = findPropertyDescriptor(req, field);
+
+  if (descriptor && descriptor.configurable === false) {
+    assignSanitizedValue(req, field);
+    return;
+  }
+
+  try {
+    Object.defineProperty(req, field, {
+      configurable: true,
+      enumerable: descriptor ? descriptor.enumerable : true,
+      /**
+       * Gets the sanitized request value.
+       *
+       * @returns {*} Sanitized value.
+       */
+      get() {
+        return sanitizedValue;
+      },
+      /**
+       * Re-sanitizes later assignments before downstream handlers read them.
+       *
+       * @param {*} value New request value.
+       * @returns {void}
+       */
+      set(value) {
+        sanitizedValue = sanitizeValue(value);
+      },
+    });
+  } catch (_error) {
+    assignSanitizedValue(req, field);
+  }
+}
+
+/**
+ * Wraps the Express app's query parser once so `req.query` stays sanitized
+ * without replacing the getter on individual requests.
+ *
+ * @param {import('express').Request|object} req Express request or test double.
+ * @returns {boolean} True when the parser was present or already wrapped.
+ */
+function wrapExpressQueryParser(req) {
+  if (
+    !req.app ||
+    !req.app.locals ||
+    typeof req.app.get !== 'function' ||
+    typeof req.app.set !== 'function'
+  ) {
+    return false;
+  }
+
+  if (req.app.locals[QUERY_PARSER_SANITIZED]) {
+    return true;
+  }
+
+  const queryParser = req.app.get('query parser fn');
+
+  if (typeof queryParser !== 'function') {
+    return false;
+  }
+
+  const sanitizedQueryParser = (queryString) => sanitizeValue(queryParser(queryString));
+  req.app.set('query parser fn', sanitizedQueryParser);
+  req.app.locals[QUERY_PARSER_SANITIZED] = true;
+
+  return true;
+}
+
+/**
+ * Reads a request field without letting getter-only framework properties abort
+ * sanitization.
+ *
+ * @param {object} req Express request or request-like object.
+ * @param {string} field Field name.
+ * @returns {*} Field value, or undefined when the getter throws.
+ */
+function readRequestField(req, field) {
+  try {
+    return req[field];
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+/**
+ * Finds the effective property descriptor for a request field.
+ *
+ * @param {object} target Request object.
+ * @param {string} field Field name.
+ * @returns {PropertyDescriptor|undefined} Property descriptor when present.
+ */
+function findPropertyDescriptor(target, field) {
+  let current = target;
+
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, field);
+
+    if (descriptor) {
+      return descriptor;
+    }
+
+    current = Object.getPrototypeOf(current);
+  }
+
+  return undefined;
+}
+
+/**
+ * Detects framework getter-only properties inherited from the request prototype.
+ *
+ * @param {object} req Express request or request-like object.
+ * @param {PropertyDescriptor|undefined} descriptor Effective descriptor.
+ * @returns {boolean} True when the property is an inherited getter without setter.
+ */
+function isGetterOnlyPrototypeProperty(req, descriptor) {
+  return Boolean(
+    descriptor &&
+      typeof descriptor.get === 'function' &&
+      typeof descriptor.set !== 'function' &&
+      !Object.prototype.hasOwnProperty.call(req, 'query')
+  );
+}
+
+/**
+ * Stores a sanitized fallback on a dedicated property when a framework-owned
+ * field cannot be assigned safely.
+ *
+ * @param {object} req Express request or request-like object.
+ * @param {string} field Fallback field name.
+ * @param {*} value Sanitized value.
+ * @returns {void}
+ */
+function defineSanitizedFallback(req, field, value) {
+  try {
+    Object.defineProperty(req, field, {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: sanitizeValue(value),
+    });
+  } catch (_error) {
+    // Some test doubles may be frozen. Fallback storage is best-effort only.
+  }
+}
+
+/**
+ * Capitalizes a field name for fallback-property construction.
+ *
+ * @param {string} value Field name.
+ * @returns {string} Capitalized field name.
+ */
+function capitalize(value) {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
 }
 
 module.exports = {

--- a/src/middleware/sanitizeInput.test.js
+++ b/src/middleware/sanitizeInput.test.js
@@ -12,6 +12,10 @@ function buildApp() {
   return app;
 }
 
+function hasOwn(object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}
+
 describe('sanitizeInput middleware', () => {
   it('sanitizes params, query, and body before handlers run', async () => {
     const res = await request(buildApp())
@@ -70,6 +74,188 @@ describe('sanitizeInput middleware', () => {
 
     expect(req.query).toEqual({ search: 'hello' });
     expect({}.bad).toBeUndefined();
+  });
+
+  it('sanitizes Express 5 getter-only query values without shadowing req.query', async () => {
+    const app = express();
+
+    app.use(sanitizeInput);
+    app.get('/query', (req, res) => {
+      res.json({
+        hasOwnQuery: hasOwn(req, 'query'),
+        query: req.query,
+        sanitizedQuery: req.sanitizedQuery,
+      });
+    });
+
+    const res = await request(app).get('/query?search=%20hello%00%20&tag=%20a&tag=%09b');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      hasOwnQuery: false,
+      query: { search: 'hello', tag: ['a', 'b'] },
+      sanitizedQuery: { search: 'hello', tag: ['a', 'b'] },
+    });
+
+    const secondRes = await request(app).get('/query?search=%20again%00%20');
+
+    expect(secondRes.status).toBe(200);
+    expect(secondRes.body).toEqual({
+      hasOwnQuery: false,
+      query: { search: 'again' },
+      sanitizedQuery: { search: 'again' },
+    });
+  });
+
+  it('falls back to sanitizedQuery for getter-only query test doubles without redefining query', () => {
+    const proto = {};
+    Object.defineProperty(proto, 'query', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return {
+          search: '  hello\u0000  ',
+          constructor: 'drop',
+          nested: { note: '\u0000keep  me' },
+        };
+      },
+    });
+
+    const req = Object.create(proto);
+    req.body = {};
+    req.params = {};
+    const next = jest.fn();
+
+    expect(() => sanitizeInput(req, {}, next)).not.toThrow();
+
+    expect(hasOwn(req, 'query')).toBe(false);
+    expect(req.sanitizedQuery).toEqual({ search: 'hello', nested: { note: 'keep me' } });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses sanitizedQuery when the Express query parser is disabled', () => {
+    const proto = {};
+    Object.defineProperty(proto, 'query', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return { search: '  raw\u0000  ' };
+      },
+    });
+
+    const req = Object.create(proto);
+    req.app = {
+      locals: {},
+      get: jest.fn(() => false),
+      set: jest.fn(),
+    };
+    req.body = {};
+    req.params = {};
+    const next = jest.fn();
+
+    sanitizeInput(req, {}, next);
+
+    expect(req.sanitizedQuery).toEqual({ search: 'raw' });
+    expect(req.app.set).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues when a getter-only query throws', () => {
+    const proto = {};
+    Object.defineProperty(proto, 'query', {
+      configurable: true,
+      get() {
+        throw new Error('query read failed');
+      },
+    });
+
+    const req = Object.create(proto);
+    req.body = {};
+    req.params = {};
+    const next = jest.fn();
+
+    expect(() => sanitizeInput(req, {}, next)).not.toThrow();
+
+    expect(req.sanitizedQuery).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to dedicated storage when body assignment throws', () => {
+    const req = { query: {}, params: {} };
+    Object.defineProperty(req, 'body', {
+      configurable: true,
+      get() {
+        return { note: '  dirty\u0000 value  ' };
+      },
+      set() {
+        throw new Error('body assignment failed');
+      },
+    });
+    const next = jest.fn();
+
+    sanitizeInput(req, {}, next);
+
+    expect(req.sanitizedBody).toEqual({ note: 'dirty value' });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to dedicated storage when an accessor cannot be installed', () => {
+    const target = { body: {}, query: {}, params: { invoiceId: '  inv\u0000-4  ' } };
+    const req = new Proxy(target, {
+      defineProperty(proxiedTarget, property, descriptor) {
+        if (property === 'params') {
+          throw new Error('params accessor failed');
+        }
+
+        return Reflect.defineProperty(proxiedTarget, property, descriptor);
+      },
+    });
+    const next = jest.fn();
+
+    sanitizeInput(req, {}, next);
+
+    expect(req.sanitizedParams).toEqual({ invoiceId: 'inv-4' });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('installs sanitized accessors when query and params are initially absent', () => {
+    const req = { body: {} };
+    const next = jest.fn();
+
+    sanitizeInput(req, {}, next);
+    req.query = { search: '  clean\u0000 me  ' };
+    req.params = { invoiceId: '  inv\u0000-5  ' };
+
+    expect(req.query).toEqual({ search: 'clean me' });
+    expect(req.params).toEqual({ invoiceId: 'inv-5' });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when request fields are non-writable', () => {
+    const req = {};
+
+    Object.defineProperty(req, 'body', {
+      configurable: false,
+      value: { note: '  dirty\u0000  ' },
+      writable: false,
+    });
+    Object.defineProperty(req, 'query', {
+      configurable: false,
+      get() {
+        return { search: '  dirty\u0000  ' };
+      },
+    });
+    Object.defineProperty(req, 'params', {
+      configurable: false,
+      value: { invoiceId: '  inv\u0000-1  ' },
+      writable: false,
+    });
+    Object.freeze(req);
+
+    const next = jest.fn();
+
+    expect(() => sanitizeInput(req, {}, next)).not.toThrow();
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it('handles empty body and query gracefully', async () => {


### PR DESCRIPTION
## Summary

Fixes #511.

- sanitizes Express 5 `req.query` values by wrapping the app query parser instead of installing an own `query` property on each request
- keeps request-owned `query` test doubles and `params` assignments guarded so later reassignment is sanitized before handlers read it
- documents the Express 5 query handling contract in the request lifecycle notes
- expands middleware tests for getter-only query, disabled query parser, nested values, arrays, prototype-pollution keys, reassignment, and defensive fallback paths

## Security notes

The prior middleware shadowed `req.query` with `Object.defineProperty`, which is fragile with Express 5's getter-only query property. This change leaves the framework getter intact, wraps the parser output with the existing `sanitizeValue` helper, and still removes prototype-pollution keys plus control characters before downstream handlers consume query, params, or body values.

## Validation

- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
  - used because `npm ci --ignore-scripts --no-audit --no-fund` fails before install due the existing package-lock/package.json mismatch
- `npm test -- --runInBand src/middleware/sanitizeInput.test.js`
  - passed, 14 tests
- `npm test -- --runInBand src/middleware/sanitizeInput.test.js --coverage --collectCoverageFrom=src/middleware/sanitizeInput.js --coverageThreshold={}`
  - passed, 100 percent statements, branches, functions, and lines for `src/middleware/sanitizeInput.js`
- `npx eslint src/middleware/sanitizeInput.js src/middleware/sanitizeInput.test.js`
  - passed
- `git diff --check`
  - passed

## Full-suite baseline status

`npm test` was also run. It is currently blocked by unrelated baseline failures outside this patch. The Jest summary was:

```text
Test Suites: 86 failed, 1 skipped, 42 passed, 128 of 129 total
Tests:       265 failed, 5 skipped, 950 passed, 1220 total
```

Representative blockers from the full output:

```text
FAIL tests/invoice.state.test.js
TypeError: Cannot read properties of undefined (reading 'REJECTED')

FAIL src/workers/jobWorker.test.js
SyntaxError: src/metrics.js: Identifier 'registerJobQueue' has already been declared. (846:9)

FAIL tests/rateLimit.redis.test.js
Cannot find module 'mocha' from 'tests/rateLimit.redis.test.js'

FAIL tests/e2e/smoke.test.js
AggregateError
```

`npm run lint` was also run and is blocked by unrelated existing repo-wide lint failures. Touched-file lint passes. The repo-wide summary was:

```text
93 problems (85 errors, 8 warnings)
```
