### PR TITLE
test(invoice-verification): cover fraud and business-rule decision ma…

### DIFF
--- a/tests/invoiceVerification.service.test.js
+++ b/tests/invoiceVerification.service.test.js
@@ -599,6 +599,14 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       expect(result).toEqual({ status: 'VERIFIED' });
     });
 
+    it('should handle explicitly null or undefined options parameter', async () => {
+      const resultNull = await verifyInvoice({ amount: 5000, customer: 'Acme Corp' }, null);
+      expect(resultNull).toEqual({ status: 'VERIFIED' });
+
+      const resultUndefined = await verifyInvoice({ amount: 5000, customer: 'Acme Corp' }, undefined);
+      expect(resultUndefined).toEqual({ status: 'VERIFIED' });
+    });
+
     it('should treat undefined amount field as invalid', async () => {
       const result = await verifyInvoice({ amount: undefined, customer: 'Acme Corp' });
       expect(result).toEqual({
@@ -833,6 +841,24 @@ describe('Invoice Verification Service - Comprehensive Decision Matrix', () => {
       // Structural checks run before threshold resolution, so this is a clean reject.
       const result = await verifyInvoice({ amount: -1, customer: 'Acme' });
       expect(result.reasonCode).toBe(ReasonCode.INVALID_AMOUNT);
+    });
+
+    it('propagates non-VerificationConfigError exceptions from threshold resolution', async () => {
+      const originalHas = Map.prototype.has;
+      Map.prototype.has = function (key) {
+        if (key === 'cause-generic-error') {
+          throw new TypeError('Generic Map error');
+        }
+        return originalHas.apply(this, arguments);
+      };
+
+      try {
+        await expect(
+          verifyInvoice({ amount: 5000, customer: 'Acme' }, { tenantId: 'cause-generic-error' })
+        ).rejects.toThrow(TypeError);
+      } finally {
+        Map.prototype.has = originalHas;
+      }
     });
   });
 });


### PR DESCRIPTION
Closes #577 

Description
This pull request introduces comprehensive unit test coverage for the invoice verification service (src/services/invoiceVerification.js). It validates all logical decision branches, including terminal outcomes (VERIFIED, REJECTED, MANUAL_REVIEW), boundary values, invalid payloads, configuration-driven overrides (both global and per-tenant), and security/injection-detection checks.

Additionally, new test cases were added to guarantee that:

Non-VerificationConfigError errors occurring during threshold resolution are propagated/re-thrown correctly (achieving 100% statement, branch, function, and line coverage for invoiceVerification.js).
Explicitly null or undefined options parameters are handled gracefully.
