### PR TITLE
Unify request and correlation ID middleware

### DIFF
--- a/docs/request-lifecycle-middleware-order.md
+++ b/docs/request-lifecycle-middleware-order.md
@@ -16,12 +16,12 @@ Applied in this order before any route handler runs:
 | 3 | URL-encoded body limit | Form payloads (50 KB) |
 | 4 | Security headers (`createSecurityMiddleware`) | Helmet-style hardening |
 | 5 | Audit middleware | Structured request audit trail |
-| 6 | Request ID | Validates and propagates `req.id` for logging; only `X-Request-Id`/`X-Request-ID` values matching `[A-Za-z0-9._-]{1,128}` are trusted, otherwise a fresh UUID is generated and echoed back in the response header |
-| 7 | Correlation ID | Cross-service trace correlation |
+| 6 | Request ID | Resolves the canonical request identifier from `X-Request-Id`, `request-id`, or `X-Correlation-Id`, then attaches it to both `req.id` and `req.correlationId` for logging |
+| 7 | Correlation ID | Echoes the canonical identifier in `X-Correlation-Id` and refreshes the request-scoped logger bindings |
 
-## Request ID header contract
+## Request identifier header contract
 
-The request ID middleware accepts a client-supplied header only when it is a non-empty string of at most 128 characters and contains only the safe characters `[A-Za-z0-9._-]`. Values with control characters, newlines, whitespace, or other disallowed bytes are rejected and replaced with a server-generated UUID. The sanitized value is then attached to `req.id`, propagated into child loggers, and echoed in the `X-Request-Id` response header.
+The identifier pipeline accepts a client-supplied request or correlation header only when it is 8 to 64 characters long and contains only the safe characters `[A-Za-z0-9_-]`. Values with dots, control characters, newlines, whitespace, or other disallowed bytes are rejected. `X-Request-Id` and `request-id` take precedence over `X-Correlation-Id` when multiple valid headers are present. The sanitized value is attached to both `req.id` and `req.correlationId`, propagated into child loggers as `requestId` and `correlationId`, and echoed in `X-Request-Id` and `X-Correlation-Id`. If no inbound identifier is trusted, the server generates a full-strength `req_` identifier from UUID entropy.
 
 ## Inline routes (defined on `app` directly)
 

--- a/src/middleware/correlationId.js
+++ b/src/middleware/correlationId.js
@@ -1,10 +1,13 @@
 'use strict';
 
-const { randomUUID } = require('crypto');
 const { createRequestLogger } = require('../logger');
-
-const CORRELATION_HEADER = 'x-correlation-id';
-const CORRELATION_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+const {
+  CORRELATION_HEADER,
+  REQUEST_IDENTIFIER_PATTERN,
+  generateRequestIdentifier,
+  resolveRequestIdentifierFromHeaders,
+  resolveRequestIdentifierFromRequest,
+} = require('./requestIdentifier');
 
 /**
  * Attach a validated correlation ID to the request and response.
@@ -15,22 +18,21 @@ const CORRELATION_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
  * @returns {void}
  */
 function correlationIdMiddleware(req, res, next) {
-  const candidate = req.header(CORRELATION_HEADER);
-  // Fallback uses the full UUID (no truncation) so the generated id keeps its
-  // full entropy, matching the strength of the requestId middleware fallback.
-  // `req_` + 32 hex chars = 36 chars, within the accepted {8,64} bound.
   const correlationId =
-    typeof candidate === 'string' && CORRELATION_ID_PATTERN.test(candidate)
-      ? candidate
-      : `req_${randomUUID().replace(/-/g, '')}`;
+    resolveRequestIdentifierFromRequest(req) ||
+    resolveRequestIdentifierFromHeaders(req.headers) ||
+    generateRequestIdentifier();
 
+  req.id = correlationId;
   req.correlationId = correlationId;
   req.log = createRequestLogger(req);
+  res.setHeader('X-Request-Id', correlationId);
   res.setHeader('X-Correlation-Id', correlationId);
   next();
 }
 
 module.exports = {
   CORRELATION_HEADER,
+  CORRELATION_ID_PATTERN: REQUEST_IDENTIFIER_PATTERN,
   correlationIdMiddleware,
 };

--- a/src/middleware/requestId.js
+++ b/src/middleware/requestId.js
@@ -17,88 +17,14 @@
  * @module middleware/requestId
  */
 
-const { randomUUID } = require('crypto');
 const { createRequestLogger } = require('../logger');
-const REQUEST_ID_HEADER_NAMES = ['x-request-id', 'request-id'];
-
-/**
- * Maximum accepted length, in characters, for a client-supplied request id.
- * Values longer than this are rejected and replaced with a generated id.
- *
- * @type {number}
- */
-const MAX_REQUEST_ID_LENGTH = 128;
-
-/**
- * Strict charset for an acceptable inbound request id.
- *
- * Only unreserved URL characters are allowed (`[A-Za-z0-9._-]`), which excludes
- * whitespace, newlines (CR/LF), and all control characters that would otherwise
- * be vectors for log injection. The bound `{1,128}` also rejects empty and
- * oversized values.
- *
- * @type {RegExp}
- */
-const REQUEST_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
-
-/**
- * Validate and sanitize a client-supplied request id.
- *
- * Returns the value unchanged only when it is a non-empty string within the
- * length bound and composed exclusively of the allowed charset. Any other
- * input - a non-string (e.g. a repeated header parsed as an array), an empty
- * string, an oversized string, or a string containing control characters,
- * newlines, or other disallowed bytes - yields `null`, signalling that a fresh
- * server-generated id must be used instead.
- *
- * @param {unknown} value - Candidate request id taken from an inbound header.
- * @returns {string|null} The validated id, or `null` when it must be replaced.
- */
-function sanitizeRequestId(value) {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  // Cheap length guard first so oversized payloads never reach the regex.
-  if (value.length === 0 || value.length > MAX_REQUEST_ID_LENGTH) {
-    return null;
-  }
-
-  if (!REQUEST_ID_PATTERN.test(value)) {
-    return null;
-  }
-
-  return value;
-}
-
-/**
- * Generate a fresh, full-strength server-side request id.
- *
- * Uses a v4 UUID (122 bits of entropy) so fallback ids are as strong as the
- * fallback used by {@link module:middleware/correlationId}.
- *
- * @returns {string} A newly generated UUID.
- */
-function generateRequestId() {
-  return randomUUID();
-}
-
-/**
- * Resolve the first acceptable request id from supported inbound header names.
- *
- * @param {NodeJS.Dict<string | string[]> | undefined} headers - Inbound request headers.
- * @returns {string|null} The first validated request id, or `null` when none are acceptable.
- */
-function resolveRequestIdFromHeaders(headers) {
-  for (const headerName of REQUEST_ID_HEADER_NAMES) {
-    const value = sanitizeRequestId(headers?.[headerName]);
-    if (value) {
-      return value;
-    }
-  }
-
-  return null;
-}
+const {
+  MAX_REQUEST_IDENTIFIER_LENGTH,
+  REQUEST_IDENTIFIER_PATTERN,
+  sanitizeRequestIdentifier,
+  generateRequestIdentifier,
+  resolveRequestIdentifierFromHeaders,
+} = require('./requestIdentifier');
 
 /**
  * Attaches a validated, bounded request ID to the request and response objects.
@@ -112,12 +38,14 @@ function resolveRequestIdFromHeaders(headers) {
  * @param {import('express').NextFunction} next - Express next function
  */
 const requestId = (req, res, next) => {
-  // Prefer a validated client-supplied id (standard for distributed tracing),
-  // otherwise fall back to a fresh server-generated id.
-  const id = resolveRequestIdFromHeaders(req.headers) || generateRequestId();
+  // Prefer a validated client-supplied id, otherwise fall back to a fresh
+  // server-generated id. This is the canonical id for both request and
+  // correlation fields.
+  const id = resolveRequestIdentifierFromHeaders(req.headers) || generateRequestIdentifier();
 
   // Attach to request object for use in subsequent middleware/handlers.
   req.id = id;
+  req.correlationId = id;
   req.log = createRequestLogger(req);
 
   // Echo the validated id so clients/proxies can see it.
@@ -127,9 +55,8 @@ const requestId = (req, res, next) => {
 };
 
 module.exports = requestId;
-module.exports.sanitizeRequestId = sanitizeRequestId;
-module.exports.generateRequestId = generateRequestId;
-module.exports.resolveRequestIdFromHeaders = resolveRequestIdFromHeaders;
-module.exports.MAX_REQUEST_ID_LENGTH = MAX_REQUEST_ID_LENGTH;
-module.exports.REQUEST_ID_PATTERN = REQUEST_ID_PATTERN;
-
+module.exports.sanitizeRequestId = sanitizeRequestIdentifier;
+module.exports.generateRequestId = generateRequestIdentifier;
+module.exports.resolveRequestIdFromHeaders = resolveRequestIdentifierFromHeaders;
+module.exports.MAX_REQUEST_ID_LENGTH = MAX_REQUEST_IDENTIFIER_LENGTH;
+module.exports.REQUEST_ID_PATTERN = REQUEST_IDENTIFIER_PATTERN;

--- a/src/middleware/requestIdentifier.js
+++ b/src/middleware/requestIdentifier.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { randomUUID } = require('crypto');
+
+const CORRELATION_HEADER = 'x-correlation-id';
+const REQUEST_ID_HEADER_NAMES = Object.freeze(['x-request-id', 'request-id']);
+const REQUEST_IDENTIFIER_HEADER_NAMES = Object.freeze([
+  ...REQUEST_ID_HEADER_NAMES,
+  CORRELATION_HEADER,
+]);
+
+const MAX_REQUEST_IDENTIFIER_LENGTH = 64;
+const REQUEST_IDENTIFIER_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+
+/**
+ * Validate a client-supplied request identifier.
+ *
+ * @param {unknown} value Candidate identifier from a request header or request object.
+ * @returns {string|null} The trusted identifier, or null when a new one is required.
+ */
+function sanitizeRequestIdentifier(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  if (value.length === 0 || value.length > MAX_REQUEST_IDENTIFIER_LENGTH) {
+    return null;
+  }
+
+  if (!REQUEST_IDENTIFIER_PATTERN.test(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+/**
+ * Generate a full-strength server-side request identifier.
+ *
+ * @returns {string} A generated identifier within the accepted charset and length bound.
+ */
+function generateRequestIdentifier() {
+  return `req_${randomUUID().replace(/-/g, '')}`;
+}
+
+/**
+ * Resolve the first acceptable identifier from the supported inbound headers.
+ *
+ * Request-ID aliases are preferred over correlation ID when clients send both,
+ * because `req.id` is the primary server-side request identity.
+ *
+ * @param {NodeJS.Dict<string | string[]> | undefined} headers Inbound request headers.
+ * @returns {string|null} The first trusted identifier, or null when none are acceptable.
+ */
+function resolveRequestIdentifierFromHeaders(headers) {
+  for (const headerName of REQUEST_IDENTIFIER_HEADER_NAMES) {
+    const value = sanitizeRequestIdentifier(headers?.[headerName]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the canonical identifier already attached to a request, if present.
+ *
+ * @param {import('express').Request} req Express request object.
+ * @returns {string|null} The trusted in-memory identifier, or null.
+ */
+function resolveRequestIdentifierFromRequest(req) {
+  return sanitizeRequestIdentifier(req.id) || sanitizeRequestIdentifier(req.correlationId);
+}
+
+module.exports = {
+  CORRELATION_HEADER,
+  REQUEST_ID_HEADER_NAMES,
+  REQUEST_IDENTIFIER_HEADER_NAMES,
+  MAX_REQUEST_IDENTIFIER_LENGTH,
+  REQUEST_IDENTIFIER_PATTERN,
+  sanitizeRequestIdentifier,
+  generateRequestIdentifier,
+  resolveRequestIdentifierFromHeaders,
+  resolveRequestIdentifierFromRequest,
+};

--- a/tests/integration/observability.test.js
+++ b/tests/integration/observability.test.js
@@ -44,10 +44,10 @@ describe('Observability Integration', () => {
       .set('x-correlation-id', 'corr-123');
 
     expect(response.status).toBe(200);
-    expect(response.body.requestId).toBeDefined();
+    expect(response.body.requestId).toBe('corr-123');
     expect(response.body.correlationId).toBe('corr-123');
     expect(response.body.loggerBindings).toMatchObject({
-      requestId: response.body.requestId,
+      requestId: 'corr-123',
       correlationId: 'corr-123',
     });
   });

--- a/tests/middleware-security.test.js
+++ b/tests/middleware-security.test.js
@@ -43,6 +43,33 @@ function assertStructuredError(response, expected) {
   assert.equal(response.headers['x-correlation-id'], response.body.error.correlation_id);
 }
 
+test('identifier middleware echoes one canonical id across request and correlation headers', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+  const response = await request(app)
+    .get('/missing-route')
+    .set('X-Request-Id', 'request-abc123')
+    .set('X-Correlation-Id', 'correl-xyz789');
+
+  assert.equal(response.status, 404);
+  assert.equal(response.body.error.correlation_id, 'request-abc123');
+  assert.equal(response.headers['x-request-id'], 'request-abc123');
+  assert.equal(response.headers['x-correlation-id'], 'request-abc123');
+});
+
+test('identifier middleware rejects invalid request-id aliases before using correlation id', async () => {
+  const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
+  const response = await request(app)
+    .get('/missing-route')
+    .set('X-Request-Id', 'bad id with spaces')
+    .set('request-id', 'bad.id.with.dots')
+    .set('X-Correlation-Id', 'trace-safe-123');
+
+  assert.equal(response.status, 404);
+  assert.equal(response.body.error.correlation_id, 'trace-safe-123');
+  assert.equal(response.headers['x-request-id'], 'trace-safe-123');
+  assert.equal(response.headers['x-correlation-id'], 'trace-safe-123');
+});
+
 test('protected endpoint rejects requests without Authorization header', async () => {
   const app = createApp({ enableTestRoutes: true, securityToken: VALID_TOKEN });
   const response = await request(app).get('/__test__/auth');

--- a/tests/unit/requestId.test.js
+++ b/tests/unit/requestId.test.js
@@ -25,6 +25,7 @@ describe('Request ID Middleware', () => {
     requestId(req, res, next);
     expect(req.id).toBeDefined();
     expect(typeof req.id).toBe('string');
+    expect(req.correlationId).toBe(req.id);
     expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', req.id);
     expect(next).toHaveBeenCalled();
   });
@@ -33,7 +34,7 @@ describe('Request ID Middleware', () => {
     requestId(req, res, next);
 
     expect(req.log).toBeDefined();
-    expect(req.log.bindings()).toMatchObject({ requestId: req.id });
+    expect(req.log.bindings()).toMatchObject({ requestId: req.id, correlationId: req.id });
   });
 
   it('should reuse an existing X-Request-Id header', () => {
@@ -43,6 +44,7 @@ describe('Request ID Middleware', () => {
     requestId(req, res, next);
 
     expect(req.id).toBe(existingId);
+    expect(req.correlationId).toBe(existingId);
     expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', existingId);
     expect(next).toHaveBeenCalled();
   });
@@ -54,7 +56,8 @@ describe('Request ID Middleware', () => {
 
     expect(req.id).toBeDefined();
     expect(req.id).not.toBe('bad id with spaces');
-    expect(req.log.bindings()).toMatchObject({ requestId: req.id });
+    expect(req.correlationId).toBe(req.id);
+    expect(req.log.bindings()).toMatchObject({ requestId: req.id, correlationId: req.id });
     expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', req.id);
     expect(next).toHaveBeenCalled();
   });
@@ -66,6 +69,7 @@ describe('Request ID Middleware', () => {
     requestId(req, res, next);
 
     expect(req.id).toBe(existingId);
+    expect(req.correlationId).toBe(existingId);
     expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', existingId);
     expect(next).toHaveBeenCalled();
   });
@@ -77,18 +81,85 @@ describe('Request ID Middleware', () => {
     requestId(req, res, next);
 
     expect(req.id).toBe('alt-id-456');
-    expect(req.log.bindings()).toMatchObject({ requestId: 'alt-id-456' });
+    expect(req.correlationId).toBe('alt-id-456');
+    expect(req.log.bindings()).toMatchObject({ requestId: 'alt-id-456', correlationId: 'alt-id-456' });
     expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'alt-id-456');
     expect(next).toHaveBeenCalled();
   });
 
   it('should propagate the correlation id into the request-scoped logger', () => {
-    requestId(req, res, next);
     req.headers['x-correlation-id'] = 'corr-123';
+    requestId(req, res, next);
 
     correlationIdMiddleware(req, res, next);
 
-    expect(req.log.bindings()).toMatchObject({ requestId: req.id, correlationId: 'corr-123' });
+    expect(req.id).toBe('corr-123');
+    expect(req.correlationId).toBe('corr-123');
+    expect(req.log.bindings()).toMatchObject({ requestId: 'corr-123', correlationId: 'corr-123' });
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'corr-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', 'corr-123');
+  });
+
+  it('should prefer request-id aliases over a divergent correlation id', () => {
+    req.headers['x-request-id'] = 'request-123';
+    req.headers['x-correlation-id'] = 'correl-456';
+
+    requestId(req, res, next);
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.id).toBe('request-123');
+    expect(req.correlationId).toBe('request-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'request-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', 'request-123');
+  });
+
+  it('should use a valid correlation id when request-id aliases are invalid', () => {
+    req.headers['x-request-id'] = 'bad id with spaces';
+    req.headers['request-id'] = 'bad.id.with.dots';
+    req.headers['x-correlation-id'] = 'trace-789';
+
+    requestId(req, res, next);
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.id).toBe('trace-789');
+    expect(req.correlationId).toBe('trace-789');
+  });
+
+  it('should reject short, dotted, oversized, and control-character ids', () => {
+    const invalidValues = [
+      'short',
+      'id.with.dot',
+      'a'.repeat(65),
+      'clean-id\r\nforged',
+      ['array-value'],
+    ];
+
+    for (const value of invalidValues) {
+      expect(requestId.sanitizeRequestId(value)).toBeNull();
+    }
+
+    expect(requestId.sanitizeRequestId('a'.repeat(64))).toBe('a'.repeat(64));
+  });
+
+  it('should let correlation middleware reuse an existing canonical correlation id', () => {
+    req.id = 'invalid id with spaces';
+    req.correlationId = 'correl-123';
+
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.id).toBe('correl-123');
+    expect(req.correlationId).toBe('correl-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'correl-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', 'correl-123');
+  });
+
+  it('should let correlation middleware generate a canonical id when none exists', () => {
+    correlationIdMiddleware(req, res, next);
+
+    expect(req.id).toMatch(/^req_[A-Za-z0-9]+$/);
+    expect(req.correlationId).toBe(req.id);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', req.id);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', req.id);
   });
 
   it('should keep request-scoped loggers isolated between requests', () => {


### PR DESCRIPTION
## Summary

Fixes #518.

- add a shared request identifier resolver for `X-Request-Id`, `request-id`, and `X-Correlation-Id`
- make `req.id`, `req.correlationId`, `X-Request-Id`, `X-Correlation-Id`, and request-scoped logger bindings use one canonical id
- preserve request-id helper exports as compatibility aliases
- update middleware security, unit, integration, and lifecycle documentation coverage

## Validation

- `npm test -- --runTestsByPath tests/unit/requestId.test.js --silent`
- `npm test -- --runTestsByPath tests/integration/observability.test.js --silent`
- `npx jest --runInBand --forceExit --runTestsByPath tests/unit/requestId.test.js tests/integration/observability.test.js --coverage --collectCoverageFrom=src/middleware/requestIdentifier.js --collectCoverageFrom=src/middleware/requestId.js --collectCoverageFrom=src/middleware/correlationId.js --coverageThreshold='{}'`
  - `src/middleware/requestIdentifier.js`, `src/middleware/requestId.js`, and `src/middleware/correlationId.js`: 100% statements, branches, functions, and lines
- `npx eslint src/middleware/requestIdentifier.js src/middleware/requestId.js src/middleware/correlationId.js tests/unit/requestId.test.js tests/integration/observability.test.js tests/middleware-security.test.js`
- `git diff --check`

## Baseline Notes

- `npm test -- --runTestsByPath tests/middleware-security.test.js --silent` is blocked before executing tests by the existing `src/metrics.js` duplicate `registerJobQueue` parse error.
- Full `npm test -- --silent` remains baseline-red: 86 failed, 1 skipped, 42 passed suites; 265 failed, 5 skipped, 952 passed tests. Failures include the same `src/metrics.js` duplicate declaration plus existing shutdown, CSV escaping, upload, config, and rate-limit failures.
- Full `npm run lint -- --quiet` remains baseline-red with 85 existing errors. Touched-code ESLint passes.
