### PR TITLE
feat(health): configure Soroban probe timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,7 @@ SOROBAN_MAX_RETRIES=3
 SOROBAN_BASE_DELAY=200
 SOROBAN_MAX_DELAY=5000
 # Soroban latency thresholds (ms) â€“ warn & fail
+# SOROBAN_HEALTH_TIMEOUT_MS=5000 # /ready health probe abort timeout, clamped to 250-10000 ms
 # SOROBAN_LATENCY_WARN_MS=200   # RPC latency <= warn is considered healthy
 # SOROBAN_LATENCY_FAIL_MS=500   # RPC latency > fail is considered unhealthy (degraded between)
 
@@ -244,4 +245,3 @@ KYC_PROVIDER_SECRET=replace-with-your-kyc-signing-secret
 # ---------------------------
 # Timeout in milliseconds for graceful shutdown before force exit (default: 10000)
 SHUTDOWN_TIMEOUT_MS=10000
-

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Health state is also surfaced as a Prometheus gauge (`readiness_gauge`).
 
 Environment variables:
 
+- `SOROBAN_RPC_URL` - Optional Soroban RPC endpoint. When unset, Soroban readiness reports `unknown` and does not block readiness.
+- `SOROBAN_HEALTH_TIMEOUT_MS` - Soroban readiness probe abort timeout in milliseconds. Defaults to `5000` and is clamped to `250-10000`.
+- `SOROBAN_LATENCY_WARN_MS` - RPC latency at or below this value is reported as `healthy`. Defaults to `200`.
+- `SOROBAN_LATENCY_FAIL_MS` - RPC latency above this value is reported as `unhealthy`, with `degraded` between warn and fail. Defaults to `500`.
 - `SENTRY_DSN` — Optional Sentry DSN. Example: `https://<PUBLIC_KEY>@o<ORG_ID>.ingest.sentry.io/<PROJECT_ID>`
 - `SENTRY_RELEASE` — Optional release tag. Defaults to package version when available.
 - `SENTRY_ENVIRONMENT` — Optional environment tag. Defaults to `NODE_ENV`.

--- a/src/services/health.js
+++ b/src/services/health.js
@@ -10,6 +10,30 @@ const { escrowIndexerLastCursorAdvanceTimestampSeconds, readinessGauge } = requi
 const db = require('../db/knex');
 const cfg = require('../config');
 
+const DEFAULT_SOROBAN_HEALTH_TIMEOUT_MS = 5000;
+const MIN_SOROBAN_HEALTH_TIMEOUT_MS = 250;
+const MAX_SOROBAN_HEALTH_TIMEOUT_MS = 10000;
+
+/**
+ * Resolves the Soroban RPC health-probe timeout from environment variables.
+ * Values are clamped so a typo cannot disable the timeout or make readiness
+ * probes wait indefinitely.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env] Environment source.
+ * @returns {number} Timeout in milliseconds.
+ */
+function resolveSorobanHealthTimeoutMs(env = process.env) {
+  const configuredTimeoutMs = parseInt(env.SOROBAN_HEALTH_TIMEOUT_MS, 10);
+  if (Number.isNaN(configuredTimeoutMs)) {
+    return DEFAULT_SOROBAN_HEALTH_TIMEOUT_MS;
+  }
+
+  return Math.min(
+    Math.max(configuredTimeoutMs, MIN_SOROBAN_HEALTH_TIMEOUT_MS),
+    MAX_SOROBAN_HEALTH_TIMEOUT_MS
+  );
+}
+
 /**
  * Classify Soroban RPC latency against configurable thresholds.
  * Returns "healthy" for latency <= warn, "degraded" for latency > warn && <= fail,
@@ -20,8 +44,12 @@ const cfg = require('../config');
 function classifySorobanLatency(latencyMs) {
   const warnMs = parseInt(process.env.SOROBAN_LATENCY_WARN_MS, 10) || 200;
   const failMs = parseInt(process.env.SOROBAN_LATENCY_FAIL_MS, 10) || 500;
-  if (latencyMs <= warnMs) return 'healthy';
-  if (latencyMs <= failMs) return 'degraded';
+  if (latencyMs <= warnMs) {
+    return 'healthy';
+  }
+  if (latencyMs <= failMs) {
+    return 'degraded';
+  }
   return 'unhealthy';
 }
 
@@ -36,9 +64,15 @@ async function checkSorobanHealth() {
   }
 
   const start = Date.now();
+  let timeout;
+
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
+    const timeoutMs = resolveSorobanHealthTimeoutMs();
+    timeout = setTimeout(() => controller.abort(), timeoutMs);
+    if (timeout.unref) {
+      timeout.unref();
+    }
 
     const response = await fetch(url, {
       method: 'POST',
@@ -47,7 +81,6 @@ async function checkSorobanHealth() {
       signal: controller.signal,
     });
 
-    clearTimeout(timeout);
     const latency = Date.now() - start;
 
     if (response.ok) {
@@ -58,6 +91,8 @@ async function checkSorobanHealth() {
   } catch (error) {
     const latency = Date.now() - start;
     return { status: 'unhealthy', latency, error: error.message };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -84,7 +119,9 @@ async function checkSorobanHealth() {
  */
 function inspectPoolHealth(knexInstance) {
   const pool = knexInstance && knexInstance.client && knexInstance.client.pool;
-  if (!pool) return null;
+  if (!pool) {
+    return null;
+  }
 
   const used = typeof pool.numUsed === 'function' ? pool.numUsed() : 0;
   const free = typeof pool.numFree === 'function' ? pool.numFree() : 0;
@@ -147,7 +184,9 @@ async function checkDatabaseHealth() {
         timedOut = true;
         reject(new Error('POOL_ACQUIRE_TIMEOUT'));
       }, probeTimeoutMs);
-      if (timeoutId.unref) timeoutId.unref();
+      if (timeoutId.unref) {
+        timeoutId.unref();
+      }
     });
 
     await Promise.race([db.raw('SELECT 1'), timeoutPromise]);
@@ -160,9 +199,11 @@ async function checkDatabaseHealth() {
     const status = (hasPending || atSaturation) ? 'degraded' : 'healthy';
 
     const result = { status, latency };
-    if (poolMetrics) result.pool = poolMetrics;
+    if (poolMetrics) {
+      result.pool = poolMetrics;
+    }
     return result;
-  } catch (error) {
+  } catch (_error) {
     clearTimeout(timeoutId);
     const latency = Date.now() - start;
     const result = {
@@ -170,7 +211,9 @@ async function checkDatabaseHealth() {
       latency,
       error: timedOut ? 'Connection pool acquire timeout' : 'Database unreachable',
     };
-    if (poolMetrics) result.pool = poolMetrics;
+    if (poolMetrics) {
+      result.pool = poolMetrics;
+    }
     return result;
   }
 }
@@ -221,9 +264,14 @@ async function checkKycHealth() {
   }
 
   const start = Date.now();
+  let timeout;
+
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
+    timeout = setTimeout(() => controller.abort(), 5000);
+    if (timeout.unref) {
+      timeout.unref();
+    }
 
     const response = await fetch(kycCfg.baseUrl, {
       method: 'HEAD',
@@ -231,7 +279,6 @@ async function checkKycHealth() {
       signal: controller.signal,
     });
 
-    clearTimeout(timeout);
     const latency = Date.now() - start;
 
     // Any HTTP response (even 4xx) means the host is reachable
@@ -241,6 +288,8 @@ async function checkKycHealth() {
   } catch (error) {
     const latency = Date.now() - start;
     return { status: 'unhealthy', latency, error: error.message };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -414,7 +463,9 @@ module.exports = {
   checkKycHealth,
   checkStorageHealth,
   checkIndexerStaleness,
+  checkReconciliationHealth,
   performHealthChecks,
   performReadinessChecks,
   inspectPoolHealth,
+  resolveSorobanHealthTimeoutMs,
 };

--- a/src/services/health.test.js
+++ b/src/services/health.test.js
@@ -2,21 +2,72 @@
  * @file Tests for health check service.
  */
 
+jest.mock('../metrics', () => ({
+  escrowIndexerLastCursorAdvanceTimestampSeconds: { get: jest.fn(() => 0) },
+  readinessGauge: { set: jest.fn() },
+}));
+
+jest.mock('../config', () => ({
+  get: jest.fn(() => ({
+    ESCROW_INDEXER_ENABLED: 'false',
+    ESCROW_INDEXER_STALE_THRESHOLD_SECONDS: 300,
+  })),
+}));
+
+jest.mock('./kycService', () => ({
+  getKycProviderConfig: jest.fn(() => ({ enabled: false })),
+}));
+
+jest.mock('./storage', () => ({
+  probeS3Connectivity: jest.fn().mockResolvedValue({ status: 'in_memory' }),
+}));
+
+jest.mock('../jobs/reconcileEscrow', () => ({
+  getReconciliationSummary: jest.fn(),
+}));
+
 const {
   checkSorobanHealth,
   checkDatabaseHealth,
+  checkIndexerStaleness,
+  checkKycHealth,
+  checkReconciliationHealth,
+  checkStorageHealth,
   inspectPoolHealth,
-  performHealthChecks
+  performHealthChecks,
+  performReadinessChecks,
+  resolveSorobanHealthTimeoutMs
 } = require('./health');
+
+const cfg = require('../config');
+const { escrowIndexerLastCursorAdvanceTimestampSeconds, readinessGauge } = require('../metrics');
+const { getReconciliationSummary } = require('../jobs/reconcileEscrow');
+const { getKycProviderConfig } = require('./kycService');
+const db = require('../db/knex');
+const storage = require('./storage');
 
 describe('Health Service', () => {
   let originalEnv;
   let fetchMock;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     originalEnv = { ...process.env };
     fetchMock = jest.fn();
     global.fetch = fetchMock;
+    db.client = undefined;
+    if (db.raw && db.raw.mockReset) {
+      db.raw.mockReset();
+      db.raw.mockResolvedValue([{ ok: 1 }]);
+    }
+    cfg.get.mockReturnValue({
+      ESCROW_INDEXER_ENABLED: 'false',
+      ESCROW_INDEXER_STALE_THRESHOLD_SECONDS: 300,
+    });
+    escrowIndexerLastCursorAdvanceTimestampSeconds.get.mockReturnValue(0);
+    getKycProviderConfig.mockReturnValue({ enabled: false });
+    getReconciliationSummary.mockResolvedValue(null);
+    storage.probeS3Connectivity.mockResolvedValue({ status: 'in_memory' });
   });
 
   afterEach(() => {
@@ -25,6 +76,14 @@ describe('Health Service', () => {
   });
 
   describe('checkSorobanHealth', () => {
+    it('should resolve the configured timeout with default and safety bounds', () => {
+      expect(resolveSorobanHealthTimeoutMs({})).toBe(5000);
+      expect(resolveSorobanHealthTimeoutMs({ SOROBAN_HEALTH_TIMEOUT_MS: 'invalid' })).toBe(5000);
+      expect(resolveSorobanHealthTimeoutMs({ SOROBAN_HEALTH_TIMEOUT_MS: '50' })).toBe(250);
+      expect(resolveSorobanHealthTimeoutMs({ SOROBAN_HEALTH_TIMEOUT_MS: '750' })).toBe(750);
+      expect(resolveSorobanHealthTimeoutMs({ SOROBAN_HEALTH_TIMEOUT_MS: '60000' })).toBe(10000);
+    });
+
     it('should return unknown when SOROBAN_RPC_URL is not configured', async () => {
       delete process.env.SOROBAN_RPC_URL;
 
@@ -74,6 +133,39 @@ describe('Health Service', () => {
       expect(result.error).toBe('The operation was aborted');
     });
 
+    it('should abort a hanging Soroban RPC call after the configured timeout', async () => {
+      jest.useFakeTimers();
+      try {
+        process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+        process.env.SOROBAN_HEALTH_TIMEOUT_MS = '250';
+        fetchMock.mockImplementation((url, options) => new Promise((resolve, reject) => {
+          options.signal.addEventListener('abort', () => {
+            const abortError = new Error('The operation was aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          });
+        }));
+
+        const resultPromise = checkSorobanHealth();
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://soroban-testnet.stellar.org',
+          expect.objectContaining({ signal: expect.any(AbortSignal) })
+        );
+
+        jest.advanceTimersByTime(249);
+        await Promise.resolve();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(1);
+        const result = await resultPromise;
+
+        expect(result.status).toBe('unhealthy');
+        expect(result.error).toBe('The operation was aborted');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('should classify latency as degraded when latency exceeds warn but not fail', async () => {
       process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
       // Warn at -1ms so any real latency (>= 0ms) exceeds warn; fail at 500ms
@@ -85,6 +177,18 @@ describe('Health Service', () => {
       const result = await checkSorobanHealth();
 
       expect(result.status).toBe('degraded');
+      expect(result.latency).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should classify latency as unhealthy when latency exceeds fail', async () => {
+      process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+      process.env.SOROBAN_LATENCY_WARN_MS = '-2';
+      process.env.SOROBAN_LATENCY_FAIL_MS = '-1';
+      fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+      const result = await checkSorobanHealth();
+
+      expect(result.status).toBe('unhealthy');
       expect(result.latency).toBeGreaterThanOrEqual(0);
     });
 
@@ -143,6 +247,218 @@ describe('Health Service', () => {
 
       expect(result.status).toBe('unhealthy');
       expect(result.error).toBe('Connection pool acquire timeout');
+    });
+
+    it('should return degraded when the DB pool is saturated', async () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      const db = require('../db/knex');
+      db.client = {
+        pool: {
+          numUsed: () => 8,
+          numFree: () => 1,
+          numPendingAcquires: () => 0,
+        },
+        config: { pool: { max: 10 } },
+      };
+
+      const result = await checkDatabaseHealth();
+
+      expect(result.status).toBe('degraded');
+      expect(result.pool).toEqual({ used: 8, free: 1, pending: 0, max: 10 });
+    });
+  });
+
+  describe('checkReconciliationHealth', () => {
+    it('should return not_run when no reconciliation summary exists', async () => {
+      getReconciliationSummary.mockResolvedValue(null);
+
+      const result = await checkReconciliationHealth();
+
+      expect(result.status).toBe('not_run');
+      expect(result.error).toBe('Reconciliation has not been run yet');
+    });
+
+    it('should return stale when the last reconciliation is too old', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-06-29T12:00:00Z').getTime());
+      getReconciliationSummary.mockResolvedValue({
+        reconciledAt: '2026-06-28T10:00:00.000Z',
+        mismatches: 0,
+      });
+
+      const result = await checkReconciliationHealth();
+
+      expect(result.status).toBe('stale');
+      expect(result.error).toBe('Reconciliation not run recently');
+    });
+
+    it('should return mismatches when reconciliation found discrepancies', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-06-29T12:00:00Z').getTime());
+      getReconciliationSummary.mockResolvedValue({
+        reconciledAt: '2026-06-29T11:00:00.000Z',
+        mismatches: 2,
+      });
+
+      const result = await checkReconciliationHealth();
+
+      expect(result.status).toBe('mismatches');
+      expect(result.mismatches).toBe(2);
+    });
+
+    it('should return healthy when reconciliation is recent and clean', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-06-29T12:00:00Z').getTime());
+      getReconciliationSummary.mockResolvedValue({
+        reconciledAt: '2026-06-29T11:30:00.000Z',
+        mismatches: 0,
+      });
+
+      const result = await checkReconciliationHealth();
+
+      expect(result.status).toBe('healthy');
+      expect(result.lastRun).toBe('2026-06-29T11:30:00.000Z');
+    });
+
+    it('should return error when reconciliation summary lookup throws', async () => {
+      getReconciliationSummary.mockRejectedValue(new Error('summary failed'));
+
+      const result = await checkReconciliationHealth();
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('summary failed');
+    });
+  });
+
+  describe('checkKycHealth', () => {
+    it('should return disabled when the provider is not configured', async () => {
+      getKycProviderConfig.mockReturnValue({ enabled: false });
+
+      const result = await checkKycHealth();
+
+      expect(result.status).toBe('disabled');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return healthy when the provider responds below 500', async () => {
+      getKycProviderConfig.mockReturnValue({
+        enabled: true,
+        baseUrl: 'https://kyc.example.com/health',
+        apiKey: 'test-key',
+      });
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+      const result = await checkKycHealth();
+
+      expect(result.status).toBe('healthy');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://kyc.example.com/health',
+        expect.objectContaining({
+          method: 'HEAD',
+          headers: { Authorization: 'Bearer test-key' },
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
+
+    it('should return unhealthy when the provider returns a server error', async () => {
+      getKycProviderConfig.mockReturnValue({
+        enabled: true,
+        baseUrl: 'https://kyc.example.com/health',
+        apiKey: 'test-key',
+      });
+      fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+      const result = await checkKycHealth();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.error).toBe('HTTP 503');
+    });
+
+    it('should return unhealthy when the provider request throws', async () => {
+      getKycProviderConfig.mockReturnValue({
+        enabled: true,
+        baseUrl: 'https://kyc.example.com/health',
+        apiKey: 'test-key',
+      });
+      fetchMock.mockRejectedValue(new Error('KYC network failure'));
+
+      const result = await checkKycHealth();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.error).toBe('KYC network failure');
+    });
+  });
+
+  describe('checkIndexerStaleness', () => {
+    it('should return disabled when the escrow indexer is off', async () => {
+      cfg.get.mockReturnValue({ ESCROW_INDEXER_ENABLED: 'false' });
+
+      const result = await checkIndexerStaleness();
+
+      expect(result.status).toBe('disabled');
+    });
+
+    it('should return healthy when the cursor has not been set yet', async () => {
+      cfg.get.mockReturnValue({
+        ESCROW_INDEXER_ENABLED: 'true',
+        ESCROW_INDEXER_STALE_THRESHOLD_SECONDS: 300,
+      });
+      escrowIndexerLastCursorAdvanceTimestampSeconds.get.mockReturnValue(undefined);
+
+      const result = await checkIndexerStaleness();
+
+      expect(result).toEqual({ status: 'healthy', lastAdvanceTimestamp: 0, threshold: 300 });
+    });
+
+    it('should return stale when the cursor is older than the threshold', async () => {
+      cfg.get.mockReturnValue({
+        ESCROW_INDEXER_ENABLED: 'true',
+        ESCROW_INDEXER_STALE_THRESHOLD_SECONDS: 300,
+      });
+      escrowIndexerLastCursorAdvanceTimestampSeconds.get.mockReturnValue(1000);
+      jest.spyOn(Date, 'now').mockReturnValue(1401 * 1000);
+
+      const result = await checkIndexerStaleness();
+
+      expect(result.status).toBe('stale');
+      expect(result.elapsedSeconds).toBe(401);
+      expect(result.threshold).toBe(300);
+    });
+
+    it('should return healthy when the cursor is within the threshold', async () => {
+      cfg.get.mockReturnValue({
+        ESCROW_INDEXER_ENABLED: 'true',
+        ESCROW_INDEXER_STALE_THRESHOLD_SECONDS: 300,
+      });
+      escrowIndexerLastCursorAdvanceTimestampSeconds.get.mockReturnValue(1000);
+      jest.spyOn(Date, 'now').mockReturnValue(1200 * 1000);
+
+      const result = await checkIndexerStaleness();
+
+      expect(result.status).toBe('healthy');
+      expect(result.elapsedSeconds).toBe(200);
+    });
+
+    it('should return error when the indexer config lookup throws', async () => {
+      cfg.get.mockImplementation(() => {
+        throw new Error('config failed');
+      });
+
+      const result = await checkIndexerStaleness();
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('config failed');
+    });
+  });
+
+  describe('checkStorageHealth', () => {
+    it('should return the storage service probe result', async () => {
+      storage.probeS3Connectivity.mockResolvedValue({
+        status: 'healthy',
+        latency: 12,
+      });
+
+      const result = await checkStorageHealth();
+
+      expect(result).toEqual({ status: 'healthy', latency: 12 });
     });
   });
 
@@ -229,6 +545,59 @@ describe('Health Service', () => {
       expect(result.checks.soroban).toBeDefined();
       expect(result.checks.database).toBeDefined();
       expect(duration).toBeLessThan(100);
+    });
+  });
+
+  describe('performReadinessChecks', () => {
+    it('should report ready and set gauge to 1 when critical checks are healthy', async () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+      fetchMock.mockResolvedValue({ ok: true, status: 200 });
+      storage.probeS3Connectivity.mockResolvedValue({ status: 'in_memory' });
+
+      const result = await performReadinessChecks();
+
+      expect(result.healthy).toBe(true);
+      expect(result.checks.database.status).toBe('healthy');
+      expect(result.checks.soroban.status).toBe('healthy');
+      expect(readinessGauge.set).toHaveBeenCalledWith(1);
+    });
+
+    it('should set gauge to 0.5 when a critical dependency is degraded but ready', async () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+      process.env.SOROBAN_LATENCY_WARN_MS = '-1';
+      process.env.SOROBAN_LATENCY_FAIL_MS = '500';
+      fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+      const result = await performReadinessChecks();
+
+      expect(result.healthy).toBe(true);
+      expect(result.checks.soroban.status).toBe('degraded');
+      expect(readinessGauge.set).toHaveBeenCalledWith(0.5);
+    });
+
+    it('should report not ready and set gauge to 0 when DB is not configured', async () => {
+      delete process.env.DATABASE_URL;
+      delete process.env.SOROBAN_RPC_URL;
+
+      const result = await performReadinessChecks();
+
+      expect(result.healthy).toBe(false);
+      expect(result.checks.database.status).toBe('not_configured');
+      expect(readinessGauge.set).toHaveBeenCalledWith(0);
+    });
+
+    it('should report not ready when storage is not configured', async () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      delete process.env.SOROBAN_RPC_URL;
+      storage.probeS3Connectivity.mockResolvedValue({ status: 'not_configured' });
+
+      const result = await performReadinessChecks();
+
+      expect(result.healthy).toBe(false);
+      expect(result.checks.storage.status).toBe('not_configured');
+      expect(readinessGauge.set).toHaveBeenCalledWith(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `SOROBAN_HEALTH_TIMEOUT_MS` for the Soroban readiness probe.
- Resolves the timeout through a bounded helper with default `5000`, min `250`, and max `10000` ms.
- Clears Soroban and KYC abort timers in `finally` paths so failed probes do not leave timeout handles behind.
- Documents the new timeout in `.env.example` and the README health endpoint section.
- Expands health service coverage around Soroban timeout bounds, abort behavior, KYC, storage, indexer staleness, reconciliation health, DB pool degradation, and readiness gauge states.

Fixes #513

## Validation

- `npm test -- --runTestsByPath src/services/health.test.js`
  - 41 passed
- `npx jest --runInBand --runTestsByPath src/services/health.test.js --coverage --collectCoverageFrom=src/services/health.js --coverageThreshold='{}'`
  - 41 passed
  - `src/services/health.js`: 98.55% statements, 99.26% lines, 90.9% branches
- `npx eslint src/services/health.js src/services/health.test.js`
- `git diff --check`

## Full-suite notes

- `npm test` remains red on upstream baseline failures unrelated to this PR.
  - Summary: 85 failed, 1 skipped, 43 passed, 128 of 129 suites; 265 failed, 5 skipped, 988 passed, 1258 total.
  - Representative failures: `src/metrics.js` duplicate `registerJobQueue` declaration parse error, shutdown test timeout/expectation mismatch, invoice upload 500s, rate-limit expectation mismatches, and existing audit-log CSV tests.
- `npm run lint` remains red on upstream baseline issues unrelated to touched files.
  - Summary: 77 errors, 8 warnings.
  - Touched-file lint is clean with the focused ESLint command above.
