### PR TITLE
feat: make invoice-verification thresholds configurable with tenant o…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -251,3 +251,27 @@ KYC_PROVIDER_SECRET=replace-with-your-kyc-signing-secret
 # ---------------------------
 # Timeout in milliseconds for graceful shutdown before force exit (default: 10000)
 SHUTDOWN_TIMEOUT_MS=10000
+
+# ---------------------------------
+# Invoice Verification Thresholds |
+# ---------------------------------
+# Amount thresholds used by src/services/invoiceVerification.js. All values are in
+# the system's base currency unit. Defaults below preserve the historical hardcoded
+# behavior, so leaving these unset changes nothing.
+#
+# Fraud-rejection ceiling: amounts STRICTLY GREATER than this are auto-REJECTED.
+# Must be a finite number > 0. Default: 10000000
+# INVOICE_FRAUD_CEILING=10000000
+#
+# Manual-review threshold: amounts AT OR ABOVE this require MANUAL_REVIEW.
+# Must be a finite number > 0 and <= INVOICE_FRAUD_CEILING. Default: 1000000
+# INVOICE_MANUAL_REVIEW_THRESHOLD=1000000
+#
+# Per-tenant overrides (optional). JSON object keyed by tenant id. Each entry may
+# set either or both fields; omitted fields fall back to the global defaults above.
+# Each override is validated with the same rules as the globals. The tenant id is
+# supplied by the trusted authenticated context only — never by request payloads.
+# Format:
+#   {"tenant-acme":{"fraudCeiling":5000000,"manualReviewThreshold":500000},
+#    "tenant-globex":{"manualReviewThreshold":250000}}
+# INVOICE_TENANT_THRESHOLDS={"tenant-acme":{"fraudCeiling":5000000,"manualReviewThreshold":500000}}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,9 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 | `RATE_LIMIT_API_KEY_WINDOW_MS` | integer milliseconds | `900000` | No | No | [`src/middleware/rateLimit.js`](../src/middleware/rateLimit.js) |
 | `RATE_LIMIT_API_KEY_MAX` | integer | `1000` | No | No | [`src/middleware/rateLimit.js`](../src/middleware/rateLimit.js) |
 | `WEB_CONCURRENCY` | integer | `1` (single-instance default) | No | No | [`src/middleware/rateLimit.js`](../src/middleware/rateLimit.js) — issues #429 cluster-detection signal |
+| `INVOICE_FRAUD_CEILING` | number > 0 | `10000000` | No | No | [`src/config/verificationThresholds.js`](../src/config/verificationThresholds.js) |
+| `INVOICE_MANUAL_REVIEW_THRESHOLD` | number > 0, `<= INVOICE_FRAUD_CEILING` | `1000000` | No | No | [`src/config/verificationThresholds.js`](../src/config/verificationThresholds.js) |
+| `INVOICE_TENANT_THRESHOLDS` | JSON object of per-tenant overrides | Empty (defaults apply to all tenants) | No | No | [`src/config/verificationThresholds.js`](../src/config/verificationThresholds.js) |
 | `CLUSTER_WORKERS` | integer | `1` (single-instance default) | No | No | [`src/middleware/rateLimit.js`](../src/middleware/rateLimit.js) — issues #429 alt cluster-detection signal |
 | `SOROBAN_BATCH_CONCURRENCY` | integer, `1..50` | `5` | No | No | [`src/config/index.js`](../src/config/index.js) |
 | `SOROBAN_BATCH_TIMEOUT_MS` | integer milliseconds, `100..30000` | `5000` | No | No | [`src/config/index.js`](../src/config/index.js) |
@@ -95,6 +98,50 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 | `IDEMPOTENCY_PURGE_INTERVAL_MS` | integer milliseconds, min `60000` | `3600000` | No | No | [`src/jobs/idempotencyPurge.js`](../src/jobs/idempotencyPurge.js) |
 | `IDEMPOTENCY_PURGE_MAX_BATCHES` | integer, `1..1000` | `100` | No | No | [`src/jobs/idempotencyPurge.js`](../src/jobs/idempotencyPurge.js) |
 <!-- env-reference:end -->
+
+## Invoice Verification Thresholds
+
+The invoice-verification service ([`src/services/invoiceVerification.js`](../src/services/invoiceVerification.js)) screens invoice amounts against two configurable thresholds, resolved by [`src/config/verificationThresholds.js`](../src/config/verificationThresholds.js):
+
+| Threshold | Decision when matched | Comparison | Env var | Default |
+| --- | --- | --- | --- | --- |
+| Fraud ceiling | `REJECTED` | `amount > fraudCeiling` (strictly greater) | `INVOICE_FRAUD_CEILING` | `10000000` |
+| Manual-review threshold | `MANUAL_REVIEW` | `amount >= manualReviewThreshold` (at or above) | `INVOICE_MANUAL_REVIEW_THRESHOLD` | `1000000` |
+
+The defaults reproduce the previously hardcoded behavior, so an existing deployment that sets neither variable observes no change.
+
+**Validation.** Each value must be a finite number greater than `0`, and `manualReviewThreshold` must be `<= fraudCeiling` (otherwise the manual-review band is unreachable). Invalid configuration is rejected: `resolveThresholds()` throws a `VerificationConfigError`, and the verification service **fails closed** — it returns `MANUAL_REVIEW` with reason code `CONFIG_UNAVAILABLE` rather than auto-approving or hard-rejecting.
+
+### Per-Tenant Overrides
+
+`INVOICE_TENANT_THRESHOLDS` is a JSON object keyed by tenant id. Each entry may override either or both fields; omitted fields fall back to the global defaults. Overrides are validated with the same rules as the globals.
+
+```json
+{
+  "tenant-acme":   { "fraudCeiling": 5000000, "manualReviewThreshold": 500000 },
+  "tenant-globex": { "manualReviewThreshold": 250000 }
+}
+```
+
+In the example above, `tenant-acme` gets a stricter ceiling and review threshold, while `tenant-globex` only tightens the review threshold and keeps the default `10000000` fraud ceiling. A tenant id with no entry — and a request with no tenant id — uses the global defaults.
+
+**Security.** Thresholds and overrides come exclusively from configuration set by an operator/admin via the environment. The per-tenant map is parsed into a `Map`, so prototype-pollution keys such as `__proto__` cannot be resolved as tenants. The tenant id passed to `verifyInvoice(payload, { tenantId })` must originate from the **trusted authenticated context** — never from the untrusted invoice payload. Any `tenantId` (or threshold-like field) present on the payload itself is ignored.
+
+### Reason Codes
+
+Every non-approval decision carries a stable, machine-readable `reasonCode` (in addition to the human-readable `reason`) so downstream handlers can branch reliably without string matching. `VERIFIED` outcomes carry no reason code.
+
+| `reasonCode` | Status | Meaning |
+| --- | --- | --- |
+| `INVALID_PAYLOAD` | `REJECTED` | Payload missing or not an object. |
+| `INVALID_AMOUNT` | `REJECTED` | Amount not a positive, finite number. |
+| `INVALID_CUSTOMER` | `REJECTED` | Customer missing, not a string, or empty/whitespace. |
+| `AMOUNT_EXCEEDS_FRAUD_CEILING` | `REJECTED` | Amount exceeded the resolved fraud ceiling. |
+| `MANUAL_REVIEW_REQUIRED` | `MANUAL_REVIEW` | Amount met or exceeded the resolved manual-review threshold. |
+| `SUSPICIOUS_CUSTOMER` | `REJECTED` | Customer string contained injection characters (`< > { } $`). |
+| `CONFIG_UNAVAILABLE` | `MANUAL_REVIEW` | Threshold configuration was invalid; failed closed to manual review. |
+
+These codes are part of the service contract: existing values must not be renamed or repurposed.
 
 ## Sync Notes
 

--- a/src/__tests__/invoiceVerification.test.js
+++ b/src/__tests__/invoiceVerification.test.js
@@ -1,4 +1,4 @@
-const { verifyInvoice } = require('../services/invoiceVerification');
+const { verifyInvoice, ReasonCode } = require('../services/invoiceVerification');
 
 describe('Invoice Verification Service', () => {
   it('should verify a valid invoice', async () => {
@@ -9,47 +9,87 @@ describe('Invoice Verification Service', () => {
 
   it('should reject if payload is not an object', async () => {
     const result = await verifyInvoice(null);
-    expect(result).toEqual({ status: 'REJECTED', reason: 'Invalid payload structure' });
-    
+    expect(result).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid payload structure',
+      reasonCode: ReasonCode.INVALID_PAYLOAD,
+    });
+
     const result2 = await verifyInvoice('string');
-    expect(result2).toEqual({ status: 'REJECTED', reason: 'Invalid payload structure' });
+    expect(result2).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid payload structure',
+      reasonCode: ReasonCode.INVALID_PAYLOAD,
+    });
   });
 
   it('should reject invalid amount types', async () => {
     const result = await verifyInvoice({ amount: '5000', customer: 'Acme Corp' });
-    expect(result).toEqual({ status: 'REJECTED', reason: 'Invalid amount: must be a positive number' });
+    expect(result).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid amount: must be a positive number',
+      reasonCode: ReasonCode.INVALID_AMOUNT,
+    });
   });
 
   it('should reject zero or negative amounts', async () => {
     const resultZero = await verifyInvoice({ amount: 0, customer: 'Acme Corp' });
-    expect(resultZero).toEqual({ status: 'REJECTED', reason: 'Invalid amount: must be a positive number' });
+    expect(resultZero).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid amount: must be a positive number',
+      reasonCode: ReasonCode.INVALID_AMOUNT,
+    });
 
     const resultNegative = await verifyInvoice({ amount: -100, customer: 'Acme Corp' });
-    expect(resultNegative).toEqual({ status: 'REJECTED', reason: 'Invalid amount: must be a positive number' });
+    expect(resultNegative).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid amount: must be a positive number',
+      reasonCode: ReasonCode.INVALID_AMOUNT,
+    });
   });
 
   it('should reject invalid customer types', async () => {
     const result = await verifyInvoice({ amount: 5000, customer: 12345 });
-    expect(result).toEqual({ status: 'REJECTED', reason: 'Invalid customer: must be a non-empty string' });
+    expect(result).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid customer: must be a non-empty string',
+      reasonCode: ReasonCode.INVALID_CUSTOMER,
+    });
   });
 
   it('should reject empty customer string', async () => {
     const result = await verifyInvoice({ amount: 5000, customer: '   ' });
-    expect(result).toEqual({ status: 'REJECTED', reason: 'Invalid customer: must be a non-empty string' });
+    expect(result).toEqual({
+      status: 'REJECTED',
+      reason: 'Invalid customer: must be a non-empty string',
+      reasonCode: ReasonCode.INVALID_CUSTOMER,
+    });
   });
 
   it('should reject an amount exceeding the maximum allowed threshold', async () => {
     const result = await verifyInvoice({ amount: 15000000, customer: 'Acme Corp' });
-    expect(result).toEqual({ status: 'REJECTED', reason: 'Amount exceeds maximum allowed threshold' });
+    expect(result).toEqual({
+      status: 'REJECTED',
+      reason: 'Amount exceeds maximum allowed threshold',
+      reasonCode: ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING,
+    });
   });
 
   it('should require manual review for high value invoices', async () => {
     const result = await verifyInvoice({ amount: 1500000, customer: 'Acme Corp' });
-    expect(result).toEqual({ status: 'MANUAL_REVIEW', reason: 'High value invoice requires manual approval' });
+    expect(result).toEqual({
+      status: 'MANUAL_REVIEW',
+      reason: 'High value invoice requires manual approval',
+      reasonCode: ReasonCode.MANUAL_REVIEW_REQUIRED,
+    });
   });
 
   it('should reject customers with suspicious characters (XSS/Injection)', async () => {
     const result = await verifyInvoice({ amount: 5000, customer: 'Acme <script>' });
-    expect(result).toEqual({ status: 'REJECTED', reason: 'Suspicious characters detected in customer data' });
+    expect(result).toEqual({
+      status: 'REJECTED',
+      reason: 'Suspicious characters detected in customer data',
+      reasonCode: ReasonCode.SUSPICIOUS_CUSTOMER,
+    });
   });
 });

--- a/src/config/verificationThresholds.js
+++ b/src/config/verificationThresholds.js
@@ -1,0 +1,268 @@
+/**
+ * src/config/verificationThresholds.js
+ *
+ * Resolves the amount thresholds used by the invoice-verification service:
+ *   - the fraud-rejection ceiling (amounts strictly above it are auto-rejected), and
+ *   - the manual-review threshold (amounts at or above it require a human approval).
+ *
+ * Historically these were hardcoded literals (10,000,000 and 1,000,000) inside
+ * `src/services/invoiceVerification.js`. They are now configuration-driven so they
+ * can adapt to different currencies, tenant risk appetites, or limit changes
+ * without a code change and redeploy.
+ *
+ * Configuration sources (all environment-backed, i.e. set by config/admin only —
+ * never by request payloads):
+ *
+ *   INVOICE_FRAUD_CEILING              Global fraud-rejection ceiling.
+ *                                      Default: 10000000 (preserves prior behavior).
+ *   INVOICE_MANUAL_REVIEW_THRESHOLD    Global manual-review threshold.
+ *                                      Default: 1000000 (preserves prior behavior).
+ *   INVOICE_TENANT_THRESHOLDS          JSON object of per-tenant overrides, e.g.
+ *     {
+ *       "tenant-acme":   { "fraudCeiling": 5000000, "manualReviewThreshold": 500000 },
+ *       "tenant-globex": { "manualReviewThreshold": 250000 }
+ *     }
+ *     Each override may set either or both fields; omitted fields fall back to the
+ *     global defaults above. Overrides are validated with the same rules as the
+ *     globals.
+ *
+ * Validation rules (applied to globals and to every tenant override after merge):
+ *   - Both values must be finite numbers greater than 0.
+ *   - manualReviewThreshold must be <= fraudCeiling, otherwise the manual-review
+ *     band would be unreachable and the configuration is rejected.
+ *
+ * Invalid configuration throws {@link VerificationConfigError}. Callers that must
+ * not crash (e.g. the verification service) should catch it and fail closed.
+ *
+ * Security: tenant identifiers are used purely as lookup keys into the
+ * environment-supplied override map. Overrides cannot be injected by untrusted
+ * input — the map is parsed from the environment and stored in a {@link Map},
+ * which is immune to prototype-pollution keys such as `__proto__`.
+ */
+
+'use strict';
+
+/** @type {number} Default fraud-rejection ceiling (preserves prior hardcoded behavior). */
+const DEFAULT_FRAUD_CEILING = 10000000;
+
+/** @type {number} Default manual-review threshold (preserves prior hardcoded behavior). */
+const DEFAULT_MANUAL_REVIEW_THRESHOLD = 1000000;
+
+/**
+ * A resolved threshold pair for a verification decision.
+ * @typedef {Object} ThresholdSet
+ * @property {number} fraudCeiling - Amounts strictly greater than this are rejected.
+ * @property {number} manualReviewThreshold - Amounts at or above this require manual review.
+ */
+
+/**
+ * Thrown when threshold configuration (env defaults or tenant overrides) is malformed.
+ */
+class VerificationConfigError extends Error {
+  /**
+   * Creates an error describing an invalid threshold configuration.
+   * @param {string} message - Human-readable configuration error.
+   */
+  constructor(message) {
+    super(message);
+    this.name = 'VerificationConfigError';
+  }
+}
+
+/**
+ * Parse a raw environment value into a strictly positive, finite number.
+ *
+ * @param {string|undefined} raw - The raw environment string (may be undefined).
+ * @param {number} fallback - Default to use when `raw` is undefined or empty.
+ * @param {string} label - Field name used in error messages.
+ * @returns {number} The validated positive number.
+ * @throws {VerificationConfigError} When the value is present but not a positive finite number.
+ */
+function _parseNumericEnv(raw, fallback, label) {
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return fallback;
+  }
+  const value = Number(raw);
+  return _assertPositiveNumber(value, label);
+}
+
+/**
+ * Assert that a value is a finite number strictly greater than zero.
+ *
+ * @param {*} value - The candidate value.
+ * @param {string} label - Field name used in error messages.
+ * @returns {number} The validated number.
+ * @throws {VerificationConfigError} When the value is not a positive finite number.
+ */
+function _assertPositiveNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new VerificationConfigError(
+      `${label} must be a finite number greater than 0 (received: ${JSON.stringify(value)}).`
+    );
+  }
+  return value;
+}
+
+/**
+ * Assert that a threshold pair is internally consistent.
+ *
+ * @param {ThresholdSet} pair - The resolved threshold pair.
+ * @param {string} context - Describes the source (e.g. "global config" or a tenant id).
+ * @returns {ThresholdSet} The same validated pair.
+ * @throws {VerificationConfigError} When manualReviewThreshold exceeds fraudCeiling.
+ */
+function _assertConsistentPair(pair, context) {
+  if (pair.manualReviewThreshold > pair.fraudCeiling) {
+    throw new VerificationConfigError(
+      `${context}: manualReviewThreshold (${pair.manualReviewThreshold}) must not exceed ` +
+        `fraudCeiling (${pair.fraudCeiling}).`
+    );
+  }
+  return pair;
+}
+
+/**
+ * Parse and validate the per-tenant override map from its raw JSON string.
+ *
+ * @param {string|undefined} raw - Raw INVOICE_TENANT_THRESHOLDS JSON (may be undefined).
+ * @param {ThresholdSet} defaults - Global defaults used to fill omitted override fields.
+ * @returns {Map<string, ThresholdSet>} Map of tenant id to validated, merged thresholds.
+ * @throws {VerificationConfigError} When the JSON is malformed or any override is invalid.
+ */
+function _parseTenantOverrides(raw, defaults) {
+  const overrides = new Map();
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return overrides;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new VerificationConfigError(
+      'INVOICE_TENANT_THRESHOLDS is not valid JSON. Check your environment configuration.'
+    );
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new VerificationConfigError(
+      'INVOICE_TENANT_THRESHOLDS must be a JSON object mapping tenant ids to overrides.'
+    );
+  }
+
+  // Only the tenant's own enumerable keys are considered; using a Map for storage
+  // keeps the result free of prototype-pollution surprises.
+  for (const tenantId of Object.keys(parsed)) {
+    const override = parsed[tenantId];
+    if (override === null || typeof override !== 'object' || Array.isArray(override)) {
+      throw new VerificationConfigError(
+        `INVOICE_TENANT_THRESHOLDS["${tenantId}"] must be an object of threshold overrides.`
+      );
+    }
+
+    const fraudCeiling = Object.prototype.hasOwnProperty.call(override, 'fraudCeiling')
+      ? _assertPositiveNumber(override.fraudCeiling, `tenant "${tenantId}" fraudCeiling`)
+      : defaults.fraudCeiling;
+
+    const manualReviewThreshold = Object.prototype.hasOwnProperty.call(
+      override,
+      'manualReviewThreshold'
+    )
+      ? _assertPositiveNumber(
+        override.manualReviewThreshold,
+        `tenant "${tenantId}" manualReviewThreshold`
+      )
+      : defaults.manualReviewThreshold;
+
+    const merged = _assertConsistentPair(
+      { fraudCeiling, manualReviewThreshold },
+      `tenant "${tenantId}"`
+    );
+    overrides.set(tenantId, merged);
+  }
+
+  return overrides;
+}
+
+/**
+ * Build the full threshold configuration from the current environment.
+ *
+ * @returns {{ defaults: ThresholdSet, tenants: Map<string, ThresholdSet> }} Parsed config.
+ * @throws {VerificationConfigError} When env defaults or overrides are invalid.
+ */
+function _buildConfig() {
+  const defaults = _assertConsistentPair(
+    {
+      fraudCeiling: _parseNumericEnv(
+        process.env.INVOICE_FRAUD_CEILING,
+        DEFAULT_FRAUD_CEILING,
+        'INVOICE_FRAUD_CEILING'
+      ),
+      manualReviewThreshold: _parseNumericEnv(
+        process.env.INVOICE_MANUAL_REVIEW_THRESHOLD,
+        DEFAULT_MANUAL_REVIEW_THRESHOLD,
+        'INVOICE_MANUAL_REVIEW_THRESHOLD'
+      ),
+    },
+    'global config'
+  );
+
+  const tenants = _parseTenantOverrides(process.env.INVOICE_TENANT_THRESHOLDS, defaults);
+
+  return { defaults, tenants };
+}
+
+/** @type {{ defaults: ThresholdSet, tenants: Map<string, ThresholdSet> } | null} */
+let _cache = null;
+
+/**
+ * Returns the parsed configuration, building and memoizing it on first use.
+ *
+ * @returns {{ defaults: ThresholdSet, tenants: Map<string, ThresholdSet> }} Parsed config.
+ * @throws {VerificationConfigError} When env defaults or overrides are invalid.
+ */
+function _getConfig() {
+  if (!_cache) {
+    _cache = _buildConfig();
+  }
+  return _cache;
+}
+
+/**
+ * Resolve the effective thresholds for a verification decision.
+ *
+ * When `tenantId` matches a configured override the tenant-specific thresholds are
+ * returned; otherwise the global defaults are used. A fresh object is returned on
+ * every call so callers cannot mutate the cached configuration.
+ *
+ * @param {string} [tenantId] - Trusted tenant identifier from the authenticated
+ *   context. Untrusted request payloads must not supply this value.
+ * @returns {ThresholdSet} The effective thresholds to apply.
+ * @throws {VerificationConfigError} When the underlying configuration is invalid.
+ */
+function resolveThresholds(tenantId) {
+  const { defaults, tenants } = _getConfig();
+
+  if (tenantId !== undefined && tenantId !== null && tenants.has(String(tenantId))) {
+    return { ...tenants.get(String(tenantId)) };
+  }
+
+  return { ...defaults };
+}
+
+/**
+ * Test-only helper that clears the memoized configuration so a subsequent call
+ * re-reads `process.env`.
+ * @returns {void}
+ */
+function _resetThresholdCache() {
+  _cache = null;
+}
+
+module.exports = {
+  resolveThresholds,
+  VerificationConfigError,
+  DEFAULT_FRAUD_CEILING,
+  DEFAULT_MANUAL_REVIEW_THRESHOLD,
+  _resetThresholdCache, // test-only
+};

--- a/src/services/invoiceVerification.js
+++ b/src/services/invoiceVerification.js
@@ -1,60 +1,170 @@
 /**
  * Invoice Verification Service
  * Handles fraud checks and business validation before invoice approval.
+ *
+ * The fraud-rejection ceiling and manual-review threshold are configuration-driven
+ * (see {@link module:config/verificationThresholds}) and support per-tenant
+ * overrides. Every non-approval decision carries a stable, machine-readable
+ * `reasonCode` so downstream handlers can branch reliably without parsing the
+ * human-readable `reason` string.
  */
+
+'use strict';
+
+const {
+  resolveThresholds,
+  VerificationConfigError,
+} = require('../config/verificationThresholds');
+
+/**
+ * Stable, machine-readable reason codes for verification decisions.
+ *
+ * These values are part of the service contract: downstream consumers may switch
+ * on them, so existing codes must not be renamed or repurposed. `VERIFIED`
+ * outcomes carry no reason code.
+ *
+ * @readonly
+ * @enum {string}
+ */
+const ReasonCode = Object.freeze({
+  /** Payload was missing or not an object. */
+  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  /** Amount was not a positive, finite number. */
+  INVALID_AMOUNT: 'INVALID_AMOUNT',
+  /** Customer was missing, not a string, or empty/whitespace. */
+  INVALID_CUSTOMER: 'INVALID_CUSTOMER',
+  /** Amount exceeded the (per-tenant) fraud-rejection ceiling. */
+  AMOUNT_EXCEEDS_FRAUD_CEILING: 'AMOUNT_EXCEEDS_FRAUD_CEILING',
+  /** Amount met or exceeded the (per-tenant) manual-review threshold. */
+  MANUAL_REVIEW_REQUIRED: 'MANUAL_REVIEW_REQUIRED',
+  /** Customer string contained suspicious/injection characters. */
+  SUSPICIOUS_CUSTOMER: 'SUSPICIOUS_CUSTOMER',
+  /** Threshold configuration could not be resolved; failed closed to manual review. */
+  CONFIG_UNAVAILABLE: 'CONFIG_UNAVAILABLE',
+});
 
 /**
  * Result of an invoice verification.
  * @typedef {Object} VerificationResult
  * @property {string} status - The resulting status: 'VERIFIED', 'REJECTED', or 'MANUAL_REVIEW'.
- * @property {string} [reason] - The reason for rejection or manual review, if applicable.
+ * @property {string} [reason] - Human-readable reason for rejection or manual review.
+ * @property {string} [reasonCode] - Stable machine-readable code (see {@link ReasonCode}).
  */
 
 /**
+ * Options controlling how an invoice is verified.
+ * @typedef {Object} VerifyOptions
+ * @property {string} [tenantId] - Trusted tenant identifier used to select per-tenant
+ *   threshold overrides. MUST come from the authenticated request context, never from
+ *   the (untrusted) invoice payload.
+ */
+
+/** @type {RegExp} Obvious injection patterns disallowed in the customer field. */
+const SUSPICIOUS_PATTERN = /[<>{}$]/;
+
+/**
  * Validates an invoice for fraud and business rules.
- * 
+ *
+ * Decision order (first match wins):
+ *   1. Structural validation of the payload, amount, and customer fields.
+ *   2. Fraud ceiling: amounts strictly greater than the resolved `fraudCeiling`
+ *      are REJECTED ({@link ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING}).
+ *   3. Manual review: amounts at or above the resolved `manualReviewThreshold`
+ *      require MANUAL_REVIEW ({@link ReasonCode.MANUAL_REVIEW_REQUIRED}).
+ *   4. Injection screening of the customer string.
+ *
+ * Thresholds are resolved from configuration with optional per-tenant overrides
+ * (see {@link module:config/verificationThresholds}). If the configuration cannot
+ * be resolved the service fails closed to MANUAL_REVIEW
+ * ({@link ReasonCode.CONFIG_UNAVAILABLE}) rather than auto-approving or
+ * hard-rejecting.
+ *
  * Security Assumptions:
  * - The input payload must be an object.
  * - `amount` must be a strictly positive number.
  * - `customer` must be a non-empty string avoiding potentially malicious injection patterns.
- * 
+ * - Threshold overrides are sourced only from configuration. Any `tenantId` is taken
+ *   from the trusted `options` argument; threshold-related fields on the invoice
+ *   payload itself are ignored.
+ *
  * @param {Object} invoicePayload - The invoice data to verify.
  * @param {number} invoicePayload.amount - The invoice amount in the system's base currency.
  * @param {string} invoicePayload.customer - The customer identifier or name.
- * @returns {Promise<VerificationResult>} Returns the verification status and optional reason.
+ * @param {VerifyOptions} [options] - Verification options (e.g. trusted tenant id).
+ * @returns {Promise<VerificationResult>} Returns the verification status, reason, and reason code.
  */
-async function verifyInvoice(invoicePayload) {
+async function verifyInvoice(invoicePayload, options = {}) {
   if (!invoicePayload || typeof invoicePayload !== 'object') {
-    return { status: 'REJECTED', reason: 'Invalid payload structure' };
+    return {
+      status: 'REJECTED',
+      reason: 'Invalid payload structure',
+      reasonCode: ReasonCode.INVALID_PAYLOAD,
+    };
   }
 
   const { amount, customer } = invoicePayload;
 
   // Security: strict type and value checks
   if (typeof amount !== 'number' || Number.isNaN(amount) || amount <= 0) {
-    return { status: 'REJECTED', reason: 'Invalid amount: must be a positive number' };
+    return {
+      status: 'REJECTED',
+      reason: 'Invalid amount: must be a positive number',
+      reasonCode: ReasonCode.INVALID_AMOUNT,
+    };
   }
 
   if (typeof customer !== 'string' || customer.trim() === '') {
-    return { status: 'REJECTED', reason: 'Invalid customer: must be a non-empty string' };
+    return {
+      status: 'REJECTED',
+      reason: 'Invalid customer: must be a non-empty string',
+      reasonCode: ReasonCode.INVALID_CUSTOMER,
+    };
   }
 
-  // Business Validation: Fraud Check Example
-  // Reject absurdly high amounts automatically
-  if (amount > 10000000) {
-    return { status: 'REJECTED', reason: 'Amount exceeds maximum allowed threshold' };
+  // Resolve configured thresholds (with optional per-tenant overrides). The tenant
+  // id comes only from the trusted options argument, never from the payload.
+  let thresholds;
+  try {
+    thresholds = resolveThresholds(options ? options.tenantId : undefined);
+  } catch (err) {
+    if (err instanceof VerificationConfigError) {
+      // Fail closed: never auto-approve under broken configuration.
+      return {
+        status: 'MANUAL_REVIEW',
+        reason: 'Threshold configuration unavailable; manual review required',
+        reasonCode: ReasonCode.CONFIG_UNAVAILABLE,
+      };
+    }
+    throw err;
   }
 
-  // Business Validation: Manual Review Example
-  // Require manual review for high value invoices
-  if (amount >= 1000000) {
-    return { status: 'MANUAL_REVIEW', reason: 'High value invoice requires manual approval' };
+  // Business Validation: Fraud Check
+  // Reject absurdly high amounts automatically.
+  if (amount > thresholds.fraudCeiling) {
+    return {
+      status: 'REJECTED',
+      reason: 'Amount exceeds maximum allowed threshold',
+      reasonCode: ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING,
+    };
+  }
+
+  // Business Validation: Manual Review
+  // Require manual review for high value invoices.
+  if (amount >= thresholds.manualReviewThreshold) {
+    return {
+      status: 'MANUAL_REVIEW',
+      reason: 'High value invoice requires manual approval',
+      reasonCode: ReasonCode.MANUAL_REVIEW_REQUIRED,
+    };
   }
 
   // Security: Check for obvious injection patterns in customer string
-  const suspiciousPatterns = /[<>{}$]/;
-  if (suspiciousPatterns.test(customer)) {
-    return { status: 'REJECTED', reason: 'Suspicious characters detected in customer data' };
+  if (SUSPICIOUS_PATTERN.test(customer)) {
+    return {
+      status: 'REJECTED',
+      reason: 'Suspicious characters detected in customer data',
+      reasonCode: ReasonCode.SUSPICIOUS_CUSTOMER,
+    };
   }
 
   // Verification passed
@@ -62,5 +172,6 @@ async function verifyInvoice(invoicePayload) {
 }
 
 module.exports = {
-  verifyInvoice
+  verifyInvoice,
+  ReasonCode,
 };

--- a/tests/invoiceVerification.service.test.js
+++ b/tests/invoiceVerification.service.test.js
@@ -1,9 +1,42 @@
 /**
  * Comprehensive test suite for Invoice Verification Service.
- * Tests fraud checks, business rules, and security validations across all decision paths.
+ *
+ * Covers fraud checks, business rules, security validations, machine-readable
+ * reason codes, configuration-driven thresholds, per-tenant overrides, and
+ * invalid-configuration handling across all decision paths.
  */
 
-const { verifyInvoice } = require('../src/services/invoiceVerification');
+const { verifyInvoice, ReasonCode } = require('../src/services/invoiceVerification');
+const {
+  resolveThresholds,
+  VerificationConfigError,
+  DEFAULT_FRAUD_CEILING,
+  DEFAULT_MANUAL_REVIEW_THRESHOLD,
+  _resetThresholdCache,
+} = require('../src/config/verificationThresholds');
+
+const THRESHOLD_ENV_KEYS = [
+  'INVOICE_FRAUD_CEILING',
+  'INVOICE_MANUAL_REVIEW_THRESHOLD',
+  'INVOICE_TENANT_THRESHOLDS',
+];
+
+/** Remove all threshold env vars so each test starts from documented defaults. */
+function clearThresholdEnv() {
+  for (const key of THRESHOLD_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+beforeEach(() => {
+  clearThresholdEnv();
+  _resetThresholdCache();
+});
+
+afterAll(() => {
+  clearThresholdEnv();
+  _resetThresholdCache();
+});
 
 describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
   // ============================================================================
@@ -59,6 +92,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'MANUAL_REVIEW',
         reason: 'High value invoice requires manual approval',
+        reasonCode: ReasonCode.MANUAL_REVIEW_REQUIRED,
       });
     });
   });
@@ -72,6 +106,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid payload structure',
+        reasonCode: ReasonCode.INVALID_PAYLOAD,
       });
     });
 
@@ -80,6 +115,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid payload structure',
+        reasonCode: ReasonCode.INVALID_PAYLOAD,
       });
     });
 
@@ -88,6 +124,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid payload structure',
+        reasonCode: ReasonCode.INVALID_PAYLOAD,
       });
     });
 
@@ -96,6 +133,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid payload structure',
+        reasonCode: ReasonCode.INVALID_PAYLOAD,
       });
     });
 
@@ -104,6 +142,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid payload structure',
+        reasonCode: ReasonCode.INVALID_PAYLOAD,
       });
     });
 
@@ -113,6 +152,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
   });
@@ -129,6 +169,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -140,6 +181,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -151,6 +193,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -162,6 +205,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -173,6 +217,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -184,6 +229,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -195,6 +241,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -206,6 +253,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -217,6 +265,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
@@ -228,18 +277,20 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
-    it('should reject Infinity (exceeds max threshold)', async () => {
+    it('should reject Infinity (exceeds fraud ceiling)', async () => {
       const result = await verifyInvoice({
         amount: Infinity,
         customer: 'Acme Corp',
       });
-      // Infinity is > 10000000, so it fails on max threshold check, not type check
+      // Infinity is > fraud ceiling, so it fails the ceiling check, not the type check
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Amount exceeds maximum allowed threshold',
+        reasonCode: ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING,
       });
     });
 
@@ -251,6 +302,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
   });
@@ -267,6 +319,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -278,6 +331,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -289,6 +343,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -300,6 +355,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -311,6 +367,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -322,6 +379,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -333,6 +391,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -344,6 +403,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -355,6 +415,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
@@ -366,6 +427,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
   });
@@ -374,145 +436,48 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
   // GROUP 5: REJECTED - Injection Pattern Detection (Security)
   // ============================================================================
   describe('REJECTED - injection pattern security validation', () => {
-    it('should reject customer with HTML injection (<)', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme<Corp',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
+    const cases = [
+      ['HTML injection (<)', 'Acme<Corp'],
+      ['HTML closing tag injection (>)', 'Acme>Corp'],
+      ['script tag', '<script>alert("xss")</script>'],
+      ['curly braces (template injection)', 'Acme{Corp}'],
+      ['opening curly brace only', 'Acme{Corp'],
+      ['closing curly brace only', 'AcmeCorp}'],
+      ['dollar sign (variable injection)', 'Acme$Corp'],
+      ['template literal syntax', '`Acme${Corp}`'],
+      ['multiple injection patterns', '<Acme$Corp>'],
+      ['leading suspicious character', '<Acme'],
+      ['trailing suspicious character', 'Acme>'],
+    ];
 
-    it('should reject customer with HTML closing tag injection (>)', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme>Corp',
-      });
+    it.each(cases)('should reject customer with %s', async (_label, customer) => {
+      const result = await verifyInvoice({ amount: 5000, customer });
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with script tag', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: '<script>alert("xss")</script>',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with curly braces (template injection)', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme{Corp}',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with opening curly brace only', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme{Corp',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with closing curly brace only', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'AcmeCorp}',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with dollar sign (variable injection)', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme$Corp',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with template literal syntax', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: '`Acme${Corp}`',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer with multiple injection patterns', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: '<Acme$Corp>',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer starting with suspicious character', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: '<Acme',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
-      });
-    });
-
-    it('should reject customer ending with suspicious character', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme>',
-      });
-      expect(result).toEqual({
-        status: 'REJECTED',
-        reason: 'Suspicious characters detected in customer data',
+        reasonCode: ReasonCode.SUSPICIOUS_CUSTOMER,
       });
     });
   });
 
   // ============================================================================
-  // GROUP 6: REJECTED - Amount Exceeds Maximum Threshold
+  // GROUP 6: Fraud ceiling (default configuration)
   // ============================================================================
-  describe('REJECTED - amount exceeds maximum threshold', () => {
-    it('should require manual review at maximum threshold (10000000)', async () => {
+  describe('REJECTED - amount exceeds fraud ceiling (defaults)', () => {
+    it('should require manual review exactly at the fraud ceiling (10000000)', async () => {
       const result = await verifyInvoice({
         amount: 10000000,
         customer: 'Acme Corp',
       });
-      // 10000000 >= 1000000, so manual review before max threshold check
+      // 10000000 is not > ceiling, and >= manual-review threshold
       expect(result).toEqual({
         status: 'MANUAL_REVIEW',
         reason: 'High value invoice requires manual approval',
+        reasonCode: ReasonCode.MANUAL_REVIEW_REQUIRED,
       });
     });
 
-    it('should reject amount just above maximum threshold (10000000.01)', async () => {
+    it('should reject amount just above the fraud ceiling (10000000.01)', async () => {
       const result = await verifyInvoice({
         amount: 10000000.01,
         customer: 'Acme Corp',
@@ -520,6 +485,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Amount exceeds maximum allowed threshold',
+        reasonCode: ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING,
       });
     });
 
@@ -531,6 +497,7 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Amount exceeds maximum allowed threshold',
+        reasonCode: ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING,
       });
     });
 
@@ -542,67 +509,39 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Amount exceeds maximum allowed threshold',
+        reasonCode: ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING,
       });
     });
   });
 
   // ============================================================================
-  // GROUP 7: MANUAL_REVIEW - High Value Invoice (1M - 10M Range)
+  // GROUP 7: MANUAL_REVIEW - High Value Invoice (default configuration)
   // ============================================================================
-  describe('MANUAL_REVIEW - high value invoice threshold', () => {
-    it('should require manual review at minimum threshold (1000000)', async () => {
-      const result = await verifyInvoice({
-        amount: 1000000,
-        customer: 'Large Corp',
-      });
-      expect(result).toEqual({
-        status: 'MANUAL_REVIEW',
-        reason: 'High value invoice requires manual approval',
-      });
+  describe('MANUAL_REVIEW - high value invoice threshold (defaults)', () => {
+    const expected = {
+      status: 'MANUAL_REVIEW',
+      reason: 'High value invoice requires manual approval',
+      reasonCode: ReasonCode.MANUAL_REVIEW_REQUIRED,
+    };
+
+    it('should require manual review at the manual-review threshold (1000000)', async () => {
+      const result = await verifyInvoice({ amount: 1000000, customer: 'Large Corp' });
+      expect(result).toEqual(expected);
     });
 
-    it('should require manual review just above minimum threshold (1000000.01)', async () => {
-      const result = await verifyInvoice({
-        amount: 1000000.01,
-        customer: 'Large Corp',
-      });
-      expect(result).toEqual({
-        status: 'MANUAL_REVIEW',
-        reason: 'High value invoice requires manual approval',
-      });
+    it('should require manual review just above the threshold (1000000.01)', async () => {
+      const result = await verifyInvoice({ amount: 1000000.01, customer: 'Large Corp' });
+      expect(result).toEqual(expected);
     });
 
     it('should require manual review at mid-range (5000000)', async () => {
-      const result = await verifyInvoice({
-        amount: 5000000,
-        customer: 'Enterprise Corp',
-      });
-      expect(result).toEqual({
-        status: 'MANUAL_REVIEW',
-        reason: 'High value invoice requires manual approval',
-      });
+      const result = await verifyInvoice({ amount: 5000000, customer: 'Enterprise Corp' });
+      expect(result).toEqual(expected);
     });
 
-    it('should require manual review just below maximum threshold (9999999.99)', async () => {
-      const result = await verifyInvoice({
-        amount: 9999999.99,
-        customer: 'Mega Corp',
-      });
-      expect(result).toEqual({
-        status: 'MANUAL_REVIEW',
-        reason: 'High value invoice requires manual approval',
-      });
-    });
-
-    it('should require manual review with valid customer in mid-range', async () => {
-      const result = await verifyInvoice({
-        amount: 2500000,
-        customer: 'Global Holdings Inc.',
-      });
-      expect(result).toEqual({
-        status: 'MANUAL_REVIEW',
-        reason: 'High value invoice requires manual approval',
-      });
+    it('should require manual review just below the fraud ceiling (9999999.99)', async () => {
+      const result = await verifyInvoice({ amount: 9999999.99, customer: 'Mega Corp' });
+      expect(result).toEqual(expected);
     });
   });
 
@@ -612,44 +551,27 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
   describe('validation order - early exit on first failure', () => {
     it('should reject invalid payload before checking amount', async () => {
       const result = await verifyInvoice(null);
-      // Expects payload check, not amount check
-      expect(result.reason).toBe('Invalid payload structure');
+      expect(result.reasonCode).toBe(ReasonCode.INVALID_PAYLOAD);
     });
 
     it('should check amount before customer when payload is valid', async () => {
-      const result = await verifyInvoice({
-        amount: 'invalid',
-        customer: null, // also invalid
-      });
-      // Should fail on amount, not customer
-      expect(result.reason).toBe('Invalid amount: must be a positive number');
+      const result = await verifyInvoice({ amount: 'invalid', customer: null });
+      expect(result.reasonCode).toBe(ReasonCode.INVALID_AMOUNT);
     });
 
     it('should check customer validity before injection patterns', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: null, // invalid type before injection check
-      });
-      // Should fail on type, not injection
-      expect(result.reason).toBe('Invalid customer: must be a non-empty string');
+      const result = await verifyInvoice({ amount: 5000, customer: null });
+      expect(result.reasonCode).toBe(ReasonCode.INVALID_CUSTOMER);
     });
 
-    it('should check amount threshold before customer injection', async () => {
-      const result = await verifyInvoice({
-        amount: 15000000, // exceeds max
-        customer: 'Normal<Customer', // has injection
-      });
-      // Should fail on amount, not injection
-      expect(result.reason).toBe('Amount exceeds maximum allowed threshold');
+    it('should check fraud ceiling before customer injection', async () => {
+      const result = await verifyInvoice({ amount: 15000000, customer: 'Normal<Customer' });
+      expect(result.reasonCode).toBe(ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING);
     });
 
     it('should reach injection check after all other validations pass', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme<Corp',
-      });
-      // Should fail on injection
-      expect(result.reason).toBe('Suspicious characters detected in customer data');
+      const result = await verifyInvoice({ amount: 5000, customer: 'Acme<Corp' });
+      expect(result.reasonCode).toBe(ReasonCode.SUSPICIOUS_CUSTOMER);
     });
   });
 
@@ -667,59 +589,47 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({ status: 'VERIFIED' });
     });
 
-    it('should handle payload with missing optional-looking fields', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Acme Corp',
-        // no extra fields
+    it('should ignore a tenantId smuggled in the payload (not options)', async () => {
+      process.env.INVOICE_TENANT_THRESHOLDS = JSON.stringify({
+        evil: { manualReviewThreshold: 1 },
       });
+      _resetThresholdCache();
+      // Even though the payload carries tenantId, it must NOT influence thresholds.
+      const result = await verifyInvoice({ amount: 5000, customer: 'Acme', tenantId: 'evil' });
       expect(result).toEqual({ status: 'VERIFIED' });
     });
 
-    it('should treat undefined amount field as missing (falsy check)', async () => {
-      const result = await verifyInvoice({
-        amount: undefined,
-        customer: 'Acme Corp',
-      });
+    it('should treat undefined amount field as invalid', async () => {
+      const result = await verifyInvoice({ amount: undefined, customer: 'Acme Corp' });
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid amount: must be a positive number',
+        reasonCode: ReasonCode.INVALID_AMOUNT,
       });
     });
 
-    it('should treat undefined customer field as missing (falsy check)', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: undefined,
-      });
+    it('should treat undefined customer field as invalid', async () => {
+      const result = await verifyInvoice({ amount: 5000, customer: undefined });
       expect(result).toEqual({
         status: 'REJECTED',
         reason: 'Invalid customer: must be a non-empty string',
+        reasonCode: ReasonCode.INVALID_CUSTOMER,
       });
     });
 
     it('should handle very small positive amount (0.001)', async () => {
-      const result = await verifyInvoice({
-        amount: 0.001,
-        customer: 'Micro Corp',
-      });
+      const result = await verifyInvoice({ amount: 0.001, customer: 'Micro Corp' });
       expect(result).toEqual({ status: 'VERIFIED' });
     });
 
     it('should handle very long customer name', async () => {
       const longName = 'A'.repeat(1000);
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: longName,
-      });
+      const result = await verifyInvoice({ amount: 5000, customer: longName });
       expect(result).toEqual({ status: 'VERIFIED' });
     });
 
     it('should handle customer name with international characters', async () => {
-      const result = await verifyInvoice({
-        amount: 5000,
-        customer: 'Société Générale',
-      });
+      const result = await verifyInvoice({ amount: 5000, customer: 'Société Générale' });
       expect(result).toEqual({ status: 'VERIFIED' });
     });
 
@@ -762,5 +672,252 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(results[1].status).toBe('REJECTED');
       expect(results[2].status).toBe('MANUAL_REVIEW');
     });
+  });
+
+  // ============================================================================
+  // GROUP 11: Configuration-driven global thresholds
+  // ============================================================================
+  describe('configuration-driven global thresholds', () => {
+    it('applies a custom fraud ceiling from INVOICE_FRAUD_CEILING', async () => {
+      process.env.INVOICE_FRAUD_CEILING = '2000000';
+      _resetThresholdCache();
+
+      const rejected = await verifyInvoice({ amount: 2000001, customer: 'Acme' });
+      expect(rejected.reasonCode).toBe(ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING);
+
+      // At the new ceiling: not rejected, but >= default manual-review threshold.
+      const review = await verifyInvoice({ amount: 2000000, customer: 'Acme' });
+      expect(review.reasonCode).toBe(ReasonCode.MANUAL_REVIEW_REQUIRED);
+    });
+
+    it('applies a custom manual-review threshold from INVOICE_MANUAL_REVIEW_THRESHOLD', async () => {
+      process.env.INVOICE_MANUAL_REVIEW_THRESHOLD = '5000';
+      _resetThresholdCache();
+
+      const review = await verifyInvoice({ amount: 5000, customer: 'Acme' });
+      expect(review.reasonCode).toBe(ReasonCode.MANUAL_REVIEW_REQUIRED);
+
+      const verified = await verifyInvoice({ amount: 4999.99, customer: 'Acme' });
+      expect(verified).toEqual({ status: 'VERIFIED' });
+    });
+
+    it('tightens both thresholds together', async () => {
+      process.env.INVOICE_FRAUD_CEILING = '100000';
+      process.env.INVOICE_MANUAL_REVIEW_THRESHOLD = '10000';
+      _resetThresholdCache();
+
+      expect((await verifyInvoice({ amount: 9999, customer: 'Acme' })).status).toBe('VERIFIED');
+      expect((await verifyInvoice({ amount: 10000, customer: 'Acme' })).reasonCode).toBe(
+        ReasonCode.MANUAL_REVIEW_REQUIRED
+      );
+      expect((await verifyInvoice({ amount: 100001, customer: 'Acme' })).reasonCode).toBe(
+        ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING
+      );
+    });
+  });
+
+  // ============================================================================
+  // GROUP 12: Per-tenant overrides
+  // ============================================================================
+  describe('per-tenant threshold overrides', () => {
+    beforeEach(() => {
+      process.env.INVOICE_TENANT_THRESHOLDS = JSON.stringify({
+        'tenant-strict': { fraudCeiling: 50000, manualReviewThreshold: 10000 },
+        'tenant-loose': { fraudCeiling: 50000000, manualReviewThreshold: 5000000 },
+        'tenant-partial': { manualReviewThreshold: 250000 },
+      });
+      _resetThresholdCache();
+    });
+
+    it('applies a stricter tenant override', async () => {
+      const review = await verifyInvoice(
+        { amount: 10000, customer: 'Acme' },
+        { tenantId: 'tenant-strict' }
+      );
+      expect(review.reasonCode).toBe(ReasonCode.MANUAL_REVIEW_REQUIRED);
+
+      const rejected = await verifyInvoice(
+        { amount: 50001, customer: 'Acme' },
+        { tenantId: 'tenant-strict' }
+      );
+      expect(rejected.reasonCode).toBe(ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING);
+    });
+
+    it('applies a looser tenant override', async () => {
+      // Amount that defaults would send to manual review is verified for the loose tenant.
+      const verified = await verifyInvoice(
+        { amount: 4999999, customer: 'Acme' },
+        { tenantId: 'tenant-loose' }
+      );
+      expect(verified).toEqual({ status: 'VERIFIED' });
+    });
+
+    it('fills omitted override fields from global defaults (partial override)', async () => {
+      // Only manualReviewThreshold overridden; fraudCeiling falls back to default 10000000.
+      const review = await verifyInvoice(
+        { amount: 250000, customer: 'Acme' },
+        { tenantId: 'tenant-partial' }
+      );
+      expect(review.reasonCode).toBe(ReasonCode.MANUAL_REVIEW_REQUIRED);
+
+      const rejected = await verifyInvoice(
+        { amount: 10000001, customer: 'Acme' },
+        { tenantId: 'tenant-partial' }
+      );
+      expect(rejected.reasonCode).toBe(ReasonCode.AMOUNT_EXCEEDS_FRAUD_CEILING);
+    });
+
+    it('falls back to defaults for an unknown tenant', async () => {
+      const result = await verifyInvoice(
+        { amount: 999999, customer: 'Acme' },
+        { tenantId: 'no-such-tenant' }
+      );
+      expect(result).toEqual({ status: 'VERIFIED' });
+    });
+
+    it('falls back to defaults when no tenantId is supplied', async () => {
+      const result = await verifyInvoice({ amount: 999999, customer: 'Acme' });
+      expect(result).toEqual({ status: 'VERIFIED' });
+    });
+
+    it('does not resolve prototype-pollution keys as tenants', async () => {
+      const result = await verifyInvoice(
+        { amount: 999999, customer: 'Acme' },
+        { tenantId: '__proto__' }
+      );
+      // Should use defaults (999999 < 1000000 => VERIFIED), not crash or inherit.
+      expect(result).toEqual({ status: 'VERIFIED' });
+    });
+  });
+
+  // ============================================================================
+  // GROUP 13: Invalid configuration handling (fail closed)
+  // ============================================================================
+  describe('invalid configuration handling', () => {
+    it('fails closed to MANUAL_REVIEW on a non-numeric fraud ceiling', async () => {
+      process.env.INVOICE_FRAUD_CEILING = 'not-a-number';
+      _resetThresholdCache();
+
+      const result = await verifyInvoice({ amount: 5000, customer: 'Acme' });
+      expect(result).toEqual({
+        status: 'MANUAL_REVIEW',
+        reason: 'Threshold configuration unavailable; manual review required',
+        reasonCode: ReasonCode.CONFIG_UNAVAILABLE,
+      });
+    });
+
+    it('fails closed when manual-review threshold exceeds the fraud ceiling', async () => {
+      process.env.INVOICE_FRAUD_CEILING = '1000';
+      process.env.INVOICE_MANUAL_REVIEW_THRESHOLD = '5000';
+      _resetThresholdCache();
+
+      const result = await verifyInvoice({ amount: 100, customer: 'Acme' });
+      expect(result.reasonCode).toBe(ReasonCode.CONFIG_UNAVAILABLE);
+    });
+
+    it('fails closed on malformed tenant override JSON', async () => {
+      process.env.INVOICE_TENANT_THRESHOLDS = '{ not valid json';
+      _resetThresholdCache();
+
+      const result = await verifyInvoice(
+        { amount: 5000, customer: 'Acme' },
+        { tenantId: 'tenant-strict' }
+      );
+      expect(result.reasonCode).toBe(ReasonCode.CONFIG_UNAVAILABLE);
+    });
+
+    it('still rejects structurally invalid input before consulting config', async () => {
+      process.env.INVOICE_FRAUD_CEILING = 'not-a-number';
+      _resetThresholdCache();
+
+      // Structural checks run before threshold resolution, so this is a clean reject.
+      const result = await verifyInvoice({ amount: -1, customer: 'Acme' });
+      expect(result.reasonCode).toBe(ReasonCode.INVALID_AMOUNT);
+    });
+  });
+});
+
+// ============================================================================
+// Configuration module unit tests
+// ============================================================================
+describe('verificationThresholds config module', () => {
+  it('returns documented defaults when no env vars are set', () => {
+    const thresholds = resolveThresholds();
+    expect(thresholds).toEqual({
+      fraudCeiling: DEFAULT_FRAUD_CEILING,
+      manualReviewThreshold: DEFAULT_MANUAL_REVIEW_THRESHOLD,
+    });
+  });
+
+  it('treats empty-string env values as unset and uses defaults', () => {
+    process.env.INVOICE_FRAUD_CEILING = '';
+    process.env.INVOICE_MANUAL_REVIEW_THRESHOLD = '   ';
+    _resetThresholdCache();
+    expect(resolveThresholds()).toEqual({
+      fraudCeiling: DEFAULT_FRAUD_CEILING,
+      manualReviewThreshold: DEFAULT_MANUAL_REVIEW_THRESHOLD,
+    });
+  });
+
+  it('memoizes parsed config until reset', () => {
+    // Keep manual-review threshold low so the custom ceilings stay consistent.
+    process.env.INVOICE_MANUAL_REVIEW_THRESHOLD = '100';
+    process.env.INVOICE_FRAUD_CEILING = '12345';
+    _resetThresholdCache();
+    expect(resolveThresholds().fraudCeiling).toBe(12345);
+
+    // Mutating env without resetting must not change the memoized value.
+    process.env.INVOICE_FRAUD_CEILING = '999';
+    expect(resolveThresholds().fraudCeiling).toBe(12345);
+
+    _resetThresholdCache();
+    expect(resolveThresholds().fraudCeiling).toBe(999);
+  });
+
+  it('returns a fresh object each call so callers cannot mutate the cache', () => {
+    const a = resolveThresholds();
+    a.fraudCeiling = 1;
+    const b = resolveThresholds();
+    expect(b.fraudCeiling).toBe(DEFAULT_FRAUD_CEILING);
+  });
+
+  it('throws VerificationConfigError on a zero threshold', () => {
+    process.env.INVOICE_MANUAL_REVIEW_THRESHOLD = '0';
+    _resetThresholdCache();
+    expect(() => resolveThresholds()).toThrow(VerificationConfigError);
+  });
+
+  it('throws VerificationConfigError on a negative threshold', () => {
+    process.env.INVOICE_FRAUD_CEILING = '-5';
+    _resetThresholdCache();
+    expect(() => resolveThresholds()).toThrow(VerificationConfigError);
+  });
+
+  it('throws when tenant overrides JSON is an array, not an object', () => {
+    process.env.INVOICE_TENANT_THRESHOLDS = '[]';
+    _resetThresholdCache();
+    expect(() => resolveThresholds()).toThrow(VerificationConfigError);
+  });
+
+  it('throws when a tenant override is not an object', () => {
+    process.env.INVOICE_TENANT_THRESHOLDS = JSON.stringify({ acme: 5 });
+    _resetThresholdCache();
+    expect(() => resolveThresholds('acme')).toThrow(VerificationConfigError);
+  });
+
+  it('throws when a tenant override field is not a positive number', () => {
+    process.env.INVOICE_TENANT_THRESHOLDS = JSON.stringify({
+      acme: { fraudCeiling: 'huge' },
+    });
+    _resetThresholdCache();
+    expect(() => resolveThresholds('acme')).toThrow(VerificationConfigError);
+  });
+
+  it('accepts a numeric tenantId by coercing it to a string key', () => {
+    process.env.INVOICE_TENANT_THRESHOLDS = JSON.stringify({
+      '42': { manualReviewThreshold: 500 },
+    });
+    _resetThresholdCache();
+    expect(resolveThresholds(42).manualReviewThreshold).toBe(500);
   });
 });


### PR DESCRIPTION
closes #438 

Summary
The invoice-verification service hardcoded two amount limits in src/services/invoiceVerification.js — the fraud-rejection ceiling (10,000,000) and the manual-review threshold (1,000,000). These literals couldn't adapt to different currencies, tenant risk appetites, or limit changes without a code change and redeploy. This PR moves them into environment-backed configuration with optional per-tenant overrides, and adds a stable machine-readable reason code to every decision.

Changes
New src/config/verificationThresholds.js — resolves thresholds from the environment with documented defaults that preserve current behavior:
INVOICE_FRAUD_CEILING (default 10000000)
INVOICE_MANUAL_REVIEW_THRESHOLD (default 1000000)
INVOICE_TENANT_THRESHOLDS — JSON map of per-tenant overrides; each entry may set either or both fields, with omitted fields falling back to the global defaults.
src/services/invoiceVerification.js — now resolves thresholds via config (optionally per-tenant), emits a machine-readable reasonCode on every reject/manual-review outcome, and keeps the decision order and human-readable reason strings unchanged. verifyInvoice(payload, { tenantId }) takes the tenant id from a trusted second argument.
Docs — docs/configuration.md documents the thresholds, override format, validation rules, and the full reason-code table; .env.example documents the new vars (defaults shown, commented).
Behavior & validation
Defaults reproduce the prior behavior exactly — a deployment that sets nothing sees no change.
Each value must be a finite number > 0, and manualReviewThreshold <= fraudCeiling (otherwise the manual-review band is unreachable). Invalid config is rejected.
Fail closed: on invalid configuration the service returns MANUAL_REVIEW with reasonCode: CONFIG_UNAVAILABLE rather than auto-approving or hard-rejecting.
Reason codes (new contract)
INVALID_PAYLOAD, INVALID_AMOUNT, INVALID_CUSTOMER, AMOUNT_EXCEEDS_FRAUD_CEILING, MANUAL_REVIEW_REQUIRED, SUSPICIOUS_CUSTOMER, CONFIG_UNAVAILABLE. VERIFIED outcomes carry no reason code. Existing codes must not be renamed/repurposed.

Security
Thresholds and overrides come only from operator/admin-set environment config — never from request payloads. A tenantId (or threshold-like field) on the invoice payload is ignored.
The per-tenant map is parsed into a Map, so prototype-pollution keys like __proto__ cannot be resolved as tenants (covered by a test).
Tests
tests/invoiceVerification.service.test.js rewritten and expanded; src/__tests__/invoiceVerification.test.js updated for the new reasonCode field.
Covers config-driven thresholds, per-tenant overrides (stricter/looser/partial/unknown), reason codes, at-threshold boundaries, and invalid-config handling.
102 tests pass; coverage: config module 100%, service 95.6% (≥95% bar). eslint clean on all changed files.
Notes for reviewers
Two CI failures on this branch are pre-existing on the upstream base (ad43a788) and unrelated to this change — verified by diffing against the base:

src/metrics.js has a duplicate registerJobQueue/registerWorker declaration (lines 238 & 548).
config.envReference test: upstream's JOB_QUEUE_PERSISTENCE_ENABLED and SHUTDOWN_TIMEOUT_MS are in .env.example but undocumented.