### PR TITLE
Log escrow-derived warnings via structured logger

### DIFF
--- a/docs/escrow-integration-overview.md
+++ b/docs/escrow-integration-overview.md
@@ -64,8 +64,16 @@ const derived = computeEscrowDerivedFields(state, {
 ```
 
 When `ledgerCloseTime` is absent (e.g. the Soroban stub does not return it),
-the function falls back transparently to the server wall clock with a warn-level
-log, preserving the existing behaviour.
+the function falls back transparently to the server wall clock, preserving the
+existing behaviour.
+
+Validation anomalies are emitted through the shared structured logger at
+`warn` level with `component: "escrowDerived"`. These warnings cover
+milliseconds accidentally passed as epoch seconds, non-numeric or negative
+ledger close times, absurd future maturity dates, and stale overdue maturity
+dates beyond the grace window. Logs include bounded numeric context such as
+`ledgerCloseTime`, `daysDiff`, and the relevant threshold, but do not include
+raw unbounded caller-supplied strings.
 
 ### Rounding
 

--- a/src/services/escrowDerived.js
+++ b/src/services/escrowDerived.js
@@ -42,6 +42,8 @@
  * @module services/escrowDerived
  */
 
+const logger = require('../logger');
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // ── Validation constants ──────────────────────────────────────────────────────
@@ -56,6 +58,25 @@ const MAX_FUTURE_DAYS = 50 * 365;
 
 // Maximum overdue grace: 1 year in past (invoices shouldn't be stale longer).
 const MAX_OVERDUE_DAYS = 365;
+
+/**
+ * Emit a structured warning for escrow-derived validation anomalies.
+ *
+ * @param {string} reason Stable machine-readable warning reason.
+ * @param {string} message Human-readable warning message.
+ * @param {Record<string, number|string|null>} fields Bounded structured fields.
+ * @returns {void}
+ */
+function logEscrowDerivedWarning(reason, message, fields) {
+  logger.warn(
+    {
+      component: 'escrowDerived',
+      reason,
+      ...fields,
+    },
+    message
+  );
+}
 
 // ── Public validation helper ──────────────────────────────────────────────────
 
@@ -89,16 +110,26 @@ function validateLedgerCloseTimeUnit(value) {
 
   // Non-numeric, negative, or NaN → invalid
   if (!isFinite(num) || num < 0) {
-    console.warn(
-      '[escrowDerived] ledgerCloseTime is non-numeric or negative: ' + value
+    logEscrowDerivedWarning(
+      'invalid_ledger_close_time',
+      '[escrowDerived] ledgerCloseTime is non-numeric or negative',
+      {
+        ledgerCloseTime: Number.isFinite(num) ? num : null,
+        valueType: typeof value,
+      }
     );
     return null;
   }
 
   // Magnitude check: values at or above the threshold are not epoch seconds.
   if (num >= EPOCH_SECONDS_THRESHOLD) {
-    console.warn(
-      '[escrowDerived] ledgerCloseTime ' + num + ' exceeds threshold ' + EPOCH_SECONDS_THRESHOLD + '; unit mismatch suspected (milliseconds passed as seconds?). Rejecting.'
+    logEscrowDerivedWarning(
+      'ledger_close_time_unit_mismatch',
+      '[escrowDerived] ledgerCloseTime ' + num + ' exceeds threshold ' + EPOCH_SECONDS_THRESHOLD + '; unit mismatch suspected (milliseconds passed as seconds?). Rejecting.',
+      {
+        ledgerCloseTime: num,
+        threshold: EPOCH_SECONDS_THRESHOLD,
+      }
     );
     return null;
   }
@@ -126,15 +157,25 @@ function validateMaturityDateBounds(maturityDate, referenceTime) {
   );
 
   if (daysDiff > MAX_FUTURE_DAYS) {
-    console.warn(
-      '[escrowDerived] maturityDate is ' + daysDiff + ' days in future (> ' + MAX_FUTURE_DAYS + ' day max); absurd value flagged. Treating as invalid.'
+    logEscrowDerivedWarning(
+      'maturity_date_too_far_future',
+      '[escrowDerived] maturityDate is ' + daysDiff + ' days in future (> ' + MAX_FUTURE_DAYS + ' day max); absurd value flagged. Treating as invalid.',
+      {
+        daysDiff,
+        maxFutureDays: MAX_FUTURE_DAYS,
+      }
     );
     return false;
   }
 
   if (daysDiff < -MAX_OVERDUE_DAYS) {
-    console.warn(
-      '[escrowDerived] maturityDate is ' + daysDiff + ' days in past (> ' + MAX_OVERDUE_DAYS + ' day grace); stale or malformed. Treating as invalid.'
+    logEscrowDerivedWarning(
+      'maturity_date_too_far_past',
+      '[escrowDerived] maturityDate is ' + daysDiff + ' days in past (> ' + MAX_OVERDUE_DAYS + ' day grace); stale or malformed. Treating as invalid.',
+      {
+        daysDiff,
+        maxOverdueDays: MAX_OVERDUE_DAYS,
+      }
     );
     return false;
   }

--- a/tests/escrow.derived.test.js
+++ b/tests/escrow.derived.test.js
@@ -3,6 +3,7 @@
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'test-secret';
 
+const logger = require('../src/logger');
 const {
   computeApyPercent,
   computeFundedPercent,
@@ -187,18 +188,31 @@ describe('validateLedgerCloseTimeUnit', () => {
   });
 
   it('logs warning when rejecting milliseconds', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
     validateLedgerCloseTimeUnit(1_700_000_000_000);
     expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'ledger_close_time_unit_mismatch',
+        ledgerCloseTime: 1_700_000_000_000,
+      }),
       expect.stringContaining('unit mismatch suspected')
     );
     warnSpy.mockRestore();
   });
 
   it('logs warning for non-numeric input', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
     validateLedgerCloseTimeUnit('bad');
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'invalid_ledger_close_time',
+        ledgerCloseTime: null,
+        valueType: 'string',
+      }),
+      expect.stringContaining('non-numeric or negative')
+    );
     warnSpy.mockRestore();
   });
 });
@@ -266,20 +280,28 @@ describe('validateMaturityDateBounds', () => {
   });
 
   it('logs warning when rejecting too-far-future', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
     const tooFar = new Date(NOW.getTime() + 100 * 365 * 24 * 60 * 60 * 1000);
     validateMaturityDateBounds(tooFar, NOW);
     expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'maturity_date_too_far_future',
+      }),
       expect.stringContaining('absurd value flagged')
     );
     warnSpy.mockRestore();
   });
 
   it('logs warning when rejecting too-stale-past', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
     const tooStale = new Date(NOW.getTime() - 500 * 24 * 60 * 60 * 1000);
     validateMaturityDateBounds(tooStale, NOW);
     expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'maturity_date_too_far_past',
+      }),
       expect.stringContaining('stale or malformed')
     );
     warnSpy.mockRestore();

--- a/tests/escrowDerived.logging.test.js
+++ b/tests/escrowDerived.logging.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const logger = require('../src/logger');
+const {
+  computeDaysToMaturity,
+  resolveReferenceTime,
+  validateLedgerCloseTimeUnit,
+  validateMaturityDateBounds,
+} = require('../src/services/escrowDerived');
+
+describe('escrowDerived structured warning logs', () => {
+  const NOW = new Date('2026-04-27T12:00:00.000Z');
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('logs milliseconds-as-seconds rejection through the structured logger', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+
+    expect(validateLedgerCloseTimeUnit(1_700_000_000_000)).toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'ledger_close_time_unit_mismatch',
+        ledgerCloseTime: 1_700_000_000_000,
+        threshold: 100_000_000_000,
+      }),
+      expect.stringContaining('unit mismatch suspected')
+    );
+  });
+
+  it('does not log raw non-numeric caller input', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    const rawValue = 'bad value with user supplied trailing payload';
+
+    expect(validateLedgerCloseTimeUnit(rawValue)).toBeNull();
+
+    const [fields, message] = warnSpy.mock.calls[0];
+    expect(fields).toMatchObject({
+      component: 'escrowDerived',
+      reason: 'invalid_ledger_close_time',
+      ledgerCloseTime: null,
+      valueType: 'string',
+    });
+    expect(JSON.stringify(fields)).not.toContain(rawValue);
+    expect(message).not.toContain(rawValue);
+  });
+
+  it('logs absurd future maturity dates through the structured logger', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    const tooFar = new Date(NOW.getTime() + 100 * 365 * 24 * 60 * 60 * 1000);
+
+    expect(validateMaturityDateBounds(tooFar, NOW)).toBe(false);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'maturity_date_too_far_future',
+        daysDiff: 36500,
+        maxFutureDays: 18250,
+      }),
+      expect.stringContaining('absurd value flagged')
+    );
+  });
+
+  it('logs stale overdue dates beyond the grace window through the structured logger', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    const tooStale = new Date(NOW.getTime() - 500 * 24 * 60 * 60 * 1000);
+
+    expect(computeDaysToMaturity(tooStale, { now: NOW })).toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'escrowDerived',
+        reason: 'maturity_date_too_far_past',
+        daysDiff: -500,
+        maxOverdueDays: 365,
+      }),
+      expect.stringContaining('stale or malformed')
+    );
+  });
+
+  it('does not log for valid ledger and maturity inputs', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    const maturity = new Date(NOW.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    expect(validateLedgerCloseTimeUnit(NOW.getTime() / 1000)).toBe(NOW.getTime() / 1000);
+    expect(computeDaysToMaturity(maturity, { now: NOW })).toBe(30);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to opts.now when an invalid Date ledger value is supplied', () => {
+    expect(resolveReferenceTime({
+      ledgerCloseTime: new Date('invalid-date'),
+      now: NOW,
+    })).toBe(NOW);
+  });
+
+  it('falls back to server wall clock when compute options are null', () => {
+    jest.useFakeTimers().setSystemTime(NOW);
+    const maturity = new Date(NOW.getTime() + 2 * 24 * 60 * 60 * 1000);
+
+    expect(computeDaysToMaturity(maturity, null)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- replaces `console.warn` in `src/services/escrowDerived.js` with the shared structured logger at `warn` level
- emits stable `component` and `reason` fields plus bounded numeric context for escrow-derived validation anomalies
- adds focused logging coverage for milliseconds-as-seconds rejection, raw caller-string redaction, absurd future maturity dates, stale overdue dates, and valid no-log paths
- documents the structured warning behavior in the escrow integration overview

Closes #507.

## Validation

- `npm test -- --runTestsByPath tests/escrowDerived.logging.test.js tests/escrow.derived.test.js --silent`
- `npx jest --runInBand --forceExit --runTestsByPath tests/escrowDerived.logging.test.js tests/escrow.derived.test.js --coverage --collectCoverageFrom=src/services/escrowDerived.js --coverageThreshold='{}' --silent`
  - `src/services/escrowDerived.js`: 100% statements, 98.41% branches, 100% functions, 100% lines
- `npx eslint src/services/escrowDerived.js tests/escrow.derived.test.js tests/escrowDerived.logging.test.js`
- `git diff --check`

## Baseline Notes

- `npm test -- --silent` remains red on existing unrelated failures: `86 failed, 1 skipped, 43 passed` suites and `265 failed, 5 skipped, 954 passed` tests. Representative failures include the pre-existing `src/metrics.js` duplicate `registerJobQueue` declaration, shutdown coordinator expectations/timeouts, audit CSV expectations, invoice file upload failures, config defaults, and rate-limit expectations.
- `npm run lint -- --quiet` remains red with the existing 85 project-wide lint errors outside this patch.
