### PR TITLE
Fix invoice status filter enum drift

### DIFF
--- a/docs/API-Examples.md
+++ b/docs/API-Examples.md
@@ -261,6 +261,44 @@ X-Request-ID: req_123456796
 }
 ```
 
+### 3. List Invoices With a Status Filter (200)
+
+`GET /api/invoices` accepts the shared invoice status vocabulary used by the
+state machine and marketplace validators.
+
+Supported `status` values:
+
+`paid`, `pending`, `overdue`, `pending_verification`, `verified`,
+`partially_funded`, `funded`, `settled`, `completed`, `defaulted`, `approved`,
+`linked_escrow`, `rejected`, `cancelled`
+
+**Request:**
+```bash
+curl -X GET "http://localhost:3001/api/invoices?status=verified&sortBy=amount&order=desc" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Request-ID: req_123456797
+
+{
+  "data": [
+    {
+      "id": "inv_1640995200000_124",
+      "amount": 25000,
+      "customer": "Globex Corp",
+      "status": "verified",
+      "createdAt": "2021-12-31T23:59:59.999Z",
+      "deletedAt": null
+    }
+  ],
+  "message": "Invoices retrieved successfully."
+}
+```
+
 ## Client Implementation Examples
 
 ### JavaScript/Node.js

--- a/src/__tests__/invoice.api.test.js
+++ b/src/__tests__/invoice.api.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const { createApp } = require('../app');
+const { ALL_INVOICE_STATUSES } = require('../services/invoiceStateMachine');
 
 jest.mock('../services/invoiceService', () => ({
   getInvoices: jest.fn(),
@@ -83,7 +84,7 @@ describe('Invoice API Integration', () => {
       const res = await request(app).get('/api/invoices?status=invalid');
 
       expect(res.statusCode).toBe(400);
-      expect(res.body.errors).toContain('Invalid status. Must be one of: paid, pending, overdue');
+      expect(res.body.errors).toContain(`Invalid status. Must be one of: ${ALL_INVOICE_STATUSES.join(', ')}`);
       expect(invoiceService.getInvoices).not.toHaveBeenCalled();
     });
 

--- a/src/services/invoiceStateMachine.js
+++ b/src/services/invoiceStateMachine.js
@@ -1,3 +1,73 @@
+'use strict';
+
+/**
+ * Canonical invoice status vocabulary shared by invoice-list and marketplace
+ * query validators.
+ */
+
+/**
+ * Lifecycle states used by invoice transition endpoints.
+ * @type {Readonly<Record<string, string>>}
+ */
+const INVOICE_STATES = Object.freeze({
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  LINKED_ESCROW: 'linked_escrow',
+  REJECTED: 'rejected',
+  CANCELLED: 'cancelled',
+});
+
+/**
+ * Legacy payment-facing statuses accepted by GET /api/invoices.
+ * @type {readonly string[]}
+ */
+const PAYMENT_STATUSES = Object.freeze(['paid', 'pending', 'overdue']);
+
+/**
+ * Funding and settlement statuses surfaced by marketplace and escrow flows.
+ * @type {readonly string[]}
+ */
+const FUNDING_PROGRESS_STATUSES = Object.freeze([
+  'pending_verification',
+  'verified',
+  'partially_funded',
+  'funded',
+  'settled',
+  'completed',
+  'defaulted',
+]);
+
+/**
+ * Authoritative invoice status list for query-parameter validation.
+ * @type {readonly string[]}
+ */
+const ALL_INVOICE_STATUSES = Object.freeze([
+  ...new Set([
+    ...PAYMENT_STATUSES,
+    ...FUNDING_PROGRESS_STATUSES,
+    ...Object.values(INVOICE_STATES),
+  ]),
+]);
+
+/**
+ * Statuses visible in public investable invoice flows.
+ * @type {readonly string[]}
+ */
+const INVESTABLE_STATUSES = Object.freeze(['verified', 'partially_funded']);
+
+/**
+ * Terminal states that should not become investable.
+ * @type {readonly string[]}
+ */
+const TERMINAL_STATES = Object.freeze([
+  INVOICE_STATES.LINKED_ESCROW,
+  INVOICE_STATES.REJECTED,
+  INVOICE_STATES.CANCELLED,
+  'completed',
+  'defaulted',
+  'settled',
+]);
+
 /**
  * Authoritative set of invoice states that involve capital movement.
  * Any state included in this set automatically triggers KYC gating.
@@ -6,5 +76,9 @@
 const CAPITAL_MOVING_STATES = new Set(['funded', 'settled']);
 
 module.exports = {
-    CAPITAL_MOVING_STATES
+  INVOICE_STATES,
+  ALL_INVOICE_STATUSES,
+  INVESTABLE_STATUSES,
+  TERMINAL_STATES,
+  CAPITAL_MOVING_STATES,
 };

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -39,7 +39,7 @@ function validateInvoiceQueryParams(query) {
   const { status, smeId, buyerId, dateFrom, dateTo, sortBy, order } = query;
 
   if (status !== undefined) {
-    const validStatuses = ['paid', 'pending', 'overdue'];
+    const validStatuses = ALL_INVOICE_STATUSES;
     if (validStatuses.includes(status)) {
       validatedParams.filters.status = status;
     } else {

--- a/tests/unit/validators.test.js
+++ b/tests/unit/validators.test.js
@@ -1,4 +1,7 @@
 const { validateInvoiceQueryParams } = require('../../src/utils/validators');
+const { ALL_INVOICE_STATUSES } = require('../../src/services/invoiceStateMachine');
+
+const statusErrorMessage = `Invalid status. Must be one of: ${ALL_INVOICE_STATUSES.join(', ')}`;
 
 describe('Validators Utility', () => {
   describe('validateInvoiceQueryParams', () => {
@@ -13,7 +16,7 @@ describe('Validators Utility', () => {
       const query = { status: 'invalid' };
       const result = validateInvoiceQueryParams(query);
       expect(result.isValid).toBe(false);
-      expect(result.fieldErrors.status).toBe('Invalid status. Must be one of: paid, pending, overdue');
+      expect(result.fieldErrors.status).toBe(statusErrorMessage);
     });
 
     it('should validate valid SME ID', () => {

--- a/tests/validators.invoiceQuery.test.js
+++ b/tests/validators.invoiceQuery.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const {
+  validateInvoiceQueryParams,
+  validateMarketplaceQueryParams,
+} = require('../src/utils/validators');
+const { ALL_INVOICE_STATUSES } = require('../src/services/invoiceStateMachine');
+
+const statusErrorMessage = `Invalid status. Must be one of: ${ALL_INVOICE_STATUSES.join(', ')}`;
+
+function acceptedStatusesFor(validator) {
+  return ALL_INVOICE_STATUSES.filter((status) => validator({ status }).isValid);
+}
+
+describe('validateInvoiceQueryParams status vocabulary', () => {
+  it('accepts every canonical invoice status', () => {
+    for (const status of ALL_INVOICE_STATUSES) {
+      const result = validateInvoiceQueryParams({ status });
+
+      expect(result.isValid).toBe(true);
+      expect(result.fieldErrors).toEqual({});
+      expect(result.validatedParams.filters.status).toBe(status);
+    }
+  });
+
+  it('keeps invoice-list and marketplace status validators aligned', () => {
+    expect(acceptedStatusesFor(validateInvoiceQueryParams)).toEqual(ALL_INVOICE_STATUSES);
+    expect(acceptedStatusesFor(validateMarketplaceQueryParams)).toEqual(ALL_INVOICE_STATUSES);
+  });
+
+  it('rejects unknown statuses with the canonical status list', () => {
+    const result = validateInvoiceQueryParams({ status: 'not_a_real_status' });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.status).toBe(statusErrorMessage);
+    expect(result.validatedParams.filters.status).toBeUndefined();
+  });
+
+  it('skips status validation when status is omitted', () => {
+    const result = validateInvoiceQueryParams({});
+
+    expect(result.isValid).toBe(true);
+    expect(result.fieldErrors).toEqual({});
+    expect(result.validatedParams.filters).not.toHaveProperty('status');
+  });
+
+  it('rejects invalid optional invoice filters', () => {
+    const result = validateInvoiceQueryParams({
+      smeId: '',
+      dateTo: '2025/01/01',
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors).toEqual({
+      smeId: 'Invalid smeId format',
+      dateTo: 'Invalid dateTo format. Use YYYY-MM-DD',
+    });
+  });
+
+  it('preserves sortBy and order validation semantics', () => {
+    expect(validateInvoiceQueryParams({ sortBy: 'amount', order: 'DESC' })).toMatchObject({
+      isValid: true,
+      validatedParams: {
+        sorting: {
+          sortBy: 'amount',
+          order: 'desc',
+        },
+      },
+    });
+
+    expect(validateInvoiceQueryParams({ sortBy: 'created_at', order: 'latest' })).toMatchObject({
+      isValid: false,
+      fieldErrors: {
+        sortBy: 'Invalid sortBy. Must be one of: amount, date',
+        order: 'Invalid order. Must be "asc" or "desc"',
+      },
+    });
+  });
+});
+
+describe('validateMarketplaceQueryParams status vocabulary', () => {
+  it('accepts canonical status with every valid marketplace filter shape', () => {
+    const result = validateMarketplaceQueryParams({
+      status: 'verified',
+      yieldBpsMin: '100',
+      yieldBpsMax: '1200',
+      maturityDateFrom: '2026-01-01',
+      maturityDateTo: '2026-12-31',
+      fundedRatioMin: '25.5',
+      fundedRatioMax: '75',
+      sortBy: 'funded_ratio',
+      order: 'ASC',
+      cursor: 'opaque.cursor',
+      page: '999',
+      limit: '50',
+    });
+
+    expect(result).toEqual({
+      isValid: true,
+      fieldErrors: {},
+      validatedParams: {
+        filters: {
+          status: 'verified',
+          yieldBpsMin: 100,
+          yieldBpsMax: 1200,
+          maturityDateFrom: '2026-01-01',
+          maturityDateTo: '2026-12-31',
+          fundedRatioMin: 25.5,
+          fundedRatioMax: 75,
+        },
+        sorting: {
+          sortBy: 'funded_ratio',
+          order: 'asc',
+        },
+        pagination: {
+          cursor: 'opaque.cursor',
+          limit: 50,
+        },
+      },
+    });
+  });
+
+  it('validates offset pagination when no cursor is present', () => {
+    expect(validateMarketplaceQueryParams({ page: '2', limit: '10' })).toMatchObject({
+      isValid: true,
+      validatedParams: {
+        pagination: {
+          page: 2,
+          limit: 10,
+        },
+      },
+    });
+  });
+
+  it('rejects unknown statuses and malformed marketplace params', () => {
+    const result = validateMarketplaceQueryParams({
+      status: 'unknown',
+      yieldBpsMin: '-1',
+      yieldBpsMax: 'NaN',
+      maturityDateFrom: '01-01-2026',
+      maturityDateTo: '2026/12/31',
+      fundedRatioMin: '-0.1',
+      fundedRatioMax: '101',
+      sortBy: 'createdAt',
+      order: 'latest',
+      cursor: '',
+      limit: '101',
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors).toEqual({
+      status: statusErrorMessage,
+      yieldBpsMin: 'yieldBpsMin must be a non-negative integer',
+      yieldBpsMax: 'yieldBpsMax must be a non-negative integer',
+      maturityDateFrom: 'Invalid maturityDateFrom format. Use YYYY-MM-DD',
+      maturityDateTo: 'Invalid maturityDateTo format. Use YYYY-MM-DD',
+      fundedRatioMin: 'fundedRatioMin must be a number between 0 and 100',
+      fundedRatioMax: 'fundedRatioMax must be a number between 0 and 100',
+      sortBy: 'Invalid sortBy. Must be one of: yield_bps, maturity_date, funded_ratio, amount, created_at',
+      order: 'Invalid order. Must be "asc" or "desc"',
+      cursor: 'cursor must be a non-empty string (max 2048 chars)',
+      limit: 'limit must be an integer between 1 and 100',
+    });
+  });
+
+  it('rejects invalid page when no cursor is present', () => {
+    const result = validateMarketplaceQueryParams({ page: '0' });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.page).toBe('page must be an integer >= 1');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #509.

- add canonical invoice status exports to `invoiceStateMachine`
- use `ALL_INVOICE_STATUSES` for both invoice-list and marketplace query status validation
- add invoice query drift tests so the two validators stay aligned
- document the shared `/api/invoices?status=` vocabulary

## Validation

- `npm test -- --runTestsByPath tests/validators.invoiceQuery.test.js tests/unit/validators.test.js --silent`
- `npx jest --runInBand --forceExit --runTestsByPath tests/validators.invoiceQuery.test.js tests/unit/validators.test.js --coverage --collectCoverageFrom=src/utils/validators.js --coverageThreshold='{}'`
  - `src/utils/validators.js`: 100% statements, 100% branches, 100% functions, 100% lines
- `npx eslint src/services/invoiceStateMachine.js src/utils/validators.js tests/validators.invoiceQuery.test.js tests/unit/validators.test.js src/__tests__/invoice.api.test.js`
- `git diff --check`

## Baseline Notes

- `npm test -- --runTestsByPath src/__tests__/invoice.api.test.js --silent` is blocked before this route test reaches the changed validator by the existing `src/metrics.js` duplicate `registerJobQueue` parse error.
- Full `npm test -- --silent` remains baseline-red: 86 failed, 1 skipped, 43 passed suites; 265 failed, 5 skipped, 957 passed tests. Failures include the same `src/metrics.js` duplicate declaration plus existing shutdown, CSV escaping, upload, config, and rate-limit failures.
- Full `npm run lint -- --quiet` remains baseline-red with 85 existing errors. Touched-file ESLint passes.
