### PR TITLE
test(contract-refresh): cover alert dedupe returns

### DIFF
--- a/docs/wasm-ops.md
+++ b/docs/wasm-ops.md
@@ -211,7 +211,9 @@ scheduled runs, only the **first** occurrence emits a metric increment and log.
 The de-dupe state for a contract is cleared automatically once its version
 returns to `current`, so a later regression re-alerts. It re-alerts immediately
 if the observed version changes to a new pair. State can be reset manually via
-`resetVersionMismatchAlertState()` (exported for tests/ops).
+`resetVersionMismatchAlertState()` (exported for tests/ops). The alert helper
+returns `true` only when it emits a new metric/log alert and `false` when an
+identical signature is suppressed.
 
 > Note: because de-dupe state is in-process, a service restart resets it and the
 > next run will alert once for any still-present mismatch — this is intentional

--- a/tests/contractListRefresh.test.js
+++ b/tests/contractListRefresh.test.js
@@ -21,10 +21,15 @@ jest.mock('../src/config/escrowVersions', () => ({
   compareVersions: jest.fn(),
 }));
 
+jest.mock('../src/metrics', () => ({
+  contractWasmVersionMismatchAlertsTotal: { inc: jest.fn() },
+}));
+
 const { getOnChainSchemaVersion, compareVersions } = require('../src/config/escrowVersions');
 const logger = require('../src/logger');
 const metrics = require('../src/metrics');
 const {
+  raiseVersionMismatchAlert,
   runContractListRefresh,
   resetVersionMismatchAlertState,
 } = require('../src/jobs/contractListRefresh');
@@ -79,6 +84,70 @@ describe('contractListRefresh version-mismatch alert (issue #457)', () => {
       status: 'ahead',
     });
     expect(message).toMatch(/mismatch/i);
+  });
+
+  it('returns false and suppresses metric/log output for an identical direct alert', () => {
+    const mismatch = {
+      contractId: 'contract-a',
+      observedVersion: 4,
+      expectedVersion: '1.2.0',
+      status: 'ahead',
+    };
+
+    const firstRaised = raiseVersionMismatchAlert(mismatch);
+    const secondRaised = raiseVersionMismatchAlert(mismatch);
+
+    expect(firstRaised).toBe(true);
+    expect(secondRaised).toBe(false);
+    expect(incSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true again when the direct alert signature changes for the same contract', () => {
+    const firstRaised = raiseVersionMismatchAlert({
+      contractId: 'contract-a',
+      observedVersion: 4,
+      expectedVersion: '1.2.0',
+      status: 'ahead',
+    });
+
+    const changedObservedRaised = raiseVersionMismatchAlert({
+      contractId: 'contract-a',
+      observedVersion: 5,
+      expectedVersion: '1.2.0',
+      status: 'ahead',
+    });
+
+    const changedExpectedRaised = raiseVersionMismatchAlert({
+      contractId: 'contract-a',
+      observedVersion: 5,
+      expectedVersion: '1.3.0',
+      status: 'ahead',
+    });
+
+    expect(firstRaised).toBe(true);
+    expect(changedObservedRaised).toBe(true);
+    expect(changedExpectedRaised).toBe(true);
+    expect(incSpy).toHaveBeenCalledTimes(3);
+    expect(errorSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('re-alerts after resetVersionMismatchAlertState clears a direct alert signature', () => {
+    const mismatch = {
+      contractId: 'contract-a',
+      observedVersion: 4,
+      expectedVersion: '1.2.0',
+      status: 'ahead',
+    };
+
+    expect(raiseVersionMismatchAlert(mismatch)).toBe(true);
+    expect(raiseVersionMismatchAlert(mismatch)).toBe(false);
+
+    resetVersionMismatchAlertState();
+
+    expect(raiseVersionMismatchAlert(mismatch)).toBe(true);
+    expect(incSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
   });
 
   it('raises an alert on an "unknown" version mismatch', async () => {


### PR DESCRIPTION
## Summary

- Mock the metrics module in `contractListRefresh` tests so this suite can exercise alert logic directly without loading the current duplicate `registerJobQueue` definition from the global metrics module.
- Add coverage for wasm-version mismatch alert de-duplication, changed mismatch signatures, and reset behavior.
- Document that `raiseVersionMismatchAlert` returns `true` only when it emits a fresh metric/log alert.

## Validation

- `npm test -- --runTestsByPath tests/contractListRefresh.test.js`
- `npx jest --runInBand --runTestsByPath tests/contractListRefresh.test.js --coverage --collectCoverageFrom=src/jobs/contractListRefresh.js --coverageThreshold='{}'`
- `npx eslint src/jobs/contractListRefresh.js tests/contractListRefresh.test.js`
- `git diff --check`

## Notes

I also ran the full baseline checks. `npm test` and `npm run lint` still fail on unrelated upstream issues, including the existing duplicate `registerJobQueue` parse error in `src/metrics.js`, shutdown/rate-limit/invoice/audit CSV test failures, and broader lint errors outside this patch.

Refs #516
