### PR TITLE
Fix investor lock funder scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ Clients can bypass the cache by sending a `Cache-Control: no-cache` request head
 | Endpoint                                | Cache key format                                           | TTL      |
 |-----------------------------------------|------------------------------------------------------------|----------|
 | `GET /api/marketplace`                  | `marketplace:<tenantId>:<originalUrl>`                     | 15s      |
-| `GET /api/investor/locks`               | `investor:locks:<tenantId>:<originalUrl>`                  | 15s      |
-| `GET /api/investor/locks/:invoiceId`    | `investor:lock:<tenantId>:<invoiceId>:<funderAddress>`     | 15s      |
+| `GET /api/investor/locks`               | `investor:locks:<tenantId>:<principalScope>:<originalUrl>` | 15s      |
+| `GET /api/investor/locks/:invoiceId`    | `investor:lock:<tenantId>:<principalScope>:<invoiceId>:<funderAddress>` | 15s      |
+
+For investor-lock responses, `<principalScope>` is `admin:<role>` for tenant-wide admin or owner reads, or `funder:<boundAddress>` for non-admin investor reads. This prevents one authenticated principal from receiving another principal's cached lock response when the URL is otherwise identical.
 
 ### Tenant isolation
 
@@ -1390,7 +1392,7 @@ Any violation throws a `CommitmentValidationError` with a typed `.code`:
 
 ### Address validation
 
-`validateAddress(address)` checks that the investor address is a valid Stellar public key (G… or C… prefix, 56 base-32 characters). It returns `{ valid, reason }` and is also called from the `GET /api/investor/locks` routes to validate the `funderAddress` query parameter.
+`validateAddress(address)` checks that the investor address is a valid Stellar public key (G… or C… prefix, 56 base-32 characters). It returns `{ valid, reason }` and is also called from the `GET /api/investor/locks` routes to validate the requested `funderAddress` query parameter and the funder address bound to a non-admin caller.
 
 ### Idempotency
 
@@ -1413,10 +1415,10 @@ The service maintains a `Map`-backed lock cache (claimNotBefore, investorEffecti
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/investor/locks` | List locks, optional `funderAddress` / `invoiceId` filters |
-| `GET` | `/api/investor/locks/:invoiceId` | Single lock for a specific invoice and funder |
+| `GET` | `/api/investor/locks` | List the caller's funder locks, with optional `funderAddress` / `invoiceId` filters |
+| `GET` | `/api/investor/locks/:invoiceId` | Single lock for a specific invoice and authorized funder |
 
-Both routes require a valid JWT (`Authorization: Bearer <token>`). An invalid `funderAddress` returns `400` with `{ error: "invalid Stellar address: …" }`.
+Both routes require a valid JWT (`Authorization: Bearer <token>`). Non-admin callers are scoped to the `funderAddress`, `walletAddress`, `stellarAddress`, or `investorAddress` claim on their authenticated principal. If they omit `funderAddress`, the routes use the bound funder address automatically. If they request a different funder, the routes return `403`. Admin and owner callers may list all tenant locks or inspect any funder. An invalid `funderAddress` returns `400` with `{ error: "invalid Stellar address: …" }`.
 
 ---
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -39,14 +39,14 @@ The investor commitment surface exposes per-funder lock data (`claimNotBefore`, 
 
 ### GET /api/investor/locks
 
-Query by funder or invoice, or list all locks.
+Query by funder or invoice. Non-admin callers are scoped to the funder address bound to their authenticated principal. Admin and owner callers may list all tenant locks.
 
 ```bash
-# List all
+# List your bound funder locks as a non-admin, or all tenant locks as an admin
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3001/api/investor/locks
 
-# Filter by funder
+# Filter by funder. Non-admin callers must request their own bound funder.
 curl -H "Authorization: Bearer $TOKEN" \
   "http://localhost:3001/api/investor/locks?funderAddress=GDRXE2..."
 
@@ -73,6 +73,10 @@ curl -H "Authorization: Bearer $TOKEN" \
 ```
 
 ## Security Notes
+
+- Non-admin callers cannot use an omitted `funderAddress` to list other funders' locks.
+- Non-admin callers receive `403` when the requested funder does not match their bound funder address.
+- Investor-lock cache keys include tenant and principal scope, so a cached admin response cannot be replayed to a scoped investor.
 
 - Endpoint requires JWT authentication (`authenticateToken` middleware)
 - Address validation: G/C prefix + 56 alphanumeric chars

--- a/src/middleware/cache.js
+++ b/src/middleware/cache.js
@@ -26,6 +26,7 @@
 
 const logger = require('../logger');
 const { cacheStoreErrorsTotal } = require('../metrics');
+const { getInvestorLockPrincipalScope } = require('../utils/investorLockScope');
 
 /**
  * Creates an Express middleware that caches JSON responses with a TTL.
@@ -130,7 +131,7 @@ function makeMarketplaceKey(req) {
  */
 function makeInvestorLocksKey(req) {
   const tenantId = req.tenantId || 'unknown';
-  return 'investor:locks:' + tenantId + ':' + req.originalUrl;
+  return 'investor:locks:' + tenantId + ':' + getInvestorLockPrincipalScope(req) + ':' + req.originalUrl;
 }
 
 /**
@@ -142,7 +143,7 @@ function makeInvestorLocksKey(req) {
  */
 function makeInvestorLockKey(req) {
   const tenantId = req.tenantId || 'unknown';
-  return 'investor:lock:' + tenantId + ':' + req.params.invoiceId + ':' + req.query.funderAddress;
+  return 'investor:lock:' + tenantId + ':' + getInvestorLockPrincipalScope(req) + ':' + req.params.invoiceId + ':' + req.query.funderAddress;
 }
 
 /**

--- a/src/routes/investor.js
+++ b/src/routes/investor.js
@@ -12,6 +12,10 @@ const { extractTenant } = require('../middleware/tenant');
 const { cacheResponse, makeInvestorLocksKey, makeInvestorLockKey } = require('../middleware/cache');
 const { getSharedStore } = require('../services/cacheStore');
 const investorCommitmentService = require('../services/investorCommitment');
+const {
+  getBoundFunderAddress,
+  isInvestorLockAdmin,
+} = require('../utils/investorLockScope');
 const logger = require('../logger');
 
 const CACHE_TTL_MS = 15000;
@@ -42,8 +46,9 @@ const cacheLock = cacheResponse({
  *       | `limit` | 20 | Items per page (1–100) |
  *       | `page`  | 1  | 1-based page number |
  *
- *       Funder scoping is always enforced server-side; a caller can only see
- *       locks for the `funderAddress` they supply, never another funder's locks.
+ *       Funder scoping is always enforced server-side. Non-admin callers can
+ *       only see locks for the funder address bound to their authenticated
+ *       principal. Admin or owner callers may inspect all funders in the tenant.
  *     tags: [Investor]
  *     security:
  *       - bearerAuth: []
@@ -52,7 +57,7 @@ const cacheLock = cacheResponse({
  *         name: funderAddress
  *         schema:
  *           type: string
- *         description: Funder Stellar address (G... or C...). When supplied only that funder's locks are returned.
+ *         description: Optional funder Stellar address (G... or C...). Non-admin callers may only request their own bound funder address.
  *       - in: query
  *         name: invoiceId
  *         schema:
@@ -113,13 +118,22 @@ const cacheLock = cacheResponse({
  *                       type: boolean
  *       400:
  *         description: Invalid address format or invalid pagination params
+ *       403:
+ *         description: Caller is not authorized for the requested funder scope
  */
 router.get('/locks', authenticateToken, extractTenant, cacheLocks, async (req, res, next) => {
   try {
     const { funderAddress, invoiceId } = req.query;
+    const hasFunderAddressParam = Object.prototype.hasOwnProperty.call(req.query, 'funderAddress');
+    const requestedFunderAddress = hasFunderAddressParam && typeof funderAddress === 'string'
+      ? funderAddress.trim()
+      : undefined;
 
-    if (funderAddress) {
-      const validation = investorCommitmentService.validateAddress(funderAddress);
+    if (hasFunderAddressParam) {
+      if (typeof funderAddress !== 'string') {
+        return res.status(400).json({ error: 'funderAddress must be a single string value' });
+      }
+      const validation = investorCommitmentService.validateAddress(requestedFunderAddress);
       if (!validation.valid) {
         return res.status(400).json({ error: validation.reason });
       }
@@ -145,10 +159,29 @@ router.get('/locks', authenticateToken, extractTenant, cacheLocks, async (req, r
     const limit = rawLimit !== undefined ? parseInt(rawLimit, 10) : 20;
     const page = rawPage !== undefined ? parseInt(rawPage, 10) : 1;
 
-    const hasFunderAddress = funderAddress && typeof funderAddress === 'string';
+    const isAdmin = isInvestorLockAdmin(req.user);
+    const boundFunderAddress = getBoundFunderAddress(req.user);
+    let effectiveFunderAddress = requestedFunderAddress;
 
-    const result = hasFunderAddress
-      ? investorCommitmentService.getInvestorLocksByAddress(funderAddress.trim(), { invoiceId, limit, page })
+    if (!isAdmin) {
+      if (!boundFunderAddress) {
+        return res.status(403).json({ error: 'Authenticated investor is not bound to a funderAddress' });
+      }
+
+      const boundValidation = investorCommitmentService.validateAddress(boundFunderAddress);
+      if (!boundValidation.valid) {
+        return res.status(403).json({ error: 'Authenticated investor has an invalid bound funderAddress' });
+      }
+
+      if (requestedFunderAddress && requestedFunderAddress !== boundFunderAddress) {
+        return res.status(403).json({ error: 'funderAddress is not authorized for this caller' });
+      }
+
+      effectiveFunderAddress = boundFunderAddress;
+    }
+
+    const result = effectiveFunderAddress
+      ? investorCommitmentService.getInvestorLocksByAddress(effectiveFunderAddress, { invoiceId, limit, page })
       : investorCommitmentService.getAllInvestorLocks({ invoiceId, limit, page });
 
     const anyStale = result.data.length > 0 && result.data.some((lock) => lock.stale === true);
@@ -156,12 +189,14 @@ router.get('/locks', authenticateToken, extractTenant, cacheLocks, async (req, r
     logger.info(
       {
         requestId: req.id,
-        funderAddress,
+        funderAddress: effectiveFunderAddress,
+        requestedFunderAddress,
         invoiceId,
         count: result.data.length,
         total: result.meta.total,
         page: result.meta.page,
         stale: anyStale,
+        adminScope: isAdmin,
       },
       'Investor locks retrieved'
     );
@@ -206,6 +241,8 @@ router.get('/locks', authenticateToken, extractTenant, cacheLocks, async (req, r
  *         description: Lock record found
  *       400:
  *         description: Missing or invalid funderAddress
+ *       403:
+ *         description: Caller is not authorized for the requested funder
  *       404:
  *         description: Lock not found
  */
@@ -223,13 +260,32 @@ router.get('/locks/:invoiceId', authenticateToken, extractTenant, cacheLock, asy
       return res.status(400).json({ error: validation.reason });
     }
 
-    const lock = investorCommitmentService.getInvestorLock(invoiceId, funderAddress.trim());
+    const requestedFunderAddress = funderAddress.trim();
+    const isAdmin = isInvestorLockAdmin(req.user);
+    const boundFunderAddress = getBoundFunderAddress(req.user);
+
+    if (!isAdmin) {
+      if (!boundFunderAddress) {
+        return res.status(403).json({ error: 'Authenticated investor is not bound to a funderAddress' });
+      }
+
+      const boundValidation = investorCommitmentService.validateAddress(boundFunderAddress);
+      if (!boundValidation.valid) {
+        return res.status(403).json({ error: 'Authenticated investor has an invalid bound funderAddress' });
+      }
+
+      if (requestedFunderAddress !== boundFunderAddress) {
+        return res.status(403).json({ error: 'funderAddress is not authorized for this caller' });
+      }
+    }
+
+    const lock = investorCommitmentService.getInvestorLock(invoiceId, requestedFunderAddress);
 
     if (!lock) {
       return res.status(404).json({ error: 'Lock not found' });
     }
 
-    logger.info({ requestId: req.id, invoiceId, funderAddress }, 'Investor lock retrieved');
+    logger.info({ requestId: req.id, invoiceId, funderAddress: requestedFunderAddress, adminScope: isAdmin }, 'Investor lock retrieved');
 
     return res.json({ data: lock, message: 'Investor lock retrieved.' });
   } catch (error) {

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -341,7 +341,7 @@ function clearInvestorLocks() {
 /** Seed representative test fixtures (test helper). */
 function seedInvestorLocks() {
   const addr1 = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
-  const addr2 = 'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL';
+  const addr2 = 'GABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEJXA';
 
   for (let i = 1; i <= 5; i++) {
     setInvestorLock({ funderAddress: addr1, claimNotBefore: `2026-0${i}-01T00:00:00Z`, investorEffectiveYieldBps: 500 + i * 50, invoiceId: `inv_${7788 + i - 1}` });

--- a/src/utils/investorLockScope.js
+++ b/src/utils/investorLockScope.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const ADMIN_ROLES = new Set(['admin', 'owner']);
+const FUNDER_ADDRESS_CLAIMS = [
+  'funderAddress',
+  'walletAddress',
+  'stellarAddress',
+  'investorAddress',
+];
+
+/**
+ * Returns true when the authenticated principal may inspect locks for any
+ * funder in the tenant.
+ *
+ * @param {object|null|undefined} user - Decoded JWT principal.
+ * @returns {boolean} Whether the principal is an investor-lock admin.
+ */
+function isInvestorLockAdmin(user) {
+  const role = typeof user?.role === 'string' ? user.role.toLowerCase() : '';
+  if (ADMIN_ROLES.has(role)) {
+    return true;
+  }
+
+  if (Array.isArray(user?.permissions)) {
+    return user.permissions.includes('investor:locks:read:any');
+  }
+
+  return false;
+}
+
+/**
+ * Resolves the funder address bound to the authenticated principal.
+ *
+ * @param {object|null|undefined} user - Decoded JWT principal.
+ * @returns {string|null} Bound funder address, or null when absent.
+ */
+function getBoundFunderAddress(user) {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+
+  for (const claim of FUNDER_ADDRESS_CLAIMS) {
+    const value = user[claim];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Builds a stable scope segment for cache keys that store investor lock data.
+ *
+ * @param {import('express').Request} req - Express request.
+ * @returns {string} Principal scope segment.
+ */
+function getInvestorLockPrincipalScope(req) {
+  if (isInvestorLockAdmin(req.user)) {
+    const role = typeof req.user?.role === 'string' ? req.user.role.toLowerCase() : 'permission';
+    return `admin:${role}`;
+  }
+
+  return `funder:${getBoundFunderAddress(req.user) || 'unbound'}`;
+}
+
+module.exports = {
+  getBoundFunderAddress,
+  getInvestorLockPrincipalScope,
+  isInvestorLockAdmin,
+};

--- a/tests/investor.locks.test.js
+++ b/tests/investor.locks.test.js
@@ -1,15 +1,40 @@
 'use strict';
 
+const makeMetricStub = () => {
+  const fn = jest.fn();
+  fn.inc = jest.fn();
+  fn.set = jest.fn();
+  fn.observe = jest.fn();
+  fn.labels = jest.fn(() => fn);
+  return fn;
+};
+
+jest.mock('../src/metrics', () => new Proxy({}, {
+  get(target, prop) {
+    if (!target[prop]) {
+      target[prop] = makeMetricStub();
+    }
+    return target[prop];
+  },
+}));
+
+jest.mock('../src/middleware/kycGating', () => ({
+  requireKycForFunding: (_req, _res, next) => next(),
+}));
+
 const request = require('supertest');
 const { createApp, resetStore } = require('../src/index');
 const jwt = require('jsonwebtoken');
 const investorCommitmentService = require('../src/services/investorCommitment');
 
 const TEST_SECRET = process.env.JWT_SECRET || 'test-secret';
-const validToken = jwt.sign({ id: 'user_investor', role: 'investor', tenantId: 'test-tenant' }, TEST_SECRET, { expiresIn: '1h' });
-
 const ADDR1 = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
-const ADDR2 = 'GDGQVOKHW4VEJRU2TETD8G6RWJ3TVM3VROMV7I3ESNITIBLL6QL6RAIL';
+const ADDR2 = 'GABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEJXA';
+const tokenFor = (payload) => jwt.sign(payload, TEST_SECRET, { expiresIn: '1h' });
+const validToken = tokenFor({ id: 'user_investor', role: 'investor', tenantId: 'test-tenant', funderAddress: ADDR1 });
+const secondInvestorToken = tokenFor({ id: 'user_investor_2', role: 'investor', tenantId: 'test-tenant', funderAddress: ADDR2 });
+const adminToken = tokenFor({ id: 'admin_user', role: 'admin', tenantId: 'test-tenant' });
+const unboundInvestorToken = tokenFor({ id: 'user_unbound', role: 'investor', tenantId: 'test-tenant' });
 
 describe('Investor Locks API', () => {
   let app;
@@ -31,7 +56,7 @@ describe('Investor Locks API', () => {
       expect(response.status).toBe(401);
     });
 
-    it('should return 200 with all locks when authenticated without filters', async () => {
+    it('should scope omitted funderAddress to the authenticated investor', async () => {
       const response = await request(app)
         .get('/api/investor/locks')
         .set('Authorization', `Bearer ${validToken}`);
@@ -40,7 +65,20 @@ describe('Investor Locks API', () => {
       expect(response.body.data).toBeDefined();
       expect(Array.isArray(response.body.data)).toBe(true);
       expect(response.body.data.length).toBeGreaterThan(0);
+      expect(response.body.data.every((lock) => lock.funderAddress === ADDR1)).toBe(true);
+      expect(response.body.data.some((lock) => lock.funderAddress === ADDR2)).toBe(false);
       expect(response.body.meta.stale).toBe(true);
+    });
+
+    it('allows admin callers to list all tenant locks when funderAddress is omitted', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(6);
+      expect(response.body.data.some((lock) => lock.funderAddress === ADDR1)).toBe(true);
+      expect(response.body.data.some((lock) => lock.funderAddress === ADDR2)).toBe(true);
     });
 
     it('should include pagination meta fields', async () => {
@@ -75,6 +113,34 @@ describe('Investor Locks API', () => {
       expect(response.status).toBe(200);
       expect(response.body.data.length).toBeGreaterThan(0);
       expect(response.body.data.every((l) => l.funderAddress === ADDR1)).toBe(true);
+    });
+
+    it('denies a non-admin caller that requests another funderAddress', async () => {
+      const response = await request(app)
+        .get(`/api/investor/locks?funderAddress=${ADDR2}`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('not authorized');
+    });
+
+    it('allows an admin caller to request another funderAddress', async () => {
+      const response = await request(app)
+        .get(`/api/investor/locks?funderAddress=${ADDR2}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data.every((lock) => lock.funderAddress === ADDR2)).toBe(true);
+    });
+
+    it('denies non-admin callers that have no bound funderAddress', async () => {
+      const response = await request(app)
+        .get('/api/investor/locks')
+        .set('Authorization', `Bearer ${unboundInvestorToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('not bound');
     });
 
     it('should return 400 for invalid address format', async () => {
@@ -221,8 +287,26 @@ describe('Investor Locks API', () => {
         page++;
       }
 
-      // All 6 seeded locks must have been seen
-      expect(seen.size).toBe(6);
+      // The non-admin caller sees only the 5 seeded locks for their bound address.
+      expect(seen.size).toBe(5);
+      expect([...seen].every((key) => key.endsWith(`:${ADDR1}`))).toBe(true);
+    });
+
+    it('does not reuse cached list responses across different bound funders', async () => {
+      resetStore();
+
+      const first = await request(app)
+        .get('/api/investor/locks?limit=100')
+        .set('Authorization', `Bearer ${validToken}`);
+      const second = await request(app)
+        .get('/api/investor/locks?limit=100')
+        .set('Authorization', `Bearer ${secondInvestorToken}`);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(first.body.data.every((lock) => lock.funderAddress === ADDR1)).toBe(true);
+      expect(second.body.data.every((lock) => lock.funderAddress === ADDR2)).toBe(true);
+      expect(second.body.data).toHaveLength(1);
     });
   });
 
@@ -265,6 +349,30 @@ describe('Investor Locks API', () => {
       expect(response.body.data).toHaveProperty('claimNotBefore');
       expect(response.body.data).toHaveProperty('investorEffectiveYieldBps');
       expect(response.body.data).toHaveProperty('stale');
+    });
+
+    it('denies a single-lock lookup for another funderAddress', async () => {
+      const response = await request(app)
+        .get(`/api/investor/locks/inv_9900?funderAddress=${ADDR2}`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('not authorized');
+    });
+
+    it('does not reuse cached single-lock responses across different bound funders', async () => {
+      resetStore();
+
+      const first = await request(app)
+        .get(`/api/investor/locks/inv_9900?funderAddress=${ADDR2}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+      const second = await request(app)
+        .get(`/api/investor/locks/inv_9900?funderAddress=${ADDR2}`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(first.status).toBe(200);
+      expect(first.body.data.funderAddress).toBe(ADDR2);
+      expect(second.status).toBe(403);
     });
   });
 });

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -128,6 +128,22 @@ jest.mock('@stellar/stellar-sdk', () => ({
     })),
   },
   StrKey: {
+    encodeEd25519PublicKey: jest.fn((payload) => {
+      const byte = Buffer.isBuffer(payload) && payload.length > 0 ? payload[0] : 1;
+      const alphabet = 'BCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      return `G${'A'.repeat(54)}${alphabet[byte % alphabet.length]}`;
+    }),
+    encodeContract: jest.fn((payload) => {
+      const byte = Buffer.isBuffer(payload) && payload.length > 0 ? payload[0] : 1;
+      const alphabet = 'BCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      return `C${'A'.repeat(54)}${alphabet[byte % alphabet.length]}`;
+    }),
+    isValidEd25519PublicKey: jest.fn((value) => {
+      return typeof value === 'string' && /^G[A-Z2-7]{55}$/.test(value) && !/^G{56}$/.test(value);
+    }),
+    isValidContract: jest.fn((value) => {
+      return typeof value === 'string' && /^C[A-Z2-7]{55}$/.test(value) && !/^C{56}$/.test(value);
+    }),
     isValidContractId: jest.fn((contractId) => {
       if (typeof contractId !== 'string') return false;
       const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;


### PR DESCRIPTION
## Summary

- Enforce authenticated funder scoping on `GET /api/investor/locks` and `GET /api/investor/locks/:invoiceId`.
- Scope non-admin callers with an omitted `funderAddress` to the funder address bound to their JWT principal.
- Return `403` when a non-admin caller has no bound funder or requests another funder.
- Preserve admin and owner tenant-wide lock inspection.
- Add principal scope to investor-lock cache keys so cached list or single-lock responses cannot cross callers.
- Update investor-lock docs and regression tests.

Closes #517

## Validation

- `npm test -- --runTestsByPath tests/investor.locks.test.js --silent`
- `npx jest --runInBand --runTestsByPath tests/investor.locks.test.js --coverage --collectCoverageFrom=src/routes/investor.js --collectCoverageFrom=src/middleware/cache.js --collectCoverageFrom=src/utils/investorLockScope.js --collectCoverageFrom=src/services/investorCommitment.js --coverageThreshold='{}'`
- `npx eslint src/routes/investor.js src/middleware/cache.js src/utils/investorLockScope.js src/services/investorCommitment.js tests/investor.locks.test.js tests/mocks/setup.js`
- `git diff --check`
- `npm test -- --silent` fails on existing repo baseline issues: duplicate `registerJobQueue` parse error in `src/metrics.js`, plus shutdown, audit CSV, invoice upload, and rate-limit test failures. Summary observed: 83 failed, 1 skipped, 45 passed test suites; 229 failed, 5 skipped, 1056 passed tests.
- `npm run lint` fails on existing repo baseline issues. Summary observed: 85 errors and 8 warnings, none from the touched-file ESLint command above.
