### PR TITLE
feat: retry transient per-invoice failures in batch escrow reader

### DIFF
--- a/docs/escrow-integration-overview.md
+++ b/docs/escrow-integration-overview.md
@@ -91,7 +91,7 @@ avoid IEEE 754 drift in UI rendering.
 | Stellar network | [`src/config/stellar.js`](../src/config/stellar.js), [`src/config/index.js`](../src/config/index.js) | `getStellarConfig`, Zod `validate()` |
 | Soroban wrapper | [`src/services/soroban.js`](../src/services/soroban.js) | `callSorobanContract` (retries) |
 | Read + legal hold | [`src/services/escrowRead.js`](../src/services/escrowRead.js) | `readEscrowState`, `fetchLegalHold` |
-| Batch read | [`src/services/escrowBatchRead.js`](../src/services/escrowBatchRead.js) | Uses `readEscrowState` with concurrency limits |
+| Batch read | [`src/services/escrowBatchRead.js`](../src/services/escrowBatchRead.js) | Uses `readEscrowState` with concurrency limits and per-invoice transient error retry |
 | Funding stub | [`src/services/escrowSubmit.js`](../src/services/escrowSubmit.js) | `submitEscrowFunding`, `FUND_OPERATION = 'fund_escrow'` |
 | Simulation | [`src/services/sorobanSim.js`](../src/services/sorobanSim.js) | `simulateOrThrowSync` (when signed XDR present) |
 | Indexer job | [`src/jobs/escrowIndexer.js`](../src/jobs/escrowIndexer.js) | `createEscrowIndexer`, `runEscrowIndexerCycle`, `persistEscrowEvent` |

--- a/src/services/escrowBatchRead.js
+++ b/src/services/escrowBatchRead.js
@@ -8,6 +8,7 @@
  */
 
 const { readEscrowState } = require('./escrowRead');
+const { classifySorobanError, withRetry, SOROBAN_RETRY_CONFIG } = require('./soroban');
 const logger = require('../logger');
 const config = require('../config');
 
@@ -40,14 +41,20 @@ async function withTimeout(promise, ms, id) {
  *
  * Implements:
  *  - Concurrency limits to prevent RPC flooding.
- *  - Individual timeouts per call.
+ *  - Individual timeouts per call (including retries).
  *  - Per-call failure isolation (one failure doesn't crash the batch).
+ *  - Automatic retry of transient errors (timeouts, 5xx, rate limits) using
+ *    the unified Soroban error classifier.
  *
  * @param {string[]} invoiceIds - Array of invoice identifiers to read.
  * @param {Object} [options={}] - Batch options.
  * @param {number} [options.concurrency] - Maximum concurrent RPC calls.
- * @param {number} [options.timeout] - Timeout in ms for each individual call.
+ * @param {number} [options.timeout] - Timeout in ms for each individual call
+ *   (including all retry attempts).
  * @param {Object} [options.readOptions={}] - Options passed to `readEscrowState`.
+ * @param {Object} [options.retryConfig={}] - Optional retry configuration overrides.
+ *   If not provided, uses the global SOROBAN_RETRY_CONFIG. The retry budget
+ *   is automatically capped to respect the per-invoice timeout.
  * @returns {Promise<{results: Object[], errors: Object[]}>} Results and errors.
  */
 async function batchReadEscrowStates(invoiceIds, options = {}) {
@@ -66,6 +73,7 @@ async function batchReadEscrowStates(invoiceIds, options = {}) {
     concurrency = cfg.SOROBAN_BATCH_CONCURRENCY,
     timeout = cfg.SOROBAN_BATCH_TIMEOUT_MS,
     readOptions = {},
+    retryConfig = {},
   } = options;
 
   const results = [];
@@ -76,6 +84,26 @@ async function batchReadEscrowStates(invoiceIds, options = {}) {
   
   /**
    * Worker function that processes IDs from the queue.
+   *
+   * For each invoice ID:
+   * 1. Wraps the read operation with retry logic for transient errors using
+   *    the unified Soroban error classifier (`classifySorobanError`).
+   * 2. Applies a timeout to the entire operation (including all retries).
+   * 3. Isolates failures so one error doesn't stop the batch.
+   *
+   * The retry budget is automatically capped to respect the per-invoice timeout,
+   * preventing retries from blowing the batch budget. This ensures that even under
+   * sustained failure, the service cannot amplify load into a self-DoS.
+   *
+   * Error classification and retry behavior:
+   * - Transient errors (timeouts, 5xx, rate limits) are retried with exponential
+   *   backoff before being recorded as failed.
+   * - Permanent errors (e.g., 400 Bad Request) are not retried and immediately
+   *   recorded as failed.
+   * - All errors are classified using `classifySorobanError` for consistent
+   *   behavior across the codebase.
+   *
+   * @returns {Promise<void>}
    */
   async function worker() {
     while (remainingIds.length > 0) {
@@ -83,19 +111,44 @@ async function batchReadEscrowStates(invoiceIds, options = {}) {
       if (!id) { continue; }
 
       try {
-        // Isolation: Each call is wrapped in its own try/catch and timeout
+        // Cap the retry budget to respect the per-invoice timeout.
+        // This prevents retries from blowing the batch budget.
+        const cappedRetryConfig = {
+          ...SOROBAN_RETRY_CONFIG,
+          ...retryConfig,
+          maxElapsedMs: Math.min(
+            retryConfig.maxElapsedMs ?? SOROBAN_RETRY_CONFIG.maxElapsedMs,
+            timeout * 0.9 // Reserve 10% of timeout for final call overhead
+          ),
+        };
+
+        // Isolation: Each call is wrapped in its own try/catch, timeout, and retry logic
         const state = await withTimeout(
-          readEscrowState(id, readOptions),
+          withRetry(() => readEscrowState(id, readOptions), cappedRetryConfig),
           timeout,
           id
         );
         results.push(state);
       } catch (err) {
-        logger.error({ invoiceId: id, err: err.message, code: err.code }, 'Batch read failure for invoice');
+        const classification = classifySorobanError(err);
+        logger.error(
+          { 
+            invoiceId: id, 
+            err: err.message, 
+            code: err.code, 
+            retryable: classification.retryable,
+            category: classification.category,
+            reason: classification.reason 
+          }, 
+          'Batch read failure for invoice'
+        );
         errors.push({
           invoiceId: id,
           error: err.message || 'Unknown error',
           code: err.code || 'INTERNAL_ERROR',
+          retryable: classification.retryable,
+          category: classification.category,
+          reason: classification.reason,
         });
       }
     }

--- a/tests/escrow.batch.test.js
+++ b/tests/escrow.batch.test.js
@@ -9,9 +9,23 @@ jest.mock('../src/services/escrowRead', () => ({
   validateInvoiceId: jest.requireActual('../src/services/escrowRead').validateInvoiceId,
 }));
 
+// Mock the soroban module to control retry behavior
+jest.mock('../src/services/soroban', () => {
+  const actual = jest.requireActual('../src/services/soroban');
+  return {
+    ...actual,
+    classifySorobanError: actual.classifySorobanError,
+    withRetry: jest.fn((operation, config) => operation()),
+  };
+});
+
 describe('escrowBatchRead Service', () => {
+  const { withRetry } = require('../src/services/soroban');
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default mock: withRetry just calls the operation (no retry)
+    withRetry.mockImplementation((operation, config) => operation());
   });
 
   it('should read multiple escrow states successfully', async () => {
@@ -96,5 +110,272 @@ describe('escrowBatchRead Service', () => {
     // With concurrency 2, we shouldn't have more than 2 active calls at a time
     expect(maxConcurrent).toBeLessThanOrEqual(concurrency);
     expect(readEscrowState).toHaveBeenCalledTimes(5);
+  });
+
+  describe('Transient error retry behavior', () => {
+    it('should retry transient errors and succeed on recovery', async () => {
+      const invoiceIds = ['inv_transient'];
+      let attemptCount = 0;
+
+      readEscrowState.mockImplementation(() => {
+        attemptCount++;
+        if (attemptCount < 2) {
+          // First attempt fails with transient error
+          const err = new Error('Service unavailable');
+          err.status = 503;
+          return Promise.reject(err);
+        }
+        // Second attempt succeeds
+        return Promise.resolve({
+          invoiceId: 'inv_transient',
+          status: 'active',
+          fundedAmount: 1000,
+          legal_hold: false,
+        });
+      });
+
+      // Mock withRetry to actually retry
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        let lastErr;
+        for (let i = 0; i <= (config.maxRetries || 3); i++) {
+          try {
+            return await operation();
+          } catch (err) {
+            lastErr = err;
+            if (i === (config.maxRetries || 3)) throw err;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+        }
+        throw lastErr;
+      });
+
+      const result = await batchReadEscrowStates(invoiceIds);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+      expect(result.results[0].invoiceId).toBe('inv_transient');
+      expect(attemptCount).toBeGreaterThan(1);
+    });
+
+    it('should exhaust retries on persistent transient errors and isolate failure', async () => {
+      const invoiceIds = ['inv_persistent_transient', 'inv_success'];
+      let attemptCount = 0;
+
+      readEscrowState.mockImplementation((id) => {
+        if (id === 'inv_persistent_transient') {
+          attemptCount++;
+          // Always fails with transient error
+          const err = new Error('Gateway timeout');
+          err.status = 504;
+          return Promise.reject(err);
+        }
+        // Other invoices succeed
+        return Promise.resolve({
+          invoiceId: id,
+          status: 'active',
+          fundedAmount: 1000,
+          legal_hold: false,
+        });
+      });
+
+      // Mock withRetry to actually retry
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        let lastErr;
+        const maxRetries = config.maxRetries || 3;
+        for (let i = 0; i <= maxRetries; i++) {
+          try {
+            return await operation();
+          } catch (err) {
+            lastErr = err;
+            if (i === maxRetries) throw err;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+        }
+        throw lastErr;
+      });
+
+      const result = await batchReadEscrowStates(invoiceIds);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.results[0].invoiceId).toBe('inv_success');
+      expect(result.errors[0].invoiceId).toBe('inv_persistent_transient');
+      expect(result.errors[0].retryable).toBe(true);
+      expect(result.errors[0].category).toBe('rpc-5xx');
+      expect(attemptCount).toBeGreaterThan(1); // Should have retried
+    });
+
+    it('should not retry permanent errors', async () => {
+      const invoiceIds = ['inv_permanent'];
+      let attemptCount = 0;
+
+      readEscrowState.mockImplementation(() => {
+        attemptCount++;
+        // Permanent error (e.g., 400 Bad Request)
+        const err = new Error('Invalid invoice ID');
+        err.status = 400;
+        return Promise.reject(err);
+      });
+
+      // Mock withRetry to track calls but not actually retry permanent errors
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        try {
+          return await operation();
+        } catch (err) {
+          // Don't retry permanent errors
+          throw err;
+        }
+      });
+
+      const result = await batchReadEscrowStates(invoiceIds);
+
+      expect(result.results).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].invoiceId).toBe('inv_permanent');
+      expect(result.errors[0].retryable).toBe(false);
+      expect(result.errors[0].category).toBe('permanent');
+      expect(attemptCount).toBe(1); // Should only have been called once
+    });
+
+    it('should retry network timeout errors', async () => {
+      const invoiceIds = ['inv_timeout'];
+      let attemptCount = 0;
+
+      readEscrowState.mockImplementation(() => {
+        attemptCount++;
+        if (attemptCount < 2) {
+          const err = new Error('Request timed out');
+          err.code = 'ETIMEDOUT';
+          return Promise.reject(err);
+        }
+        return Promise.resolve({
+          invoiceId: 'inv_timeout',
+          status: 'active',
+          fundedAmount: 1000,
+          legal_hold: false,
+        });
+      });
+
+      // Mock withRetry to actually retry
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        let lastErr;
+        for (let i = 0; i <= (config.maxRetries || 3); i++) {
+          try {
+            return await operation();
+          } catch (err) {
+            lastErr = err;
+            if (i === (config.maxRetries || 3)) throw err;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+        }
+        throw lastErr;
+      });
+
+      const result = await batchReadEscrowStates(invoiceIds);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+      expect(attemptCount).toBeGreaterThan(1);
+    });
+
+    it('should retry rate limit errors (429)', async () => {
+      const invoiceIds = ['inv_ratelimit'];
+      let attemptCount = 0;
+
+      readEscrowState.mockImplementation(() => {
+        attemptCount++;
+        if (attemptCount < 2) {
+          const err = new Error('Too many requests');
+          err.status = 429;
+          return Promise.reject(err);
+        }
+        return Promise.resolve({
+          invoiceId: 'inv_ratelimit',
+          status: 'active',
+          fundedAmount: 1000,
+          legal_hold: false,
+        });
+      });
+
+      // Mock withRetry to actually retry
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        let lastErr;
+        for (let i = 0; i <= (config.maxRetries || 3); i++) {
+          try {
+            return await operation();
+          } catch (err) {
+            lastErr = err;
+            if (i === (config.maxRetries || 3)) throw err;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+        }
+        throw lastErr;
+      });
+
+      const result = await batchReadEscrowStates(invoiceIds);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+      expect(attemptCount).toBeGreaterThan(1);
+    });
+
+    it('should cap retry budget to respect per-invoice timeout', async () => {
+      const invoiceIds = ['inv_budget'];
+      const timeout = 1000; // 1 second timeout
+
+      readEscrowState.mockImplementation(() => {
+        const err = new Error('Service unavailable');
+        err.status = 503;
+        return Promise.reject(err);
+      });
+
+      // Mock withRetry to verify the config
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        // Verify that maxElapsedMs is capped to respect timeout
+        expect(config.maxElapsedMs).toBeLessThanOrEqual(timeout);
+        throw new Error('Service unavailable');
+      });
+
+      await batchReadEscrowStates(invoiceIds, { timeout });
+
+      expect(withRetry).toHaveBeenCalled();
+    });
+
+    it('should allow custom retry configuration', async () => {
+      const invoiceIds = ['inv_custom'];
+      const customRetryConfig = {
+        maxRetries: 5,
+        baseDelay: 100,
+        maxDelay: 2000,
+      };
+
+      readEscrowState.mockImplementation(() => {
+        return Promise.resolve({
+          invoiceId: 'inv_custom',
+          status: 'active',
+          fundedAmount: 1000,
+          legal_hold: false,
+        });
+      });
+
+      // Mock withRetry to verify the config
+      const { withRetry } = require('../src/services/soroban');
+      withRetry.mockImplementation(async (operation, config) => {
+        expect(config.maxRetries).toBe(customRetryConfig.maxRetries);
+        expect(config.baseDelay).toBe(customRetryConfig.baseDelay);
+        expect(config.maxDelay).toBe(customRetryConfig.maxDelay);
+        return await operation();
+      });
+
+      await batchReadEscrowStates(invoiceIds, { retryConfig: customRetryConfig });
+
+      expect(withRetry).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Changes committed:
escrowBatchRead.js: Added retry logic using Soroban error classifier and retry primitives
escrow.batch.test.js: Added comprehensive test suite for transient error retry behavior
escrow-integration-overview.md: Updated documentation to reflect retry capability
Key features implemented:
Automatic retry of transient errors (timeouts, 5xx, rate limits) using unified classifySorobanError
Retry budget capped to 90% of per-invoice timeout to prevent self-DoS
Permanent errors isolated without retry
Configurable retry options via retryConfig parameter
Comprehensive JSDoc documentation
closes #435 