### PR TITLE
feat: persist investor locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,7 @@ The backend supports durable idempotency keys for funding operations to safely r
 
 ## Investor Commitment
 
-`src/services/investorCommitment.js` persists funding intents from the `POST /api/invest/fund-invoice` flow and exposes an in-memory lock store for the `GET /api/investor/locks` routes.
+`src/services/investorCommitment.js` persists funding intents from the `POST /api/invest/fund-invoice` flow and exposes tenant-scoped, Knex-backed investor lock storage for the `GET /api/investor/locks` routes.
 
 ### Amount validation
 
@@ -1411,15 +1411,15 @@ Any violation throws a `CommitmentValidationError` with a typed `.code`:
 
 `persistCommitment` accepts an optional `idempotencyKey`. When a row with that key already exists the function returns it immediately — no second insert is made. `updateCommitment` refuses to modify `amount_stroops` to prevent silent corruption of commitment records.
 
-### In-memory lock store
+### Investor lock store
 
-The service maintains a `Map`-backed lock cache (claimNotBefore, investorEffectiveYieldBps) mirrored from the DB. All cached entries carry `stale: true` because they are not read live from the chain.
+The service stores lock records (`claimNotBefore`, `investorEffectiveYieldBps`) in the `investor_locks` table. Rows are unique by `tenant_id`, `invoice_id`, and `funder_address`, so the same invoice/funder pair can exist independently for different tenants. Fresh database reads return `stale: false`; the stale flag is derived from each row's refresh timestamp instead of being hardcoded for every response.
 
 | Function | Purpose |
 |----------|---------|
 | `seedInvestorLocks()` | Populate representative data (used in tests) |
-| `clearInvestorLocks()` | Wipe the cache (used between test suites) |
-| `setInvestorLock(params)` | Upsert a lock record |
+| `clearInvestorLocks()` | Wipe durable lock rows, optionally by tenant (used between test suites) |
+| `setInvestorLock(params)` | Upsert a tenant-scoped lock record |
 | `getInvestorLock(invoiceId, funderAddress)` | Look up a single lock |
 | `getInvestorLocksByAddress(funderAddress, opts)` | Filter by funder address |
 | `getAllInvestorLocks(opts)` | List all locks |

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The investor commitment surface exposes per-funder lock data (`claimNotBefore`, `investorEffectiveYieldBps`) from the DB mirror. Data is currently marked as `stale: true` until on-chain indexing is implemented.
+The investor commitment surface exposes per-funder lock data (`claimNotBefore`, `investorEffectiveYieldBps`) from durable tenant-scoped database rows. Fresh database reads return `stale: false`; rows without a refresh timestamp are surfaced as stale.
 
 ## Architecture
 
@@ -27,12 +27,12 @@ The investor commitment surface exposes per-funder lock data (`claimNotBefore`, 
 | `invoiceId` | string | Associated invoice |
 | `claimNotBefore` | string | ISO timestamp when claims become valid |
 | `investorEffectiveYieldBps` | number | Effective yield in basis points |
-| `stale` | boolean | Whether data is from DB mirror |
+| `stale` | boolean | Whether the row lacks a refresh timestamp |
 
 ## Current Limits
 
-- **Indexing**: Not implemented; data is seeded in-memory for MVP
-- **Stale flag**: Always `true` for DB mirror data
+- **Indexing**: Lock ingestion remains external to this route; the API reads the durable `investor_locks` mirror
+- **Stale flag**: Derived from each row's refresh timestamp
 - **Batched reads**: Not supported; returns partial data for large result sets
 
 ## API Endpoints
@@ -59,7 +59,7 @@ Response:
 ```json
 {
   "data": [...],
-  "meta": { "count": 2, "stale": true }
+  "meta": { "count": 2, "stale": false }
 }
 ```
 
@@ -87,4 +87,4 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 1. **On-chain indexing**: Subscribe to `commit_funds` events from LiquifactEscrow
 2. **Cursor-based pagination**: For large result sets
-3. **Stale=false**: When data is synced from live events
+3. **Event freshness metadata**: Attach source ledger/event cursors when live event ingestion is available

--- a/migrations/20260629000000_create_investor_locks.js
+++ b/migrations/20260629000000_create_investor_locks.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Creates the durable tenant-scoped investor lock table.
+ *
+ * @param {import('knex').Knex} knex
+ * @returns {Promise<void>}
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable('investor_locks', (t) => {
+    t.uuid('id').primary().defaultTo(knex.fn.uuid());
+    t.string('tenant_id', 128).notNullable().index();
+    t.string('invoice_id', 64).notNullable().index();
+    t.string('funder_address', 60).notNullable().index();
+    t.timestamp('claim_not_before').notNullable();
+    t.integer('investor_effective_yield_bps').notNullable();
+    t.timestamp('last_refreshed_at').notNullable().defaultTo(knex.fn.now());
+    t.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    t.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+
+    t.unique(['tenant_id', 'invoice_id', 'funder_address'], {
+      indexName: 'investor_locks_tenant_invoice_funder_unique',
+    });
+    t.index(['tenant_id', 'funder_address', 'invoice_id'], 'investor_locks_tenant_funder_invoice_idx');
+    t.index(['tenant_id', 'invoice_id'], 'investor_locks_tenant_invoice_idx');
+  });
+};
+
+/**
+ * Drops the durable investor lock table.
+ *
+ * @param {import('knex').Knex} knex
+ * @returns {Promise<void>}
+ */
+exports.down = async function (knex) {
+  await knex.schema.dropTableIfExists('investor_locks');
+};

--- a/src/routes/investor.js
+++ b/src/routes/investor.js
@@ -38,7 +38,7 @@ const cacheLock = cacheResponse({
  *     description: |
  *       Retrieve a paginated list of investor lock records
  *       (claimNotBefore, investorEffectiveYieldBps) per funder.
- *       Returns `stale=true` in `meta` for DB-mirrored data.
+ *       Returns `meta.stale=true` only when any row lacks a fresh DB refresh timestamp.
  *
  *       **Pagination**
  *       | Param | Default | Notes |
@@ -180,9 +180,10 @@ router.get('/locks', authenticateToken, extractTenant, cacheLocks, async (req, r
       effectiveFunderAddress = boundFunderAddress;
     }
 
+    const tenantId = req.tenantId;
     const result = effectiveFunderAddress
-      ? investorCommitmentService.getInvestorLocksByAddress(effectiveFunderAddress, { invoiceId, limit, page })
-      : investorCommitmentService.getAllInvestorLocks({ invoiceId, limit, page });
+      ? await investorCommitmentService.getInvestorLocksByAddress(effectiveFunderAddress, { tenantId, invoiceId, limit, page })
+      : await investorCommitmentService.getAllInvestorLocks({ tenantId, invoiceId, limit, page });
 
     const anyStale = result.data.length > 0 && result.data.some((lock) => lock.stale === true);
 
@@ -279,7 +280,9 @@ router.get('/locks/:invoiceId', authenticateToken, extractTenant, cacheLock, asy
       }
     }
 
-    const lock = investorCommitmentService.getInvestorLock(invoiceId, requestedFunderAddress);
+    const lock = await investorCommitmentService.getInvestorLock(invoiceId, requestedFunderAddress, {
+      tenantId: req.tenantId,
+    });
 
     if (!lock) {
       return res.status(404).json({ error: 'Lock not found' });

--- a/src/services/investorCommitment.js
+++ b/src/services/investorCommitment.js
@@ -19,6 +19,8 @@ const db = require('../db/knex');
 const { isValidStellarAddress } = require('../utils/validators');
 
 const TABLE = 'investor_commitments';
+const LOCK_TABLE = 'investor_locks';
+const DEFAULT_TENANT_ID = 'default';
 
 // Sane upper bound: 10^18 stroops (≈ 10 billion XLM — exceeds total supply)
 const MAX_STROOP_AMOUNT = 10n ** 18n;
@@ -235,59 +237,98 @@ async function updateCommitment(id, fields) {
     return db(TABLE).where({ investor_address: investorAddress, invoice_id: invoiceId }).orderBy('created_at', 'desc');
   }
 
-// ── In-memory investor lock store ─────────────────────────────────────────────
-// Keys are "${invoiceId}:${funderAddress}" for O(1) lookup.
-
-/** @type {Map<string, Object>} */
-const _lockStore = new Map();
+// ── Durable investor lock store ───────────────────────────────────────────────
+// Records are keyed by tenant_id + invoice_id + funder_address.
 
 /**
- * Upsert a lock record into the in-memory store.
+ * Normalises an optional tenant ID while keeping the legacy helper surface usable.
  *
- * @param {Object} params
- * @param {string} params.funderAddress
- * @param {string} params.claimNotBefore
- * @param {number} params.investorEffectiveYieldBps
- * @param {string} params.invoiceId
- * @returns {Object} The stored lock record.
+ * @param {string|undefined|null} tenantId - Tenant identifier from the request context.
+ * @returns {string} Sanitised tenant identifier.
  */
-function setInvestorLock({ funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId }) {
-  const key = `${invoiceId}:${funderAddress}`;
-  const record = { funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId, stale: true };
-  _lockStore.set(key, record);
-  return record;
-}
-
-/**
- * Retrieve a single lock by invoiceId and funderAddress.
- *
- * @param {string} invoiceId
- * @param {string} funderAddress
- * @returns {Object|undefined}
- */
-function getInvestorLock(invoiceId, funderAddress) {
-  return _lockStore.get(`${invoiceId}:${funderAddress}`);
-}
-
-/**
- * Returns all locks, optionally filtered by invoiceId, with offset pagination.
- *
- * @param {Object} [opts]
- * @param {string} [opts.invoiceId]  - Optional invoiceId filter.
- * @param {number} [opts.limit=20]   - Page size (1–100).
- * @param {number} [opts.page=1]     - 1-based page number.
- * @returns {{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }}
- */
-function getAllInvestorLocks({ invoiceId, limit = 20, page = 1 } = {}) {
-  const safeLimit = Math.max(1, Math.min(100, limit));
-  const safePage = Math.max(1, page);
-  let items = [..._lockStore.values()];
-  if (invoiceId) {
-    items = items.filter((l) => l.invoiceId === invoiceId);
+function normalizeTenantId(tenantId) {
+  if (typeof tenantId !== 'string') {
+    return DEFAULT_TENANT_ID;
   }
-  const total = items.length;
+  const trimmed = tenantId.trim();
+  return trimmed || DEFAULT_TENANT_ID;
+}
+
+/**
+ * Converts an arbitrary value to a bounded integer.
+ *
+ * @param {number|string|undefined} value - Candidate pagination value.
+ * @param {number} fallback - Value to use when candidate is invalid.
+ * @param {number} min - Minimum allowed value.
+ * @param {number} max - Maximum allowed value.
+ * @returns {number} Clamped integer.
+ */
+function clampInteger(value, fallback, min, max) {
+  const parsed = typeof value === 'number' ? value : parseInt(value, 10);
+  const safe = Number.isInteger(parsed) ? parsed : fallback;
+  return Math.max(min, Math.min(max, safe));
+}
+
+/**
+ * Converts a DB timestamp value to the public ISO string shape.
+ *
+ * @param {Date|string|number|null|undefined} value - Stored timestamp value.
+ * @returns {string|null} ISO timestamp string, or null when absent.
+ */
+function toIsoTimestamp(value) {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toISOString();
+}
+
+/**
+ * Maps an investor_locks row to the public camelCase API shape.
+ *
+ * @param {Object} row - Database row.
+ * @returns {Object} Public investor lock record.
+ */
+function toInvestorLockRecord(row) {
+  return {
+    funderAddress: row.funder_address,
+    claimNotBefore: toIsoTimestamp(row.claim_not_before),
+    investorEffectiveYieldBps: row.investor_effective_yield_bps,
+    invoiceId: row.invoice_id,
+    stale: !row.last_refreshed_at,
+  };
+}
+
+/**
+ * Builds a paginated response object from a query builder.
+ *
+ * @param {import('knex').Knex.QueryBuilder} baseQuery - Query with all filters applied.
+ * @param {Object} opts - Pagination options.
+ * @param {number|string} [opts.limit=20] - Requested page size.
+ * @param {number|string} [opts.page=1] - Requested one-based page number.
+ * @returns {Promise<{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }>}
+ */
+async function paginateInvestorLocks(baseQuery, { limit = 20, page = 1 } = {}) {
+  const safeLimit = clampInteger(limit, 20, 1, 100);
+  const safePage = clampInteger(page, 1, 1, Number.MAX_SAFE_INTEGER);
   const offset = (safePage - 1) * safeLimit;
-  const data = items.slice(offset, offset + safeLimit);
+  const countRows = await baseQuery.clone().clearSelect().clearOrder().count({ count: '*' });
+  const total = Number(countRows[0] && countRows[0].count) || 0;
+  const rows = await baseQuery
+    .clone()
+    .select('*')
+    .orderBy('created_at', 'asc')
+    .orderBy('invoice_id', 'asc')
+    .limit(safeLimit)
+    .offset(offset);
+  const data = rows.map(toInvestorLockRecord);
+
   return {
     data,
     meta: {
@@ -298,6 +339,89 @@ function getAllInvestorLocks({ invoiceId, limit = 20, page = 1 } = {}) {
       hasMore: offset + data.length < total,
     },
   };
+}
+
+/**
+ * Upsert a tenant-scoped investor lock record into durable storage.
+ *
+ * @param {Object} params
+ * @param {string} params.funderAddress
+ * @param {string} params.claimNotBefore
+ * @param {number} params.investorEffectiveYieldBps
+ * @param {string} params.invoiceId
+ * @param {string} [params.tenantId]
+ * @returns {Promise<Object>} The stored lock record.
+ */
+async function setInvestorLock({ funderAddress, claimNotBefore, investorEffectiveYieldBps, invoiceId, tenantId }) {
+  const resolvedTenantId = normalizeTenantId(tenantId);
+  const payload = {
+    tenant_id: resolvedTenantId,
+    invoice_id: invoiceId,
+    funder_address: funderAddress,
+    claim_not_before: claimNotBefore,
+    investor_effective_yield_bps: investorEffectiveYieldBps,
+    last_refreshed_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  };
+
+  await db(LOCK_TABLE)
+    .insert(payload)
+    .onConflict(['tenant_id', 'invoice_id', 'funder_address'])
+    .merge({
+      claim_not_before: payload.claim_not_before,
+      investor_effective_yield_bps: payload.investor_effective_yield_bps,
+      last_refreshed_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    });
+
+  const row = await db(LOCK_TABLE)
+    .where({
+      tenant_id: resolvedTenantId,
+      invoice_id: invoiceId,
+      funder_address: funderAddress,
+    })
+    .first();
+
+  return toInvestorLockRecord(row);
+}
+
+/**
+ * Retrieve a single lock by invoiceId and funderAddress.
+ *
+ * @param {string} invoiceId
+ * @param {string} funderAddress
+ * @param {Object} [opts]
+ * @param {string} [opts.tenantId]
+ * @returns {Promise<Object|undefined>}
+ */
+async function getInvestorLock(invoiceId, funderAddress, { tenantId } = {}) {
+  const row = await db(LOCK_TABLE)
+    .where({
+      tenant_id: normalizeTenantId(tenantId),
+      invoice_id: invoiceId,
+      funder_address: funderAddress,
+    })
+    .first();
+
+  return row ? toInvestorLockRecord(row) : undefined;
+}
+
+/**
+ * Returns all locks, optionally filtered by invoiceId, with offset pagination.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.invoiceId]  - Optional invoiceId filter.
+ * @param {string} [opts.tenantId]   - Tenant scope.
+ * @param {number} [opts.limit=20]   - Page size (1–100).
+ * @param {number} [opts.page=1]     - 1-based page number.
+ * @returns {Promise<{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }>}
+ */
+async function getAllInvestorLocks({ tenantId, invoiceId, limit = 20, page = 1 } = {}) {
+  const query = db(LOCK_TABLE).where({ tenant_id: normalizeTenantId(tenantId) });
+  if (invoiceId) {
+    query.andWhere({ invoice_id: invoiceId });
+  }
+  return paginateInvestorLocks(query, { limit, page });
 }
 
 /**
@@ -307,46 +431,64 @@ function getAllInvestorLocks({ invoiceId, limit = 20, page = 1 } = {}) {
  * @param {string} funderAddress
  * @param {Object} [opts]
  * @param {string} [opts.invoiceId]  - Optional invoiceId filter.
+ * @param {string} [opts.tenantId]   - Tenant scope.
  * @param {number} [opts.limit=20]   - Page size (1–100).
  * @param {number} [opts.page=1]     - 1-based page number.
- * @returns {{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }}
+ * @returns {Promise<{ data: Object[], meta: { total: number, page: number, limit: number, totalPages: number, hasMore: boolean } }>}
  */
-function getInvestorLocksByAddress(funderAddress, { invoiceId, limit = 20, page = 1 } = {}) {
-  const safeLimit = Math.max(1, Math.min(100, limit));
-  const safePage = Math.max(1, page);
-  let items = [..._lockStore.values()].filter((l) => l.funderAddress === funderAddress);
+async function getInvestorLocksByAddress(funderAddress, { tenantId, invoiceId, limit = 20, page = 1 } = {}) {
+  const query = db(LOCK_TABLE).where({
+    tenant_id: normalizeTenantId(tenantId),
+    funder_address: funderAddress,
+  });
   if (invoiceId) {
-    items = items.filter((l) => l.invoiceId === invoiceId);
+    query.andWhere({ invoice_id: invoiceId });
   }
-  const total = items.length;
-  const offset = (safePage - 1) * safeLimit;
-  const data = items.slice(offset, offset + safeLimit);
-  return {
-    data,
-    meta: {
-      total,
-      page: safePage,
-      limit: safeLimit,
-      totalPages: Math.ceil(total / safeLimit) || 1,
-      hasMore: offset + data.length < total,
-    },
-  };
+  return paginateInvestorLocks(query, { limit, page });
 }
 
-/** Clear all locks (test helper). */
-function clearInvestorLocks() {
-  _lockStore.clear();
+/**
+ * Clears investor lock rows, optionally scoped to one tenant.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.tenantId] - Optional tenant to clear.
+ * @returns {Promise<void>}
+ */
+async function clearInvestorLocks({ tenantId } = {}) {
+  const query = db(LOCK_TABLE);
+  if (tenantId) {
+    query.where({ tenant_id: normalizeTenantId(tenantId) });
+  }
+  await query.delete();
 }
 
-/** Seed representative test fixtures (test helper). */
-function seedInvestorLocks() {
+/**
+ * Seeds representative investor lock rows for tests and local development.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.tenantId] - Tenant to receive the seeded rows.
+ * @returns {Promise<void>}
+ */
+async function seedInvestorLocks({ tenantId = DEFAULT_TENANT_ID } = {}) {
   const addr1 = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
   const addr2 = 'GABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEJXA';
 
   for (let i = 1; i <= 5; i++) {
-    setInvestorLock({ funderAddress: addr1, claimNotBefore: `2026-0${i}-01T00:00:00Z`, investorEffectiveYieldBps: 500 + i * 50, invoiceId: `inv_${7788 + i - 1}` });
+    await setInvestorLock({
+      tenantId,
+      funderAddress: addr1,
+      claimNotBefore: `2026-0${i}-01T00:00:00Z`,
+      investorEffectiveYieldBps: 500 + i * 50,
+      invoiceId: `inv_${7788 + i - 1}`,
+    });
   }
-  setInvestorLock({ funderAddress: addr2, claimNotBefore: '2026-06-01T00:00:00Z', investorEffectiveYieldBps: 800, invoiceId: 'inv_9900' });
+  await setInvestorLock({
+    tenantId,
+    funderAddress: addr2,
+    claimNotBefore: '2026-06-01T00:00:00Z',
+    investorEffectiveYieldBps: 800,
+    invoiceId: 'inv_9900',
+  });
 }
 
 module.exports = {

--- a/tests/investor.locks.test.js
+++ b/tests/investor.locks.test.js
@@ -22,10 +22,30 @@ jest.mock('../src/middleware/kycGating', () => ({
   requireKycForFunding: (_req, _res, next) => next(),
 }));
 
+jest.mock('../src/middleware/requestId', () => (req, _res, next) => {
+  req.id = 'test-request-id';
+  next();
+});
+
+jest.mock('../src/middleware/correlationId', () => ({
+  correlationIdMiddleware: (_req, _res, next) => next(),
+}));
+
+jest.mock('../src/routes/sme', () => {
+  const express = require('express');
+  return express.Router();
+});
+
+jest.mock('../src/routes/invest', () => {
+  const express = require('express');
+  return express.Router();
+});
+
 const request = require('supertest');
 const { createApp, resetStore } = require('../src/index');
 const jwt = require('jsonwebtoken');
 const investorCommitmentService = require('../src/services/investorCommitment');
+const db = require('../src/db/knex');
 
 const TEST_SECRET = process.env.JWT_SECRET || 'test-secret';
 const ADDR1 = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
@@ -39,15 +59,17 @@ const unboundInvestorToken = tokenFor({ id: 'user_unbound', role: 'investor', te
 describe('Investor Locks API', () => {
   let app;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     resetStore();
-    investorCommitmentService.clearInvestorLocks();
-    investorCommitmentService.seedInvestorLocks();
+    await db.migrate.latest({ directory: './migrations' });
+    await investorCommitmentService.clearInvestorLocks();
+    await investorCommitmentService.seedInvestorLocks({ tenantId: 'test-tenant' });
     app = createApp({ enableTestRoutes: true });
   });
 
-  afterAll(() => {
-    investorCommitmentService.clearInvestorLocks();
+  afterAll(async () => {
+    await investorCommitmentService.clearInvestorLocks();
+    await db.destroy();
   });
 
   describe('GET /api/investor/locks', () => {
@@ -67,7 +89,7 @@ describe('Investor Locks API', () => {
       expect(response.body.data.length).toBeGreaterThan(0);
       expect(response.body.data.every((lock) => lock.funderAddress === ADDR1)).toBe(true);
       expect(response.body.data.some((lock) => lock.funderAddress === ADDR2)).toBe(false);
-      expect(response.body.meta.stale).toBe(true);
+      expect(response.body.meta.stale).toBe(false);
     });
 
     it('allows admin callers to list all tenant locks when funderAddress is omitted', async () => {
@@ -97,12 +119,12 @@ describe('Investor Locks API', () => {
       });
     });
 
-    it('should return stale=true in meta when DB mirror data exists', async () => {
+    it('should return stale=false in meta for fresh DB-backed reads', async () => {
       const response = await request(app)
         .get('/api/investor/locks')
         .set('Authorization', `Bearer ${validToken}`);
 
-      expect(response.body.meta.stale).toBe(true);
+      expect(response.body.meta.stale).toBe(false);
     });
 
     it('should filter by funderAddress when provided', async () => {
@@ -378,8 +400,8 @@ describe('Investor Locks API', () => {
 });
 
 describe('Investor Commitment Service', () => {
-  beforeEach(() => {
-    investorCommitmentService.clearInvestorLocks();
+  beforeEach(async () => {
+    await investorCommitmentService.clearInvestorLocks();
   });
 
   describe('validateAddress', () => {
@@ -412,8 +434,8 @@ describe('Investor Commitment Service', () => {
   });
 
   describe('setInvestorLock', () => {
-    it('should create a new lock record', () => {
-      const lock = investorCommitmentService.setInvestorLock({
+    it('should create a new lock record', async () => {
+      const lock = await investorCommitmentService.setInvestorLock({
         funderAddress: ADDR1,
         claimNotBefore: '2026-03-01T00:00:00Z',
         investorEffectiveYieldBps: 900,
@@ -421,58 +443,58 @@ describe('Investor Commitment Service', () => {
       });
 
       expect(lock.funderAddress).toBe(ADDR1);
-      expect(lock.claimNotBefore).toBe('2026-03-01T00:00:00Z');
+      expect(lock.claimNotBefore).toBe('2026-03-01T00:00:00.000Z');
       expect(lock.investorEffectiveYieldBps).toBe(900);
       expect(lock.invoiceId).toBe('inv_test');
-      expect(lock.stale).toBe(true);
+      expect(lock.stale).toBe(false);
     });
 
-    it('should update existing lock', () => {
-      investorCommitmentService.setInvestorLock({
+    it('should update existing lock', async () => {
+      await investorCommitmentService.setInvestorLock({
         funderAddress: ADDR1,
         claimNotBefore: '2026-01-01T00:00:00Z',
         investorEffectiveYieldBps: 500,
         invoiceId: 'inv_upd',
       });
 
-      investorCommitmentService.setInvestorLock({
+      await investorCommitmentService.setInvestorLock({
         funderAddress: ADDR1,
         claimNotBefore: '2026-02-01T00:00:00Z',
         investorEffectiveYieldBps: 600,
         invoiceId: 'inv_upd',
       });
 
-      const result = investorCommitmentService.getInvestorLocksByAddress(ADDR1, { invoiceId: 'inv_upd' });
+      const result = await investorCommitmentService.getInvestorLocksByAddress(ADDR1, { invoiceId: 'inv_upd' });
       expect(result.data.length).toBe(1);
       expect(result.data[0].investorEffectiveYieldBps).toBe(600);
     });
   });
 
   describe('getInvestorLock', () => {
-    it('should retrieve lock by invoiceId and funderAddress', () => {
-      investorCommitmentService.setInvestorLock({
+    it('should retrieve lock by invoiceId and funderAddress', async () => {
+      await investorCommitmentService.setInvestorLock({
         funderAddress: ADDR2,
         claimNotBefore: '2026-04-01T00:00:00Z',
         investorEffectiveYieldBps: 750,
         invoiceId: 'inv_find',
       });
 
-      const lock = investorCommitmentService.getInvestorLock('inv_find', ADDR2);
+      const lock = await investorCommitmentService.getInvestorLock('inv_find', ADDR2);
       expect(lock).toBeDefined();
       expect(lock.investorEffectiveYieldBps).toBe(750);
     });
 
-    it('should return undefined for non-existent lock', () => {
-      const lock = investorCommitmentService.getInvestorLock('inv_none', ADDR1);
+    it('should return undefined for non-existent lock', async () => {
+      const lock = await investorCommitmentService.getInvestorLock('inv_none', ADDR1);
       expect(lock).toBeUndefined();
     });
   });
 
   describe('getAllInvestorLocks pagination', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       // Seed 5 locks for ADDR1
       for (let i = 1; i <= 5; i++) {
-        investorCommitmentService.setInvestorLock({
+        await investorCommitmentService.setInvestorLock({
           funderAddress: ADDR1,
           claimNotBefore: `2026-0${i}-01T00:00:00Z`,
           investorEffectiveYieldBps: 500 + i * 10,
@@ -481,8 +503,8 @@ describe('Investor Commitment Service', () => {
       }
     });
 
-    it('should return first page', () => {
-      const result = investorCommitmentService.getAllInvestorLocks({ limit: 2, page: 1 });
+    it('should return first page', async () => {
+      const result = await investorCommitmentService.getAllInvestorLocks({ limit: 2, page: 1 });
       expect(result.data.length).toBe(2);
       expect(result.meta.page).toBe(1);
       expect(result.meta.total).toBe(5);
@@ -490,37 +512,37 @@ describe('Investor Commitment Service', () => {
       expect(result.meta.totalPages).toBe(3);
     });
 
-    it('should return last page (partial)', () => {
-      const result = investorCommitmentService.getAllInvestorLocks({ limit: 2, page: 3 });
+    it('should return last page (partial)', async () => {
+      const result = await investorCommitmentService.getAllInvestorLocks({ limit: 2, page: 3 });
       expect(result.data.length).toBe(1);
       expect(result.meta.hasMore).toBe(false);
     });
 
-    it('should return empty data for out-of-range page', () => {
-      const result = investorCommitmentService.getAllInvestorLocks({ limit: 10, page: 99 });
+    it('should return empty data for out-of-range page', async () => {
+      const result = await investorCommitmentService.getAllInvestorLocks({ limit: 10, page: 99 });
       expect(result.data).toEqual([]);
       expect(result.meta.hasMore).toBe(false);
     });
 
-    it('should filter by invoiceId', () => {
-      const result = investorCommitmentService.getAllInvestorLocks({ invoiceId: 'inv_p3' });
+    it('should filter by invoiceId', async () => {
+      const result = await investorCommitmentService.getAllInvestorLocks({ invoiceId: 'inv_p3' });
       expect(result.data.length).toBe(1);
       expect(result.data[0].invoiceId).toBe('inv_p3');
     });
 
-    it('should clamp limit to 1..100', () => {
-      const low = investorCommitmentService.getAllInvestorLocks({ limit: 0 });
+    it('should clamp limit to 1..100', async () => {
+      const low = await investorCommitmentService.getAllInvestorLocks({ limit: 0 });
       expect(low.meta.limit).toBe(1);
 
-      const high = investorCommitmentService.getAllInvestorLocks({ limit: 999 });
+      const high = await investorCommitmentService.getAllInvestorLocks({ limit: 999 });
       expect(high.meta.limit).toBe(100);
     });
   });
 
   describe('getInvestorLocksByAddress pagination', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       for (let i = 1; i <= 4; i++) {
-        investorCommitmentService.setInvestorLock({
+        await investorCommitmentService.setInvestorLock({
           funderAddress: ADDR1,
           claimNotBefore: `2026-0${i}-01T00:00:00Z`,
           investorEffectiveYieldBps: 500 + i * 10,
@@ -528,7 +550,7 @@ describe('Investor Commitment Service', () => {
         });
       }
       // ADDR2 lock — must never appear in ADDR1 results
-      investorCommitmentService.setInvestorLock({
+      await investorCommitmentService.setInvestorLock({
         funderAddress: ADDR2,
         claimNotBefore: '2026-06-01T00:00:00Z',
         investorEffectiveYieldBps: 700,
@@ -536,15 +558,15 @@ describe('Investor Commitment Service', () => {
       });
     });
 
-    it('should only return locks for the specified funder', () => {
-      const result = investorCommitmentService.getInvestorLocksByAddress(ADDR1);
+    it('should only return locks for the specified funder', async () => {
+      const result = await investorCommitmentService.getInvestorLocksByAddress(ADDR1);
       expect(result.data.every((l) => l.funderAddress === ADDR1)).toBe(true);
       expect(result.meta.total).toBe(4);
     });
 
-    it('should paginate correctly for funderAddress scope', () => {
-      const p1 = investorCommitmentService.getInvestorLocksByAddress(ADDR1, { limit: 2, page: 1 });
-      const p2 = investorCommitmentService.getInvestorLocksByAddress(ADDR1, { limit: 2, page: 2 });
+    it('should paginate correctly for funderAddress scope', async () => {
+      const p1 = await investorCommitmentService.getInvestorLocksByAddress(ADDR1, { limit: 2, page: 1 });
+      const p2 = await investorCommitmentService.getInvestorLocksByAddress(ADDR1, { limit: 2, page: 2 });
 
       expect(p1.data.length).toBe(2);
       expect(p1.meta.hasMore).toBe(true);
@@ -552,9 +574,38 @@ describe('Investor Commitment Service', () => {
       expect(p2.meta.hasMore).toBe(false);
     });
 
-    it('should not include ADDR2 locks when querying ADDR1', () => {
-      const result = investorCommitmentService.getInvestorLocksByAddress(ADDR1);
+    it('should not include ADDR2 locks when querying ADDR1', async () => {
+      const result = await investorCommitmentService.getInvestorLocksByAddress(ADDR1);
       expect(result.data.some((l) => l.funderAddress === ADDR2)).toBe(false);
+    });
+  });
+
+  describe('tenant persistence', () => {
+    it('stores the same invoice/funder independently per tenant', async () => {
+      await investorCommitmentService.setInvestorLock({
+        tenantId: 'tenant-a',
+        funderAddress: ADDR1,
+        claimNotBefore: '2026-07-01T00:00:00Z',
+        investorEffectiveYieldBps: 710,
+        invoiceId: 'inv_shared',
+      });
+      await investorCommitmentService.setInvestorLock({
+        tenantId: 'tenant-b',
+        funderAddress: ADDR1,
+        claimNotBefore: '2026-08-01T00:00:00Z',
+        investorEffectiveYieldBps: 820,
+        invoiceId: 'inv_shared',
+      });
+
+      const tenantA = await investorCommitmentService.getInvestorLock('inv_shared', ADDR1, { tenantId: 'tenant-a' });
+      const tenantB = await investorCommitmentService.getInvestorLock('inv_shared', ADDR1, { tenantId: 'tenant-b' });
+      const rows = await db('investor_locks')
+        .where({ invoice_id: 'inv_shared', funder_address: ADDR1 })
+        .orderBy('tenant_id', 'asc');
+
+      expect(tenantA.investorEffectiveYieldBps).toBe(710);
+      expect(tenantB.investorEffectiveYieldBps).toBe(820);
+      expect(rows).toHaveLength(2);
     });
   });
 });

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -14,22 +14,35 @@ let mockCurrentTable = null;
 
 jest.mock('../../src/db/knex', () => {
   const auditLogEvents = [];
+  const investorLocks = [];
   let queryWheres = {};
   let mockCurrentTable;
   let _lastInserted = null;
   let _lastUpdateFields = null;
+  let _lastInsertInput = null;
+  let _limit = null;
+  let _offset = 0;
+
+  const filterInvestorLocks = () => investorLocks.filter((row) => {
+    return Object.entries(queryWheres).every(([key, value]) => row[key] === value);
+  });
 
   const m = jest.fn((table) => {
     mockCurrentTable = table;
     queryWheres = {};
     _lastInserted = null;
     _lastUpdateFields = null;
+    _lastInsertInput = null;
+    _limit = null;
+    _offset = 0;
     return m;
   });
 
   m.where = jest.fn((field, value) => {
     if (typeof field === "string") {
       queryWheres[field] = value;
+    } else if (field && typeof field === "object") {
+      queryWheres = { ...queryWheres, ...field };
     }
     return m;
   });
@@ -43,6 +56,7 @@ jest.mock('../../src/db/knex', () => {
   m.select = jest.fn().mockReturnThis();
   m.insert = jest.fn((data) => {
     const rows = Array.isArray(data) ? data : [data];
+    _lastInsertInput = rows;
     const inserted = rows.map((r) => ({
       id: Math.random().toString(),
       created_at: new Date().toISOString(),
@@ -55,6 +69,29 @@ jest.mock('../../src/db/knex', () => {
     }
     return m;
   });
+  m.onConflict = jest.fn().mockReturnThis();
+  m.merge = jest.fn((fields) => {
+    if (mockCurrentTable === "investor_locks") {
+      for (const row of _lastInsertInput || []) {
+        const existing = investorLocks.find((candidate) => (
+          candidate.tenant_id === row.tenant_id &&
+          candidate.invoice_id === row.invoice_id &&
+          candidate.funder_address === row.funder_address
+        ));
+        if (existing) {
+          Object.assign(existing, row, fields, { updated_at: new Date().toISOString() });
+        } else {
+          investorLocks.push({
+            id: Math.random().toString(),
+            created_at: new Date().toISOString(),
+            ...row,
+          });
+        }
+      }
+      return Promise.resolve(1);
+    }
+    return Promise.resolve(1);
+  });
   m.update = jest.fn((fields) => {
     _lastUpdateFields = fields;
     const updatedRows = [{ id: 'updated-id', ...fields, updated_at: new Date().toISOString() }];
@@ -65,23 +102,68 @@ jest.mock('../../src/db/knex', () => {
     auditLogEvents.length = 0;
     return Promise.resolve(1);
   });
-  m.first = jest.fn().mockResolvedValue({ id: 'test', kyc_status: 'approved' });
+  m.first = jest.fn(() => {
+    if (mockCurrentTable === "investor_locks") {
+      return Promise.resolve(filterInvestorLocks()[0]);
+    }
+    return Promise.resolve({ id: 'test', kyc_status: 'approved' });
+  });
   m.returning = jest.fn(() => {
     return Promise.resolve(_lastInserted || []);
   });
   m.delete = jest.fn(() => {
+    if (mockCurrentTable === "investor_locks") {
+      const retained = investorLocks.filter((row) => !Object.entries(queryWheres).every(([key, value]) => row[key] === value));
+      investorLocks.length = 0;
+      investorLocks.push(...retained);
+      return Promise.resolve(1);
+    }
     auditLogEvents.length = 0;
     return Promise.resolve(1);
   });
-  m.andWhere = jest.fn().mockReturnThis();
+  m.andWhere = jest.fn((field, value) => {
+    if (typeof field === "string") {
+      queryWheres[field] = value;
+    } else if (field && typeof field === "object") {
+      queryWheres = { ...queryWheres, ...field };
+    }
+    return m;
+  });
   m.orWhere = jest.fn().mockReturnThis();
-  m.count = jest.fn().mockResolvedValue([{ count: 25 }]);
+  m.count = jest.fn(() => {
+    if (mockCurrentTable === "investor_locks") {
+      return Promise.resolve([{ count: filterInvestorLocks().length }]);
+    }
+    return Promise.resolve([{ count: 25 }]);
+  });
   m.raw = jest.fn();
+  m.clone = jest.fn().mockReturnThis();
+  m.clearSelect = jest.fn().mockReturnThis();
+  m.clearOrder = jest.fn().mockReturnThis();
+  m.fn = { now: jest.fn(() => new Date().toISOString()) };
+  m.migrate = { latest: jest.fn().mockResolvedValue([0, []]) };
+  m.destroy = jest.fn().mockResolvedValue(undefined);
   m.then = jest.fn((onFulfilled) => {
     if (m._resolveValue) {
       const rv = m._resolveValue;
       m._resolveValue = null;
       return rv.then(onFulfilled);
+    }
+    if (mockCurrentTable === "investor_locks") {
+      let results = filterInvestorLocks().sort((a, b) => {
+        const createdCompare = String(a.created_at).localeCompare(String(b.created_at));
+        if (createdCompare !== 0) {
+          return createdCompare;
+        }
+        return String(a.invoice_id).localeCompare(String(b.invoice_id));
+      });
+      if (_offset) {
+        results = results.slice(_offset);
+      }
+      if (_limit !== null) {
+        results = results.slice(0, _limit);
+      }
+      return Promise.resolve(results).then(onFulfilled);
     }
     if (mockCurrentTable === "audit_log_events") {
       return Promise.resolve(mockInMemoryDb).then(onFulfilled);
@@ -89,7 +171,11 @@ jest.mock('../../src/db/knex', () => {
     return Promise.resolve([]).then(onFulfilled);
   });
 
-  m.offset = jest.fn(() => {
+  m.offset = jest.fn((value = 0) => {
+    if (mockCurrentTable === "investor_locks") {
+      _offset = value;
+      return m;
+    }
     let results = [...auditLogEvents];
 
     if (queryWheres.target_id) {
@@ -110,6 +196,10 @@ jest.mock('../../src/db/knex', () => {
 
     results.reverse();
     return Promise.resolve(results);
+  });
+  m.limit = jest.fn((value) => {
+    _limit = value;
+    return m;
   });
   return m;
 }, { virtual: true });


### PR DESCRIPTION
Closes #505

## Summary
- adds a durable `investor_locks` table keyed by `tenant_id`, `invoice_id`, and `funder_address`
- converts investor lock helpers from process-local Map storage to Knex-backed async upserts and reads
- keeps the public response shape stable while deriving `stale` from row refresh state
- scopes investor lock API reads by `req.tenantId` and keeps existing funder/admin authorization behavior
- updates investor lock tests, docs, and the shared DB mock for the new durable lock path

## Validation
- `node .\node_modules\jest\bin\jest.js tests\investor.locks.test.js --runInBand --forceExit`
- `node .\node_modules\eslint\bin\eslint.js src\services\investorCommitment.js src\routes\investor.js tests\investor.locks.test.js tests\mocks\setup.js migrations\20260629000000_create_investor_locks.js`
- `node --check src\services\investorCommitment.js`
- `node --check src\routes\investor.js`
- `node --check migrations\20260629000000_create_investor_locks.js`
- `git diff --check`
- real SQLite/Knex smoke: migrated, inserted same invoice/funder across two tenants, verified isolated reads and `stale=false`

## Notes
- The focused route test mocks unrelated `sme`, `invest`, `requestId`, and `correlationId` paths because the current main branch has unrelated parse/runtime issues in those modules that otherwise prevent this route suite from loading.
