### PR TITLE
refactor(validation): centralize Stellar StrKey helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,13 @@ The `src/middleware/smeAuth.js` middleware binds Stellar wallet authorization st
 
 ### Address format
 
-All wallet addresses are validated against `^G[A-Z2-7]{55}$` (Stellar Ed25519 public key format). Invalid formats yield a `400` before any capital-movement logic runs.
+All SME wallet addresses are validated as Stellar account public keys (`G...` StrKeys). Contract addresses (`C...`) are intentionally rejected here because this middleware binds user accounts to wallets, not escrow contracts. Invalid formats yield a `400` before any capital-movement logic runs.
+
+Shared StrKey validation lives in `src/utils/validators.js`:
+
+- `isValidStellarAccountAddress(value)` accepts only `G...` account public keys.
+- `isValidStellarContractAddress(value)` accepts only `C...` Soroban contract addresses.
+- `isValidStellarAddress(value)` accepts either form for routes and services that can work with both account and contract StrKeys.
 
 ### Error responses
 
@@ -1390,7 +1396,7 @@ Any violation throws a `CommitmentValidationError` with a typed `.code`:
 
 ### Address validation
 
-`validateAddress(address)` checks that the investor address is a valid Stellar public key (G… or C… prefix, 56 base-32 characters). It returns `{ valid, reason }` and is also called from the `GET /api/investor/locks` routes to validate the `funderAddress` query parameter.
+`validateAddress(address)` checks that the investor address is a valid Stellar StrKey address (`G...` account public key or `C...` contract address). It returns `{ valid, reason }` and is also called from the `GET /api/investor/locks` routes to validate the `funderAddress` query parameter.
 
 ### Idempotency
 

--- a/src/config/escrowMap.js
+++ b/src/config/escrowMap.js
@@ -31,7 +31,7 @@
 
 'use strict';
 
-const { isValidStellarAddress } = require('../utils/stellarAddress');
+const { isValidStellarAddress } = require('../utils/validators');
 
 /**
  * Thrown when no active escrow mapping exists for an invoice ID.

--- a/src/config/escrowVersions.js
+++ b/src/config/escrowVersions.js
@@ -11,7 +11,7 @@
 
 const { callSorobanContract } = require('../services/soroban');
 const logger = require('../logger');
-const { isValidStellarContractAddress } = require('../utils/stellarAddress');
+const { isValidStellarContractAddress } = require('../utils/validators');
 
 /**
  * Known LiquifactEscrow deployments: semver -> SCHEMA_VERSION (u32).

--- a/src/middleware/smeAuth.js
+++ b/src/middleware/smeAuth.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const AppError = require('../errors/AppError');
-const { isValidStellarAddress } = require('../utils/stellarAddress');
+const { isValidStellarAccountAddress } = require('../utils/validators');
 
 /**
  * Middleware: verifies the authenticated user has a bound Stellar wallet address.
@@ -39,7 +39,7 @@ function authorizeSmeWallet(req, res, next) {
     }));
   }
 
-  if (!isValidStellarAddress(wallet)) {
+  if (!isValidStellarAccountAddress(wallet)) {
     return next(new AppError({
       type: 'https://liquifact.com/probs/validation-error',
       title: 'Invalid Wallet Address',

--- a/src/routes/invest.js
+++ b/src/routes/invest.js
@@ -29,7 +29,7 @@ const { submitFundEscrow, EscrowSubmitError } = require('../services/escrowSubmi
 const { persistCommitment } = require('../services/investorCommitment');
 const { listOpportunities } = require('../services/investService');
 const idempotencyMiddleware = require('../middleware/idempotency');
-const { isValidStellarAddress } = require('../utils/stellarAddress');
+const { isValidStellarAddress } = require('../utils/validators');
 
 const router = express.Router();
 

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const db = require('../db/knex');
-const { isValidStellarAddress } = require('../utils/stellarAddress');
+const { isValidStellarAddress } = require('../utils/validators');
 
 const TABLE = 'investor_commitments';
 
@@ -98,7 +98,7 @@ function validateAmountStroops(value) {
 }
 
 /**
- * Validate a Stellar public key (G... or C..., 56 characters total).
+ * Validate a Stellar StrKey address (G... account or C... contract).
  *
  * @param {string} address - The candidate Stellar address.
  * @returns {{ valid: boolean, reason: string }} Result object.

--- a/src/services/tokenMeta.js
+++ b/src/services/tokenMeta.js
@@ -20,7 +20,7 @@ const logger = require('../logger');
 const {
   isValidStellarAccountAddress,
   isValidStellarContractAddress,
-} = require('../utils/stellarAddress');
+} = require('../utils/validators');
 
 /**
  * Default TTL for token metadata cache in milliseconds (30 minutes).

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -16,6 +16,11 @@ const {
   validateInvoicePayload,
   SUPPORTED_CURRENCIES,
 } = require('../schemas/invoice');
+const {
+  isValidStellarAccountAddress,
+  isValidStellarContractAddress,
+  isValidStellarAddress,
+} = require('./stellarAddress');
 
 /**
  * Supported ISO 4217 currency codes (Set for O(1) look-up).
@@ -230,4 +235,7 @@ module.exports = {
   validateMarketplaceQueryParams,
   validateInvoicePayload,
   VALID_CURRENCIES,
+  isValidStellarAccountAddress,
+  isValidStellarContractAddress,
+  isValidStellarAddress,
 };

--- a/tests/middleware-security.test.js
+++ b/tests/middleware-security.test.js
@@ -10,7 +10,7 @@ const {
   isValidStellarAccountAddress,
   isValidStellarContractAddress,
   isValidStellarAddress,
-} = require('../src/utils/stellarAddress');
+} = require('../src/utils/validators');
 
 const VALID_TOKEN = 'test-suite-token';
 const VALID_STELLAR_ACCOUNT = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 11));

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -128,6 +128,22 @@ jest.mock('@stellar/stellar-sdk', () => ({
     })),
   },
   StrKey: {
+    encodeEd25519PublicKey: jest.fn((payload) => {
+      const byte = Buffer.isBuffer(payload) && payload.length > 0 ? payload[0] : 1;
+      const alphabet = 'BCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      return `G${'A'.repeat(54)}${alphabet[byte % alphabet.length]}`;
+    }),
+    encodeContract: jest.fn((payload) => {
+      const byte = Buffer.isBuffer(payload) && payload.length > 0 ? payload[0] : 1;
+      const alphabet = 'BCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      return `C${'A'.repeat(54)}${alphabet[byte % alphabet.length]}`;
+    }),
+    isValidEd25519PublicKey: jest.fn((value) => {
+      return typeof value === 'string' && /^G[A-Z2-7]{55}$/.test(value) && !/^G{56}$/.test(value);
+    }),
+    isValidContract: jest.fn((value) => {
+      return typeof value === 'string' && /^C[A-Z2-7]{55}$/.test(value) && !/^C{56}$/.test(value);
+    }),
     isValidContractId: jest.fn((contractId) => {
       if (typeof contractId !== 'string') return false;
       const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;

--- a/tests/unit/smeAuth.test.js
+++ b/tests/unit/smeAuth.test.js
@@ -213,14 +213,14 @@ describe('authorizeSmeWallet — Stellar address format validation', () => {
     expect(res.body.walletAddress).toBe(VALID_WALLET);
   });
 
-  it('accepts a valid Stellar contract address starting with C', async () => {
+  it('returns 400 for a valid contract address because SME wallets must be account public keys', async () => {
     const app = makeApp(
       injectUser({ id: 'user-001', walletAddress: VALID_CONTRACT_ADDRESS }),
       authorizeSmeWallet
     );
     const res = await request(app).get('/test');
-    expect(res.status).toBe(200);
-    expect(res.body.walletAddress).toBe(VALID_CONTRACT_ADDRESS);
+    expect(res.status).toBe(400);
+    expect(res.body.detail).toMatch(/Stellar wallet address format is invalid/);
   });
 
   it('returns 400 for wrong-length uppercase values that only look like StrKeys', async () => {

--- a/tests/validators.strkey.test.js
+++ b/tests/validators.strkey.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { StrKey } = require('@stellar/stellar-sdk');
+const {
+  isValidStellarAccountAddress,
+  isValidStellarContractAddress,
+  isValidStellarAddress,
+} = require('../src/utils/validators');
+
+const VALID_ACCOUNT = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 21));
+const VALID_CONTRACT = StrKey.encodeContract(Buffer.alloc(32, 22));
+
+describe('shared Stellar StrKey validators', () => {
+  it('accepts account public keys only through the account helper', () => {
+    expect(isValidStellarAccountAddress(VALID_ACCOUNT)).toBe(true);
+    expect(isValidStellarAccountAddress(VALID_CONTRACT)).toBe(false);
+  });
+
+  it('accepts contract IDs only through the contract helper', () => {
+    expect(isValidStellarContractAddress(VALID_CONTRACT)).toBe(true);
+    expect(isValidStellarContractAddress(VALID_ACCOUNT)).toBe(false);
+  });
+
+  it('accepts account and contract StrKeys through the either-form helper', () => {
+    expect(isValidStellarAddress(VALID_ACCOUNT)).toBe(true);
+    expect(isValidStellarAddress(VALID_CONTRACT)).toBe(true);
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['null', null],
+    ['undefined', undefined],
+    ['lowercase account', VALID_ACCOUNT.toLowerCase()],
+    ['mixed-case account', `${VALID_ACCOUNT.slice(0, 8).toLowerCase()}${VALID_ACCOUNT.slice(8)}`],
+    ['trailing whitespace', `${VALID_ACCOUNT} `],
+    ['too short', VALID_ACCOUNT.slice(0, -1)],
+    ['too long', `${VALID_ACCOUNT}A`],
+    ['wrong prefix', `X${VALID_ACCOUNT.slice(1)}`],
+    ['same-character account lookalike', 'G'.repeat(56)],
+    ['same-character contract lookalike', 'C'.repeat(56)],
+  ])('rejects %s', (_label, value) => {
+    expect(isValidStellarAddress(value)).toBe(false);
+    expect(isValidStellarAccountAddress(value)).toBe(false);
+    expect(isValidStellarContractAddress(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Re-export the shared Stellar StrKey helpers from `src/utils/validators.js` and route the current backend call sites through that shared validation surface.
- Keep account-only, contract-only, and account-or-contract checks separate so each call site keeps the intended acceptance set.
- Tighten SME wallet auth to use the account-public-key helper, matching the README and issue guidance that SME wallets should be `G...` account keys, not `C...` contract IDs.
- Add focused StrKey validator coverage and update the Jest Stellar mock with the StrKey methods used by production validation.
- Document the shared helper names and accepted formats in the README.

## Validation

- `npm test -- --runTestsByPath tests/validators.strkey.test.js tests/unit/smeAuth.test.js`
- `npm test -- --runTestsByPath tests/validators.strkey.test.js tests/unit/smeAuth.test.js tests/escrowMap.test.js`
- `npx jest --runInBand --runTestsByPath tests/validators.strkey.test.js tests/unit/smeAuth.test.js --coverage --collectCoverageFrom=src/utils/stellarAddress.js --collectCoverageFrom=src/middleware/smeAuth.js --coverageThreshold='{}'`
- `npx eslint src/utils/validators.js src/utils/stellarAddress.js src/middleware/smeAuth.js src/routes/invest.js src/services/investorCommitment.js src/config/escrowMap.js src/config/escrowVersions.js src/services/tokenMeta.js tests/validators.strkey.test.js tests/unit/smeAuth.test.js tests/mocks/setup.js tests/middleware-security.test.js`
- `git diff --check`

## Baseline Notes

- `npm test` is still failing on unrelated upstream issues. Latest run: 45 suites passed, 84 failed, 1 skipped; 1024 tests passed, 229 failed, 5 skipped. Representative blockers include the existing duplicate `registerJobQueue` parse error in `src/metrics.js`, shutdown coordinator assertions/timeouts, audit CSV expectations, invoice upload failures, and rate-limit tests.
- `npm run lint` is still failing on unrelated upstream files. Latest run: 85 errors and 8 warnings, including `src/metrics.js`, `src/services/health.js`, `src/services/storage.js`, `src/workers/jobQueue.js`, and other files outside this patch.

Refs #521
