### PR TITLE
Restrict JWT test-secret fallback to test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Part of the LiquiFact stack: frontend (Next.js) | backend (this repo) | contract
 
    > [!IMPORTANT]
    > **Startup Validation Gate**: The application validates all required environment variables at boot time before binding to a port. If the configuration is invalid (e.g. `JWT_SECRET` is shorter than 32 characters or KYC keys are half-configured), the server will print a redacted error summary showing the failed keys and exit immediately. Secret values are never exposed in validation output.
+   > Authentication uses the validated `JWT_SECRET`, algorithm allowlist, issuer, and audience settings from the central config. The literal `test-secret` fallback is only permitted when `NODE_ENV=test`; in every other environment unavailable auth config rejects the request instead of accepting forgeable tokens.
 
 4. Start database services
 

--- a/src/__tests__/auth.test.js
+++ b/src/__tests__/auth.test.js
@@ -4,6 +4,7 @@ const express = require('express');
 const request = require('supertest');
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
+const configModule = require('../config');
 const { authenticateToken } = require('../middleware/auth');
 
 // Build a self-contained Express app so the middleware can be tested in isolation
@@ -39,12 +40,24 @@ const { privateKey } = crypto.generateKeyPairSync('rsa', {
 describe('Authentication Middleware', () => {
   const secret = process.env.JWT_SECRET || 'test-secret';
   const validPayload = { id: 1, role: 'user' };
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalJwtSecret = process.env.JWT_SECRET;
   let validToken;
   let expiredToken;
 
   beforeAll(() => {
     validToken = jwt.sign(validPayload, secret, { expiresIn: '1h' });
     expiredToken = jwt.sign(validPayload, secret, { expiresIn: '-1h' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
   });
 
   // ─── Route Protection — POST /api/invoices ────────────────────────────────
@@ -90,6 +103,18 @@ describe('Authentication Middleware', () => {
         .send({});
       expect(res.status).toBe(401);
       expect(res.body.detail).toBe('Token has expired');
+    });
+
+    it('should return 401 when token is not active yet', async () => {
+      const futureToken = jwt.sign(validPayload, secret, { expiresIn: '1h', notBefore: '1h' });
+
+      const res = await request(app)
+        .post('/api/invoices')
+        .set('Authorization', `Bearer ${futureToken}`)
+        .send({});
+
+      expect(res.status).toBe(401);
+      expect(res.body.detail).toBe('Token not yet active');
     });
 
     it('should return 201 when a valid token is provided', async () => {
@@ -207,6 +232,87 @@ describe('Authentication Middleware', () => {
         .get('/api/escrow/test-invoice')
         .set('Authorization', '');
       expect(res.status).toBe(401);
+    });
+  });
+
+  describe('JWT config fallback safety', () => {
+    it('rejects test-secret tokens outside test mode when config is unavailable', async () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.JWT_SECRET;
+      jest.spyOn(configModule, 'get').mockImplementation(() => {
+        throw new Error('Config not validated. Call validate() first.');
+      });
+
+      const forgedToken = jwt.sign(validPayload, 'test-secret', { expiresIn: '1h' });
+
+      const res = await request(app)
+        .post('/api/invoices')
+        .set('Authorization', `Bearer ${forgedToken}`)
+        .send({});
+
+      expect(res.status).toBe(401);
+      expect(res.body.detail).toBe('Authentication configuration is unavailable');
+    });
+
+    it('does not expose the secret or token when config is unavailable', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = 'test-secret';
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest.spyOn(configModule, 'get').mockImplementation(() => {
+        throw new Error('Config not validated. Call validate() first.');
+      });
+      const token = jwt.sign(validPayload, 'test-secret', { expiresIn: '1h' });
+
+      const res = await request(app)
+        .post('/api/invoices')
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(JSON.stringify(res.body)).not.toContain('test-secret');
+      expect(JSON.stringify(res.body)).not.toContain(token);
+    });
+
+    it('allows the fallback secret only while NODE_ENV is test', async () => {
+      process.env.NODE_ENV = 'test';
+      process.env.JWT_SECRET = 'test-secret';
+      jest.spyOn(configModule, 'get').mockImplementation(() => {
+        throw new Error('Config not validated. Call validate() first.');
+      });
+
+      const testToken = jwt.sign(validPayload, 'test-secret', { expiresIn: '1h' });
+
+      const res = await request(app)
+        .post('/api/invoices')
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ amount: 1000 });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('uses validated config instead of the environment fallback when available', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = 'test-secret';
+      const validatedSecret = 'validated-secret-at-least-32-characters-long';
+      jest.spyOn(configModule, 'get').mockReturnValue({
+        JWT_SECRET: validatedSecret,
+        JWT_ALGORITHMS: 'HS256',
+      });
+
+      const validConfiguredToken = jwt.sign(validPayload, validatedSecret, { expiresIn: '1h' });
+      const forgedFallbackToken = jwt.sign(validPayload, 'test-secret', { expiresIn: '1h' });
+
+      const accepted = await request(app)
+        .post('/api/invoices')
+        .set('Authorization', `Bearer ${validConfiguredToken}`)
+        .send({ amount: 1000 });
+      const rejected = await request(app)
+        .post('/api/invoices')
+        .set('Authorization', `Bearer ${forgedFallbackToken}`)
+        .send({ amount: 1000 });
+
+      expect(accepted.status).toBe(201);
+      expect(rejected.status).toBe(401);
     });
   });
 });

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -11,6 +11,39 @@ const AppError = require('../errors/AppError');
 const configModule = require('../config');
 
 /**
+ * Resolve JWT verification configuration from the validated app config.
+ * A weak literal fallback is only allowed in test mode so isolated middleware
+ * tests can run before boot validation. Non-test environments must never
+ * authenticate with an unvalidated or missing secret.
+ *
+ * @param {string} instance - Request path for RFC 7807 error metadata.
+ * @returns {{JWT_SECRET: string, JWT_ALGORITHMS?: string, JWT_ISSUER?: string, JWT_AUDIENCE?: string}} JWT config.
+ * @throws {AppError} When config is unavailable outside test mode.
+ */
+function resolveJwtConfig(instance) {
+  try {
+    return configModule.get();
+  } catch (_err) {
+    if (process.env.NODE_ENV === 'test') {
+      return {
+        JWT_SECRET: process.env.JWT_SECRET || 'test-secret',
+        JWT_ALGORITHMS: process.env.JWT_ALGORITHMS || 'HS256',
+        JWT_ISSUER: process.env.JWT_ISSUER,
+        JWT_AUDIENCE: process.env.JWT_AUDIENCE,
+      };
+    }
+
+    throw new AppError({
+      type: 'https://liquifact.com/probs/auth-config-unavailable',
+      title: 'Unauthorized',
+      status: 401,
+      detail: 'Authentication configuration is unavailable',
+      instance,
+    });
+  }
+}
+
+/**
  * Middleware function to enforce authentication for protected routes.
  * Checks the "Authorization" header for a "Bearer <token>" pattern,
  * validates the JWT with algorithm allowlist, issuer, and audience enforcement,
@@ -50,15 +83,9 @@ const authenticateToken = (req, res, next) => {
 
   let cfg;
   try {
-    cfg = configModule.get();
-  } catch (_err) {
-    // Fallback for tests or before config is validated
-    cfg = {
-      JWT_SECRET: process.env.JWT_SECRET || 'test-secret',
-      JWT_ALGORITHMS: process.env.JWT_ALGORITHMS || 'HS256',
-      JWT_ISSUER: process.env.JWT_ISSUER,
-      JWT_AUDIENCE: process.env.JWT_AUDIENCE,
-    };
+    cfg = resolveJwtConfig(req.originalUrl);
+  } catch (err) {
+    return next(err);
   }
 
   const secret = cfg.JWT_SECRET;
@@ -92,4 +119,4 @@ const authenticateToken = (req, res, next) => {
   });
 };
 
-module.exports = { authenticateToken };
+module.exports = { authenticateToken, resolveJwtConfig };


### PR DESCRIPTION
## Summary

- Resolve JWT verification settings through the validated config path in normal runtime.
- Keep the `test-secret` fallback available only when `NODE_ENV=test`.
- Return a 401 RFC 7807 `AppError` when auth config is unavailable outside test mode instead of accepting forgeable tokens.
- Add focused regression coverage for production config failure, test-only fallback, validated-config precedence, not-before tokens, and secret/token non-exposure.
- Document the production auth-config behavior in the README.

Closes #510

## Security Notes

- Tokens signed with the literal `test-secret` are rejected outside test mode when config is unavailable.
- The fallback is still available for isolated test-mode middleware tests.
- The unavailable-config response does not include the token or secret and the middleware does not log either value.

## Validation

- `npm test -- --runTestsByPath src/__tests__/auth.test.js --silent`
- `npx jest --runInBand --runTestsByPath src/__tests__/auth.test.js --coverage --collectCoverageFrom=src/middleware/auth.js --coverageThreshold='{}'`
  - `src/middleware/auth.js`: 95.23 percent statements, 85.71 percent branches, 100 percent functions, 100 percent lines.
- `npx eslint src/middleware/auth.js src/__tests__/auth.test.js`
- `git diff --check`
- `npm test -- --silent` fails on existing repo baseline issues. Summary observed: 86 failed, 1 skipped, 42 passed test suites; 265 failed, 5 skipped, 952 passed tests. Failure families include duplicate `registerJobQueue` parse error in `src/metrics.js`, shutdown timeout/assertion failures, audit CSV streaming failures, invoice upload failures, rate-limit expectation failures, and missing Stellar StrKey mock helpers on this upstream branch.
- `npm run lint` fails on existing repo baseline issues. Summary observed: 85 errors and 8 warnings, none from the touched-file ESLint command above.
