### PR TITLE
fix(security): enforce body limits for chunked requests

### DIFF
--- a/docs/request-lifecycle-middleware-order.md
+++ b/docs/request-lifecycle-middleware-order.md
@@ -23,6 +23,17 @@ Applied in this order before any route handler runs:
 
 The request ID middleware accepts a client-supplied header only when it is a non-empty string of at most 128 characters and contains only the safe characters `[A-Za-z0-9._-]`. Values with control characters, newlines, whitespace, or other disallowed bytes are rejected and replaced with a server-generated UUID. The sanitized value is then attached to `req.id`, propagated into child loggers, and echoed in the `X-Request-Id` response header.
 
+## Body Size Limits
+
+The JSON, URL-encoded, and invoice body guards reject requests early when a
+trustworthy `Content-Length` declares a body larger than the configured limit.
+Requests without a valid `Content-Length`, including `Transfer-Encoding:
+chunked`, are not treated as zero-byte bodies. They continue into the Express
+body parser, which enforces the same byte cap without buffering beyond its
+configured limit. Parser-raised 413 responses reuse the guard's stored limit
+context so `bodySizeLimitRejectionsTotal` keeps the correct `json`,
+`urlencoded`, or `invoice` label.
+
 ## Inline routes (defined on `app` directly)
 
 Health probes (`/health`, `/healthz`, `/ready`, `/readyz`), API info (`/api`),

--- a/src/__tests__/bodySizeLimits.test.js
+++ b/src/__tests__/bodySizeLimits.test.js
@@ -14,8 +14,20 @@
 
 'use strict';
 
+const http = require('http');
 const request = require('supertest');
 const express = require('express');
+
+const mockBodySizeLimitRejectionsTotal = {
+  inc: jest.fn(),
+  labels: jest.fn((type) => ({
+    inc: () => mockBodySizeLimitRejectionsTotal.inc({ type }),
+  })),
+};
+
+jest.mock('../metrics', () => ({
+  bodySizeLimitRejectionsTotal: mockBodySizeLimitRejectionsTotal,
+}));
 
 const {
   DEFAULT_LIMITS,
@@ -62,6 +74,63 @@ function makeJsonBody(targetBytes) {
  */
 function makeUrlencodedBody(targetBytes) {
   return `data=${'x'.repeat(Math.max(0, targetBytes - 5))}`;
+}
+
+/**
+ * Sends an HTTP/1.1 chunked POST without a Content-Length header.
+ *
+ * @param {import('express').Application} app
+ * @param {object} options
+ * @param {string} [options.path='/test']
+ * @param {string} options.contentType
+ * @param {string} options.body
+ * @returns {Promise<{ status: number, body: object, text: string }>}
+ */
+function postChunked(app, { path = '/test', contentType, body }) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const req = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          method: 'POST',
+          path,
+          headers: {
+            'Content-Type': contentType,
+            'Transfer-Encoding': 'chunked',
+          },
+        },
+        (res) => {
+          let text = '';
+
+          res.setEncoding('utf8');
+          res.on('data', (chunk) => {
+            text += chunk;
+          });
+          res.on('end', () => {
+            server.close(() => {
+              resolve({
+                status: res.statusCode,
+                body: text ? JSON.parse(text) : {},
+                text,
+              });
+            });
+          });
+        }
+      );
+
+      req.on('error', (error) => {
+        server.close(() => reject(error));
+      });
+
+      const splitAt = Math.max(1, Math.floor(body.length / 2));
+      req.write(body.slice(0, splitAt));
+      req.end(body.slice(splitAt));
+    });
+
+    server.on('error', reject);
+  });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -225,6 +294,16 @@ describe('jsonBodyLimit()', () => {
     handlers.forEach((h) => expect(typeof h).toBe('function'));
   });
 
+  it('uses the default JSON limit when no override is provided', async () => {
+    const defaultApp = buildApp(jsonBodyLimit());
+    const res = await request(defaultApp)
+      .post('/test')
+      .set('Content-Type', 'application/json')
+      .send(makeJsonBody(512));
+
+    expect(res.status).toBe(200);
+  });
+
   it('first handler is the named pre-flight guard', () => {
     const [guard] = jsonBodyLimit('100kb');
     expect(guard.name).toBe('jsonSizeGuard');
@@ -319,6 +398,47 @@ describe('jsonBodyLimit()', () => {
     expect(res.status).toBe(200);
   });
 
+  it('delegates malformed Content-Length values to the parser limit', () => {
+    const [guard] = jsonBodyLimit(LIMIT);
+    const next = jest.fn();
+
+    guard({ headers: { 'content-length': 'not-a-number' } }, {}, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates negative Content-Length values to the parser limit', () => {
+    const [guard] = jsonBodyLimit(LIMIT);
+    const next = jest.fn();
+
+    guard({ headers: { 'content-length': '-1' } }, {}, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts under-limit chunked JSON without a Content-Length header', async () => {
+    const res = await postChunked(app, {
+      contentType: 'application/json',
+      body: makeJsonBody(512),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.received).toBeDefined();
+  });
+
+  it('rejects oversized chunked JSON without a Content-Length header', async () => {
+    const res = await postChunked(app, {
+      contentType: 'application/json',
+      body: makeJsonBody(2048),
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({
+      error: 'Payload Too Large',
+      path: '/test',
+    });
+  });
+
   // ── Parser behaviour ──────────────────────────────────────────────────
 
   it('returns 400 for malformed JSON', async () => {
@@ -362,6 +482,16 @@ describe('urlencodedBodyLimit()', () => {
     expect(handlers).toHaveLength(2);
   });
 
+  it('uses the default URL-encoded limit when no override is provided', async () => {
+    const defaultApp = buildApp(urlencodedBodyLimit());
+    const res = await request(defaultApp)
+      .post('/test')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(makeUrlencodedBody(128));
+
+    expect(res.status).toBe(200);
+  });
+
   it('first handler is the named pre-flight guard', () => {
     const [guard] = urlencodedBodyLimit('50kb');
     expect(guard.name).toBe('urlencodedSizeGuard');
@@ -383,6 +513,19 @@ describe('urlencodedBodyLimit()', () => {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send(makeUrlencodedBody(200));
     expect(res.status).toBe(200);
+  });
+
+  it('rejects oversized chunked URL-encoded bodies without a Content-Length header', async () => {
+    const res = await postChunked(app, {
+      contentType: 'application/x-www-form-urlencoded',
+      body: makeUrlencodedBody(2048),
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({
+      error: 'Payload Too Large',
+      path: '/test',
+    });
   });
 
   it('allows Content-Length 1 byte under the limit', async () => {
@@ -494,6 +637,19 @@ describe('invoiceBodyLimit()', () => {
       .set('Content-Type', 'application/json')
       .send(makeJsonBody(3 * 1024));
     expect(res.status).toBe(413);
+  });
+
+  it('rejects oversized chunked invoice JSON without a Content-Length header', async () => {
+    const res = await postChunked(appCustom, {
+      contentType: 'application/json',
+      body: makeJsonBody(3 * 1024),
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({
+      error: 'Payload Too Large',
+      path: '/test',
+    });
   });
 
   it('413 response includes path and limit fields', async () => {
@@ -653,6 +809,7 @@ describe('bodySizeLimitRejectionsTotal metric', () => {
   beforeEach(() => {
     // Spy on the counter's .inc() method to track invocations
     metricSpy = jest.spyOn(bodySizeLimitRejectionsTotal, 'inc');
+    bodySizeLimitRejectionsTotal.labels.mockClear();
   });
 
   afterEach(() => {
@@ -686,6 +843,31 @@ describe('bodySizeLimitRejectionsTotal metric', () => {
     expect(metricSpy).toHaveBeenCalledWith({ type: 'json' });
   });
 
+  it('increments metric with type "json" on oversized chunked JSON body rejection', async () => {
+    const app = buildApp(jsonBodyLimit('1kb'));
+
+    const res = await postChunked(app, {
+      contentType: 'application/json',
+      body: makeJsonBody(2048),
+    });
+
+    expect(res.status).toBe(413);
+    expect(metricSpy).toHaveBeenCalledWith({ type: 'json' });
+  });
+
+  it('keeps the legacy invoice label when jsonBodyLimit receives the invoice default', async () => {
+    const app = buildApp(jsonBodyLimit(DEFAULT_LIMITS.invoice));
+
+    const res = await request(app)
+      .post('/test')
+      .set('Content-Type', 'application/json')
+      .set('Content-Length', String(parseSize(DEFAULT_LIMITS.invoice) + 1))
+      .send('{}');
+
+    expect(res.status).toBe(413);
+    expect(metricSpy).toHaveBeenCalledWith({ type: 'invoice' });
+  });
+
   // ── Pre-flight guard: URL-encoded ─────────────────────────────────────
 
   it('increments metric with type "urlencoded" on oversized URL-encoded pre-flight', async () => {
@@ -711,6 +893,30 @@ describe('bodySizeLimitRejectionsTotal metric', () => {
 
     expect(res.status).toBe(413);
     expect(metricSpy).toHaveBeenCalledWith({ type: 'urlencoded' });
+  });
+
+  it('increments metric with type "urlencoded" on oversized chunked URL-encoded rejection', async () => {
+    const app = buildApp(urlencodedBodyLimit('1kb'));
+
+    const res = await postChunked(app, {
+      contentType: 'application/x-www-form-urlencoded',
+      body: makeUrlencodedBody(2048),
+    });
+
+    expect(res.status).toBe(413);
+    expect(metricSpy).toHaveBeenCalledWith({ type: 'urlencoded' });
+  });
+
+  it('increments metric with type "invoice" on oversized chunked invoice rejection', async () => {
+    const app = buildApp(invoiceBodyLimit('1kb'));
+
+    const res = await postChunked(app, {
+      contentType: 'application/json',
+      body: makeJsonBody(2048),
+    });
+
+    expect(res.status).toBe(413);
+    expect(metricSpy).toHaveBeenCalledWith({ type: 'invoice' });
   });
 
   // ── PayloadTooLargeHandler: derives from content-type ────────────────

--- a/src/middleware/bodySizeLimits.js
+++ b/src/middleware/bodySizeLimits.js
@@ -13,6 +13,8 @@
 const express = require('express');
 const { bodySizeLimitRejectionsTotal } = require('../metrics');
 
+const BODY_LIMIT_CONTEXT = Symbol('liquifact.bodyLimitContext');
+
 /**
  * Default byte limits for each body content type.
  * Values are intentionally conservative to prevent abuse.
@@ -71,11 +73,11 @@ function parseSize(sizeStr) {
  * @param {import('express').Request}  req  - Express request object.
  * @param {import('express').Response} res  - Express response object.
  * @param {string} limit - The human-readable size limit that was exceeded.
+ * @param {string} type - Metric label for the body limit that rejected the request.
  * @returns {void}
  */
 function sendPayloadTooLarge(req, res, limit, type) {
-  const limitType = type || 'unknown';
-  bodySizeLimitRejectionsTotal.labels(limitType).inc();
+  bodySizeLimitRejectionsTotal.labels(type).inc();
 
   res.status(413).json({
     error: 'Payload Too Large',
@@ -85,19 +87,6 @@ function sendPayloadTooLarge(req, res, limit, type) {
   });
 }
 
-/**
- * Creates a JSON body parser middleware with an explicit size limit.
- *
- * The middleware sets `strict: true` so only JSON objects and arrays
- * are accepted (primitive root values are rejected).
- *
- * @param {string} [limit=DEFAULT_LIMITS.json] - Maximum allowed body size.
- * @returns {import('express').RequestHandler[]} Array of two handlers:
- *   the express body parser and a size-validation guard.
- *
- * @example
- * app.use(jsonBodyLimit('200kb'));
- */
 /**
  * Determines the limit type label for metrics from the body parser type.
  * Used to distinguish between `json`, `urlencoded`, and `invoice` limit types.
@@ -114,10 +103,106 @@ function resolveLimitType(parserType, resolvedLimit) {
   return parserType;
 }
 
-function jsonBodyLimit(limit) {
+/**
+ * Stores body-limit metadata on the request so parser-raised size errors keep
+ * the same metric label as pre-flight rejections.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {string} limit - Human-readable limit string.
+ * @param {string} type - Metric label for the active body limit.
+ * @returns {void}
+ */
+function setBodyLimitContext(req, limit, type) {
+  req[BODY_LIMIT_CONTEXT] = { limit, type };
+}
+
+/**
+ * Reads body-limit metadata captured by the pre-parser guard.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {{ limit: string, type: string }|undefined} Stored context.
+ */
+function getBodyLimitContext(req) {
+  return req[BODY_LIMIT_CONTEXT];
+}
+
+/**
+ * Parses a trustworthy Content-Length value.
+ *
+ * Missing, repeated, negative, decimal, or malformed values return null so the
+ * downstream parser limit remains authoritative instead of treating the body as
+ * zero bytes.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {number|null} Declared byte length, or null when absent or invalid.
+ */
+function getDeclaredContentLength(req) {
+  const rawContentLength = req.headers && req.headers['content-length'];
+
+  if (typeof rawContentLength !== 'string' || rawContentLength.trim() === '') {
+    return null;
+  }
+
+  const declaredLength = Number(rawContentLength);
+
+  if (!Number.isInteger(declaredLength) || declaredLength < 0) {
+    return null;
+  }
+
+  return declaredLength;
+}
+
+/**
+ * Applies the shared body-size pre-flight behavior for parser middleware.
+ *
+ * Requests without a valid Content-Length, including chunked transfer bodies,
+ * are not assumed to be zero bytes. The parser still enforces the configured
+ * byte cap, and the stored context preserves the correct 413 metric label.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @param {number} maxBytes - Maximum allowed bytes.
+ * @param {string} resolvedLimit - Human-readable limit string.
+ * @param {string} limitType - Metric label for this body limit.
+ * @returns {void}
+ */
+function enforceDeclaredBodyLimit(req, res, next, maxBytes, resolvedLimit, limitType) {
+  setBodyLimitContext(req, resolvedLimit, limitType);
+
+  const contentLength = getDeclaredContentLength(req);
+
+  if (contentLength === null) {
+    next();
+    return;
+  }
+
+  if (contentLength > maxBytes) {
+    sendPayloadTooLarge(req, res, resolvedLimit, limitType);
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Creates a JSON body parser middleware with an explicit size limit.
+ *
+ * The middleware sets `strict: true` so only JSON objects and arrays
+ * are accepted (primitive root values are rejected).
+ *
+ * @param {string} [limit=DEFAULT_LIMITS.json] - Maximum allowed body size.
+ * @param {string} [typeOverride] - Optional metric label override.
+ * @returns {import('express').RequestHandler[]} Array of two handlers:
+ *   the express body parser and a size-validation guard.
+ *
+ * @example
+ * app.use(jsonBodyLimit('200kb'));
+ */
+function jsonBodyLimit(limit, typeOverride) {
   const resolvedLimit = limit || DEFAULT_LIMITS.json;
   const maxBytes = parseSize(resolvedLimit);
-  const limitType = resolveLimitType('json', resolvedLimit);
+  const limitType = typeOverride || resolveLimitType('json', resolvedLimit);
 
   return [
     /**
@@ -130,11 +215,7 @@ function jsonBodyLimit(limit) {
      * @returns {void}
      */
     function jsonSizeGuard(req, res, next) {
-      const contentLength = parseInt(req.headers['content-length'] || '0', 10);
-      if (!isNaN(contentLength) && contentLength > maxBytes) {
-        return sendPayloadTooLarge(req, res, resolvedLimit, limitType);
-      }
-      next();
+      enforceDeclaredBodyLimit(req, res, next, maxBytes, resolvedLimit, limitType);
     },
     express.json({ limit: resolvedLimit, strict: true }),
   ];
@@ -164,31 +245,12 @@ function urlencodedBodyLimit(limit) {
      * @returns {void}
      */
     function urlencodedSizeGuard(req, res, next) {
-      const contentLength = parseInt(req.headers['content-length'] || '0', 10);
-      if (!isNaN(contentLength) && contentLength > maxBytes) {
-        return sendPayloadTooLarge(req, res, resolvedLimit, 'urlencoded');
-      }
-      next();
+      enforceDeclaredBodyLimit(req, res, next, maxBytes, resolvedLimit, 'urlencoded');
     },
     express.urlencoded({ limit: resolvedLimit, extended: false }),
   ];
 }
 
-/**
- * Express error-handling middleware that converts body-parser's
- * `PayloadTooLargeError` into a clean 413 JSON response.
- *
- * Mount this **after** all routes so it catches errors bubbled via `next(err)`.
- *
- * @param {Error}                          err
- * @param {import('express').Request}      req
- * @param {import('express').Response}     res
- * @param {import('express').NextFunction} next
- * @returns {void}
- *
- * @example
- * app.use(payloadTooLargeHandler);
- */
 /**
  * Derives the limit type label from the request's content-type header for
  * metrics emitted by the error handler. Content-type headers are
@@ -200,15 +262,35 @@ function urlencodedBodyLimit(limit) {
  */
 function deriveLimitTypeFromContentType(req) {
   const ct = (req.headers && req.headers['content-type']) || '';
-  if (ct.startsWith('application/json')) return 'json';
-  if (ct.startsWith('application/x-www-form-urlencoded')) return 'urlencoded';
+  if (ct.startsWith('application/json')) {
+    return 'json';
+  }
+  if (ct.startsWith('application/x-www-form-urlencoded')) {
+    return 'urlencoded';
+  }
   return 'unknown';
 }
 
+/**
+ * Express error-handling middleware that converts body-parser's
+ * `PayloadTooLargeError` into a clean 413 JSON response.
+ *
+ * Mount this **after** all routes so it catches errors bubbled via `next(err)`.
+ *
+ * @param {Error} err - Body parser or application error.
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @returns {void}
+ *
+ * @example
+ * app.use(payloadTooLargeHandler);
+ */
 function payloadTooLargeHandler(err, req, res, next) {
   if (err.type === 'entity.too.large') {
+    const limitContext = getBodyLimitContext(req);
     const limitValue = typeof err.limit === 'number' ? `${err.limit}b` : 'unknown';
-    const limitType = deriveLimitTypeFromContentType(req);
+    const limitType = limitContext ? limitContext.type : deriveLimitTypeFromContentType(req);
 
     bodySizeLimitRejectionsTotal.labels(limitType).inc();
 
@@ -235,7 +317,7 @@ function payloadTooLargeHandler(err, req, res, next) {
  * router.post('/invoices', ...invoiceBodyLimit(), invoiceHandler);
  */
 function invoiceBodyLimit(limit) {
-  return jsonBodyLimit(limit || DEFAULT_LIMITS.invoice);
+  return jsonBodyLimit(limit || DEFAULT_LIMITS.invoice, 'invoice');
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

Fixes #512.

- stops treating missing or invalid `Content-Length` as a zero-byte body
- keeps the fast pre-flight 413 path for trustworthy oversized `Content-Length` values
- lets chunked and no-length bodies flow into the configured Express parser limit without buffering beyond that cap
- stores body-limit context before parsing so parser-raised 413 responses keep the correct `json`, `urlencoded`, or `invoice` metric label
- fixes custom `invoiceBodyLimit(...)` metric labeling so invoice routes remain labeled `invoice`
- adds real chunked HTTP tests plus malformed and negative `Content-Length` coverage
- documents the chunked/no-length behavior in the request lifecycle notes

## Security notes

The old guard parsed a missing `Content-Length` as `0`, which made chunked requests look under limit at the pre-flight stage. The parser still enforced a cap, but parser-raised rejections could lose the intended body-limit label, especially for invoice limits. This patch records the active body-limit context before parsing and explicitly delegates absent, malformed, decimal, or negative `Content-Length` values to the parser limit instead of assuming zero bytes.

## Validation

- `npm test -- --runInBand src/__tests__/bodySizeLimits.test.js`
  - passed, 114 tests
- `npm test -- --runInBand src/__tests__/bodySizeLimits.test.js --coverage --collectCoverageFrom=src/middleware/bodySizeLimits.js --coverageThreshold={}`
  - passed, 100 percent statements, branches, functions, and lines for `src/middleware/bodySizeLimits.js`
- `npx eslint src/middleware/bodySizeLimits.js src/__tests__/bodySizeLimits.test.js`
  - passed
- `git diff --check`
  - passed

## Full-suite baseline status

`npm test` was also run. It is currently blocked by unrelated baseline failures outside this patch. The Jest summary was:

```text
Test Suites: 85 failed, 1 skipped, 43 passed, 128 of 129 total
Tests:       265 failed, 5 skipped, 1061 passed, 1331 total
```

Representative blockers from the full output:

```text
FAIL tests/auditLogStore.streaming.test.js
CSV formula-injection expectation failures and an upstream-error propagation timeout.

FAIL tests/shutdown.test.js
Graceful shutdown expectation and timeout failures.

FAIL tests/invoiceFile.upload.test.js
PDF upload route expected 201 but returned 500 in several cases.

FAIL tests/idempotency.test.js
Cannot find module '../middleware/idempotency'.

FAIL tests/api-errors.test.js
SyntaxError: src/metrics.js: Identifier 'registerJobQueue' has already been declared. (846:9)
```

`npm run lint` was also run and is blocked by unrelated existing repo-wide lint failures. Touched-file lint passes. The repo-wide summary was:

```text
88 problems (80 errors, 8 warnings)
```
