### PR TITLE
Fail closed on cursor dev secret in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ PORT=3001
 HELMET_CSP=false
 # JWT secret (required, min 32 chars, generate securely)
 JWT_SECRET=your-super-secure-jwt-secret-key-at-least-32-chars-long-here
+# Optional dedicated cursor HMAC secret. When absent, cursor signing uses JWT_SECRET.
+# In production, never rely on the development/test fallback.
+# CURSOR_SECRET=replace-with-a-long-random-cursor-secret
+# Recommended in production to limit cursor replay windows.
+CURSOR_TTL_ENABLED=false
+CURSOR_TTL_SECONDS=3600
 
 # CORS origins (optional, comma-separated)
 # CORS_ORIGINS=https://yourapp.com,http://localhost:3000
@@ -244,4 +250,3 @@ KYC_PROVIDER_SECRET=replace-with-your-kyc-signing-secret
 # ---------------------------
 # Timeout in milliseconds for graceful shutdown before force exit (default: 10000)
 SHUTDOWN_TIMEOUT_MS=10000
-

--- a/README.md
+++ b/README.md
@@ -553,6 +553,8 @@ The documentation covers all public endpoints including health checks, invoice m
 
   **Cursor pagination (recommended)** — stable under inserts/deletes; use the `nextCursor` value from one response as the `cursor` param in the next request. Cursors are opaque and HMAC-signed; any modification returns 400.
 
+  Cursor signatures use `CURSOR_SECRET` when set, otherwise `JWT_SECRET`. The public development fallback is only available in `development` and `test`; production deployments must configure a real secret before signing or verifying cursors. For production, prefer `CURSOR_TTL_ENABLED=true` with a bounded `CURSOR_TTL_SECONDS` such as `3600` to limit replay windows. Shorter TTLs reduce replay risk but can expire long-running pagination sessions.
+
   **Offset pagination (legacy)** — use `page` + `limit` as before. `nextCursor` and `hasMore` are also returned so clients can migrate incrementally.
 
   | Param | Mode | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 ## Boot-Time Validation
 
 - `JWT_SECRET` is required by [`src/config/index.js`](../src/config/index.js) and must be at least 32 characters.
+- `CURSOR_SECRET` is optional when `JWT_SECRET` is available, but production cursor signing must never fall back to the public development/test cursor secret.
 - `STELLAR_NETWORK` and `SOROBAN_RPC_URL` are documented as a required boot-time pair in the Stellar validation section of the [README](../README.md#stellar-network-configuration). The expected pairs are `TESTNET` with `https://soroban-testnet.stellar.org`, `MAINNET` with `https://soroban.stellar.org`, and `FUTURENET` with `https://rpc-futurenet.stellar.org`.
 - `KYC_PROVIDER_URL` and `KYC_PROVIDER_API_KEY` must either both be set or both be absent outside `NODE_ENV=test`.
 - `ESCROW_PLATFORM_ADDRESS` is required only when `ESCROW_SIGNING_MODE` is `delegated` or `custodial` in [`src/services/escrowSubmit.js`](../src/services/escrowSubmit.js).
@@ -21,6 +22,9 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 | `PORT` | integer port | `3001` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/index.js`](../src/index.js), [`src/server.js`](../src/server.js) |
 | `HELMET_CSP` | boolean string | `false` in template; app defaults vary by environment | No | No | [`src/app.js`](../src/app.js) |
 | `JWT_SECRET` | string, min 32 chars for config validation | None | Yes | **Secret** | [`src/config/index.js`](../src/config/index.js), [`src/middleware/auth.js`](../src/middleware/auth.js) |
+| `CURSOR_SECRET` | string, min 32 chars when set | Falls back to `JWT_SECRET`; public dev fallback only in development/test | No | **Secret** | [`src/config/index.js`](../src/config/index.js), [`src/utils/cursorPagination.js`](../src/utils/cursorPagination.js) |
+| `CURSOR_TTL_ENABLED` | boolean string | `false` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/utils/cursorPagination.js`](../src/utils/cursorPagination.js) |
+| `CURSOR_TTL_SECONDS` | integer seconds | `3600` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/utils/cursorPagination.js`](../src/utils/cursorPagination.js) |
 | `CORS_ORIGINS` | comma-separated origins | Development localhost fallback; production denies when unset | No | No | [`src/config/cors.js`](../src/config/cors.js) |
 | `CORS_ALLOWED_ORIGINS` | comma-separated origins | Optional alias preferred over `CORS_ORIGINS` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/config/cors.js`](../src/config/cors.js) |
 | `CORS_MAX_AGE` | integer seconds | `600` | No | No | [`src/config/cors.js`](../src/config/cors.js) |

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -19,6 +19,9 @@ const ConfigSchema = z
     JWT_ALGORITHMS: z.string().optional().default('HS256'), // Comma-separated allowlist, e.g. HS256,RS256
     JWT_ISSUER: z.string().optional(), // Optional issuer claim to enforce
     JWT_AUDIENCE: z.string().optional(), // Optional audience claim to enforce
+    CURSOR_SECRET: z.string().min(32).optional(), // Dedicated marketplace cursor HMAC secret
+    CURSOR_TTL_ENABLED: z.enum(['true', 'false']).default('false'),
+    CURSOR_TTL_SECONDS: z.coerce.number().int().min(1).default(3600),
     CORS_ALLOWED_ORIGINS: z.string().optional(), // Comma-separated, optional for dev fallbacks
     SOROBAN_RPC_URL: z.string().url().default('https://soroban-testnet.stellar.org'),
     NETWORK_PASSPHRASE: z.string().default('Test SDF Network ; September 2015'),
@@ -36,6 +39,13 @@ const ConfigSchema = z
   })
   .superRefine((data, ctx) => {
     if (data.NODE_ENV === 'test') { return; }
+    if (data.NODE_ENV === 'production' && !data.CURSOR_SECRET && !data.JWT_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'CURSOR_SECRET or JWT_SECRET must be configured in production.',
+        path: ['CURSOR_SECRET'],
+      });
+    }
     const hasUrl = Boolean(data.KYC_PROVIDER_URL);
     const hasKey = Boolean(data.KYC_PROVIDER_API_KEY);
     if (hasUrl !== hasKey) {

--- a/src/utils/cursorPagination.js
+++ b/src/utils/cursorPagination.js
@@ -7,16 +7,40 @@
 
 const crypto = require('crypto');
 
-const CURSOR_SECRET = process.env.CURSOR_SECRET || process.env.JWT_SECRET || 'dev-cursor-secret-change-in-prod';
+const DEV_CURSOR_SECRET = 'dev-cursor-secret-change-in-prod';
 
 const ALLOWED_SORT_FIELDS = Object.freeze(['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at']);
 
 /**
+ * Resolves the HMAC secret used to sign and verify opaque cursors.
+ * Production must use a real CURSOR_SECRET or JWT_SECRET. The public dev
+ * fallback is available only for local development and test runs.
+ *
+ * @returns {string} Cursor signing secret.
+ * @throws {Error} When no real secret is configured outside development/test.
+ */
+function _resolveCursorSecret() {
+  const configuredSecret = process.env.CURSOR_SECRET || process.env.JWT_SECRET;
+  if (configuredSecret) {
+    return configuredSecret;
+  }
+
+  const nodeEnv = process.env.NODE_ENV || 'development';
+  if (nodeEnv === 'development' || nodeEnv === 'test') {
+    return DEV_CURSOR_SECRET;
+  }
+
+  throw new Error('CURSOR_SECRET or JWT_SECRET must be configured for cursor pagination outside development/test');
+}
+
+/**
+ * Signs a base64url cursor payload with the resolved HMAC secret.
+ *
  * @param {string} payload
  * @returns {string}
  */
 function _sign(payload) {
-  return crypto.createHmac('sha256', CURSOR_SECRET).update(payload).digest('hex');
+  return crypto.createHmac('sha256', _resolveCursorSecret()).update(payload).digest('hex');
 }
 
 /**
@@ -117,6 +141,8 @@ function decodeCursor(cursor, expectedSortField) {
  */
 class CursorError extends Error {
   /**
+   * Create a cursor domain error.
+   *
    * @param {string} message
    */
   constructor(message) {

--- a/tests/cursorPagination.secret.test.js
+++ b/tests/cursorPagination.secret.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const ORIGINAL_ENV = { ...process.env };
+const DEV_CURSOR_SECRET = 'dev-cursor-secret-change-in-prod';
+const REAL_CURSOR_SECRET = 'real-cursor-secret-at-least-32-chars';
+const REAL_JWT_SECRET = 'real-jwt-secret-at-least-32-chars-long';
+
+function loadCursorPagination() {
+  jest.resetModules();
+  return require('../src/utils/cursorPagination');
+}
+
+function buildSignedCursor(secret, overrides = {}) {
+  const payload = Buffer.from(JSON.stringify({
+    sortField: 'amount',
+    sortValue: 1000,
+    id: 'inv_cursor_secret',
+    iat: Math.floor(Date.now() / 1000),
+    ...overrides,
+  })).toString('base64url');
+  const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  return `${payload}.${sig}`;
+}
+
+function buildRawSignedCursor(secret, payloadValue) {
+  const payload = Buffer.from(payloadValue).toString('base64url');
+  const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  return `${payload}.${sig}`;
+}
+
+describe('cursor pagination secret resolution', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.CURSOR_SECRET;
+    delete process.env.JWT_SECRET;
+    delete process.env.CURSOR_TTL_ENABLED;
+    delete process.env.CURSOR_TTL_SECONDS;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('fails closed when no cursor or JWT secret is configured in production', () => {
+    process.env.NODE_ENV = 'production';
+    const { encodeCursor } = loadCursorPagination();
+
+    expect(() => encodeCursor({ sortField: 'amount', sortValue: 1, id: 'inv_1' }))
+      .toThrow(/CURSOR_SECRET or JWT_SECRET/);
+  });
+
+  it('signs and verifies cursors with a real production CURSOR_SECRET', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    const { encodeCursor, decodeCursor } = loadCursorPagination();
+
+    const cursor = encodeCursor({ sortField: 'amount', sortValue: 42, id: 'inv_real' });
+    const decoded = decodeCursor(cursor, 'amount');
+
+    expect(decoded).toMatchObject({ sortField: 'amount', sortValue: 42, id: 'inv_real' });
+  });
+
+  it('preserves encode validation for unsupported sort fields and missing ids', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    const { encodeCursor } = loadCursorPagination();
+
+    expect(() => encodeCursor({ sortField: 'bad_field', sortValue: 1, id: 'inv_1' }))
+      .toThrow(/unsupported sortField/);
+    expect(() => encodeCursor({ sortField: 'amount', sortValue: 1, id: '' }))
+      .toThrow(/id must be a non-empty string/);
+  });
+
+  it('falls back to JWT_SECRET when a dedicated cursor secret is absent', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = REAL_JWT_SECRET;
+    const { encodeCursor, decodeCursor } = loadCursorPagination();
+
+    const cursor = encodeCursor({ sortField: 'yield_bps', sortValue: 700, id: 'inv_jwt' });
+    const decoded = decodeCursor(cursor, 'yield_bps');
+
+    expect(decoded).toMatchObject({ sortField: 'yield_bps', sortValue: 700, id: 'inv_jwt' });
+  });
+
+  it('keeps the dev fallback available in test mode', () => {
+    process.env.NODE_ENV = 'test';
+    const { encodeCursor, decodeCursor } = loadCursorPagination();
+
+    const cursor = encodeCursor({ sortField: 'created_at', sortValue: '2026-06-29', id: 'inv_test' });
+    const decoded = decodeCursor(cursor, 'created_at');
+
+    expect(decoded.id).toBe('inv_test');
+  });
+
+  it('rejects a cursor forged with the dev secret when production uses a real secret', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    const { decodeCursor, CursorError } = loadCursorPagination();
+    const forged = buildSignedCursor(DEV_CURSOR_SECRET);
+
+    expect(() => decodeCursor(forged, 'amount')).toThrow(CursorError);
+  });
+
+  it('preserves malformed cursor and payload validation', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    const { decodeCursor, CursorError } = loadCursorPagination();
+    const notJson = buildRawSignedCursor(REAL_CURSOR_SECRET, 'not json');
+    const unknownSort = buildSignedCursor(REAL_CURSOR_SECRET, { sortField: 'bad_field' });
+    const missingId = buildSignedCursor(REAL_CURSOR_SECRET, { id: '' });
+    const missingIat = buildSignedCursor(REAL_CURSOR_SECRET, { iat: undefined });
+
+    expect(() => decodeCursor('nodothere', 'amount')).toThrow(CursorError);
+    expect(() => decodeCursor(notJson, 'amount')).toThrow(/payload is not valid JSON/);
+    expect(() => decodeCursor(unknownSort, 'amount')).toThrow(/unknown sort field/);
+    expect(() => decodeCursor(missingId, 'amount')).toThrow(/id tiebreaker/);
+    expect(() => decodeCursor(missingIat, 'amount')).toThrow(/issued-at/);
+  });
+
+  it('rejects cursors whose sort field does not match the request', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    const { encodeCursor, decodeCursor, CursorError } = loadCursorPagination();
+    const cursor = encodeCursor({ sortField: 'amount', sortValue: 1, id: 'inv_sort' });
+
+    expect(() => decodeCursor(cursor, 'yield_bps')).toThrow(CursorError);
+  });
+
+  it('expires cursors when TTL validation is enabled', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    process.env.CURSOR_TTL_ENABLED = 'true';
+    process.env.CURSOR_TTL_SECONDS = '60';
+    const { decodeCursor, CursorError } = loadCursorPagination();
+    const oldIat = Math.floor(Date.now() / 1000) - 61;
+    const expired = buildSignedCursor(REAL_CURSOR_SECRET, { iat: oldIat });
+
+    expect(() => decodeCursor(expired, 'amount')).toThrow(CursorError);
+    expect(() => decodeCursor(expired, 'amount')).toThrow(/expired/);
+  });
+
+  it('accepts fresh cursors when TTL validation is enabled', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURSOR_SECRET = REAL_CURSOR_SECRET;
+    process.env.CURSOR_TTL_ENABLED = 'true';
+    process.env.CURSOR_TTL_SECONDS = '60';
+    const { decodeCursor } = loadCursorPagination();
+    const fresh = buildSignedCursor(REAL_CURSOR_SECRET);
+
+    expect(decodeCursor(fresh, 'amount').id).toBe('inv_cursor_secret');
+  });
+});
+
+describe('cursor pagination config validation', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('accepts a production config with a dedicated cursor secret and TTL settings', () => {
+    const { ConfigSchema } = require('../src/config');
+
+    const result = ConfigSchema.safeParse({
+      NODE_ENV: 'production',
+      JWT_SECRET: REAL_JWT_SECRET,
+      CURSOR_SECRET: REAL_CURSOR_SECRET,
+      CURSOR_TTL_ENABLED: 'true',
+      CURSOR_TTL_SECONDS: '900',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.CURSOR_TTL_SECONDS).toBe(900);
+  });
+
+  it('rejects a short dedicated cursor secret', () => {
+    const { ConfigSchema } = require('../src/config');
+
+    const result = ConfigSchema.safeParse({
+      NODE_ENV: 'production',
+      JWT_SECRET: REAL_JWT_SECRET,
+      CURSOR_SECRET: 'short',
+    });
+
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error.issues)).toContain('CURSOR_SECRET');
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve marketplace cursor HMAC secrets at signing/verification time instead of capturing the public dev fallback at module load.
- Fail closed outside `development` and `test` when neither `CURSOR_SECRET` nor `JWT_SECRET` is configured.
- Keep the dev fallback available for local and test mode only.
- Add cursor config schema entries for `CURSOR_SECRET`, `CURSOR_TTL_ENABLED`, and `CURSOR_TTL_SECONDS`.
- Document production cursor-secret and TTL guidance in `.env.example`, README, and configuration docs.
- Add focused regression coverage for production fail-closed behavior, JWT fallback, test-mode dev fallback, forged dev-secret cursors, malformed cursor contracts, and TTL expiry.

Closes #508

## Security Notes

- Production no longer signs or verifies cursors with `dev-cursor-secret-change-in-prod`.
- A cursor signed with the dev secret is rejected when production uses a real cursor secret.
- `decodeCursor` still uses `crypto.timingSafeEqual` for signature comparison.
- `encodeCursor`, `decodeCursor`, `CursorError`, and `ALLOWED_SORT_FIELDS` remain the public cursor module contract.

## Validation

- `npm test -- --runTestsByPath tests/cursorPagination.secret.test.js --silent`
- `npx jest --runInBand --runTestsByPath tests/cursorPagination.secret.test.js --coverage --collectCoverageFrom=src/utils/cursorPagination.js --coverageThreshold='{}'`
  - `src/utils/cursorPagination.js`: 100 percent statements, 95.45 percent branches, 100 percent functions, 100 percent lines.
- `npx eslint src/utils/cursorPagination.js src/config/index.js tests/cursorPagination.secret.test.js`
- `git diff --check`
- `npm test -- --runTestsByPath tests/marketplace.test.js --silent` fails before marketplace tests run because the existing upstream `src/metrics.js` duplicate `registerJobQueue` parse error blocks app imports.
- `npm test -- --runTestsByPath src/config/index.test.js --silent` is baseline-red: existing issuer/audience default expectation mismatch plus the same `src/metrics.js` parse blocker in boot-gate cases.
- `npm test -- --silent` fails on existing repo baseline issues. Summary observed: 86 failed, 1 skipped, 43 passed test suites; 265 failed, 5 skipped, 959 passed tests.
- `npm run lint` fails on existing repo baseline issues. Summary observed: 83 errors and 8 warnings, none from the touched-file ESLint command above.
