### PR TITLE
feat(worker): enrich handler error logs with redacted job context

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,29 @@ The application exposes Prometheus metrics on `GET /metrics` (subject to the sam
 
 These gauges are updated by sampling registered `JobQueue` and `BackgroundWorker` instances and are intentionally bounded to avoid high-cardinality labels.
 
+### Worker error-log context
+
+When a background job handler throws, the worker (`src/workers/worker.js`) logs a
+structured `Job handler failed` error through `src/logger.js` before scheduling the
+retry. Each log line carries enough context to trace the failure back to a tenant
+and, when available, to the request that enqueued the job:
+
+- `jobId`, `jobType`, and `attempt` — which job failed and on which attempt.
+- A **safe allow-listed subset** of the job payload: `tenantId`, `invoiceId`,
+  `correlationId`, `performedBy`, `policyId`, `batchSize`. Only primitive values
+  are copied; nested objects are never logged.
+- `err` — the thrown error, serialized by pino.
+
+Full payloads are never logged, so webhook secrets, signing tokens, and invoice
+bodies cannot leak into logs. As defence in depth, the assembled context is also
+passed through the shared `redactValue` scrubber from `src/services/auditLogStore.js`,
+which masks any value whose key matches a sensitive pattern (`password`, `secret`,
+`token`, `apiKey`, `authorization`, `privateKey`, `seed`, `mnemonic`).
+
+If the enqueuing request placed a `correlationId` on the payload, the error log can
+be joined against that request's API logs for end-to-end tracing. Retry behaviour is
+unchanged: the failure is logged and the job is re-queued with exponential backoff.
+
 Soroban metric labels are intentionally coarse and bounded:
 
 - `method` is normalized to a small allowlist of method families such as `contract_call`, `simulate_transaction`, and `get_ledger_entries`. Unknown or untrusted values are collapsed to `unknown`.

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -994,24 +994,11 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
   registers: [registry],
 });
 
-const footprintCacheHitsTotal = new client.Counter({
-  name: 'footprint_cache_hits_total',
-  help: 'Total footprint cache hits',
-  registers: [registry],
-});
-
-const footprintCacheMissesTotal = new client.Counter({
-  name: 'footprint_cache_misses_total',
-  help: 'Total footprint cache misses',
-  registers: [registry],
-});
-
-const footprintCacheEvictionsTotal = new client.Counter({
-  name: 'footprint_cache_evictions_total',
-  help: 'Total footprint cache evictions',
-  registers: [registry],
-});
-
+/**
+ * Returns the shared Prometheus registry.
+ *
+ * @returns {import('prom-client').Registry} The metrics registry.
+ */
 function getRegistry() {
   return registry;
 }

--- a/src/workers/jobQueue.js
+++ b/src/workers/jobQueue.js
@@ -25,7 +25,10 @@ class JobQueue {
   constructor(options = {}) {
     this.maxRetries   = Math.min(options.maxRetries ?? 3, 10);
     this.maxQueueSize = options.maxQueueSize || 10000;
-    
+
+    /** @type {object|null} Optional persistence adapter (durable mirror). */
+    this._persistence = options.persistence || null;
+
     // Using Map for efficient O(1) lookups
     this.jobs = new Map();
     
@@ -209,12 +212,25 @@ class JobQueue {
   async restoreFromPersistence() {
     if (!this._persistence) { return 0; }
 
-    const recovered = await this._persistence.recoverUnackedJobs();
+    let recovered;
+    try {
+      recovered = await this._persistence.recoverUnackedJobs();
+    } catch (_err) {
+      // Recovery failure must never block startup — degrade to empty queue.
+      return 0;
+    }
     let count = 0;
 
     for (const job of recovered) {
       if (this.jobs.has(job.id)) { continue; }
       if (this.queue.length + this.retryQueue.length >= this.maxQueueSize) { break; }
+
+      // In-flight jobs from a crashed process are re-run (at-least-once):
+      // reset to PENDING so _isReadyToProcess accepts them again.
+      if (job.status === JOB_STATUS.PROCESSING) {
+        job.status    = JOB_STATUS.PENDING;
+        job.startedAt = null;
+      }
 
       this.jobs.set(job.id, job);
       // Jobs that already had attempts go to the retry queue; fresh ones to main.

--- a/src/workers/jobWorker.test.js
+++ b/src/workers/jobWorker.test.js
@@ -298,7 +298,8 @@ describe('JobQueue (in-memory)', () => {
     it('counts each status correctly', () => {
       const id1 = queue.enqueue('t', {});
       const id2 = queue.enqueue('t', {});
-      queue.dequeue();
+      queue.dequeue(); // id1 → processing
+      queue.dequeue(); // id2 → processing
       queue.ack(id1);
       const stats = queue.getStats();
       expect(stats.completed).toBe(1);
@@ -773,18 +774,27 @@ describe('BackgroundWorker', () => {
       });
       await worker.start();
       worker.enqueue('t', {});
-      await new Promise(r => setTimeout(r, 30));
+      // Wait past the 50ms poll interval so the job is actually in flight.
+      await new Promise(r => setTimeout(r, 70));
       await worker.stop(500);
       expect(done).toBe(true);
     });
 
     it('times out if jobs take too long', async () => {
-      worker.registerHandler('t', async () => new Promise(r => setTimeout(r, 2000)));
+      worker.registerHandler('t', async () => new Promise(r => setTimeout(r, 300)));
       await worker.start();
       worker.enqueue('t', {});
-      await new Promise(r => setTimeout(r, 30));
+      // Wait past the 50ms poll interval so the job is actually in flight.
+      await new Promise(r => setTimeout(r, 70));
       await worker.stop(80);
       expect(worker.processingCount).toBeGreaterThan(0);
+
+      // Drain the in-flight job before the queue is cleared, so its late
+      // ack does not fire against a cleared queue and leak error logs
+      // into subsequent tests.
+      while (worker.processingCount > 0) {
+        await new Promise(r => setTimeout(r, 25));
+      }
     });
 
     it('resolves cleanly when not running', async () => {
@@ -869,7 +879,8 @@ describe('BackgroundWorker', () => {
       worker.registerHandler('t', jest.fn(async () => new Promise(r => setTimeout(r, 100))));
       await worker.start();
       worker.enqueue('t', {});
-      await new Promise(r => setTimeout(r, 40));
+      // Wait past the 50ms poll interval so the job is actually in flight.
+      await new Promise(r => setTimeout(r, 70));
 
       const stats = worker.getStats();
       expect(stats.isRunning).toBe(true);
@@ -994,6 +1005,36 @@ describe('buildJobContext', () => {
     const ctx = buildJobContext({ ...base, payload: 'string-payload' });
     expect(ctx).toEqual({ jobId: 'job-abc', jobType: 'webhook_delivery', attempt: 2 });
   });
+
+  it('returns an empty object for null or non-object jobs', () => {
+    expect(buildJobContext(null)).toEqual({});
+    expect(buildJobContext(undefined)).toEqual({});
+    expect(buildJobContext('job-as-string')).toEqual({});
+  });
+
+  it('excludes allow-listed keys whose values are not primitives', () => {
+    const ctx = buildJobContext({
+      ...base,
+      payload: {
+        tenantId: { nested: 'object-not-allowed' },
+        invoiceId: ['array-not-allowed'],
+        correlationId: 'req_ok',
+      },
+    });
+    expect(ctx.tenantId).toBeUndefined();
+    expect(ctx.invoiceId).toBeUndefined();
+    expect(ctx.correlationId).toBe('req_ok');
+  });
+
+  it('keeps null values for allow-listed keys', () => {
+    const ctx = buildJobContext({ ...base, payload: { tenantId: null } });
+    expect(ctx.tenantId).toBeNull();
+  });
+
+  it('falls back to job.attempt then 1 when attempts is absent', () => {
+    expect(buildJobContext({ id: 'j', type: 't', attempt: 4 }).attempt).toBe(4);
+    expect(buildJobContext({ id: 'j', type: 't' }).attempt).toBe(1);
+  });
 });
 
 describe('BackgroundWorker – error log enrichment', () => {
@@ -1091,5 +1132,146 @@ describe('BackgroundWorker – error log enrichment', () => {
 
     const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Job handler failed');
     expect(call[0]).toMatchObject({ jobId: expect.any(String), jobType: 'test_job', attempt: 1 });
+  });
+
+  it('includes the thrown error object in the log call', async () => {
+    const boom = new Error('kaboom');
+    worker.registerHandler('test_job', jest.fn().mockRejectedValue(boom));
+    worker.start();
+    worker.enqueue('test_job', { tenantId: 't-err' });
+
+    await new Promise((r) => setTimeout(r, 200));
+    await worker.stop();
+
+    const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Job handler failed');
+    expect(call[0].err).toBe(boom);
+  });
+
+  it('still schedules a retry via the queue after logging (behaviour unchanged)', async () => {
+    worker.registerHandler('test_job', jest.fn().mockRejectedValue(new Error('boom')));
+    worker.start();
+    const id = worker.enqueue('test_job', { tenantId: 't-retry' });
+
+    await new Promise((r) => setTimeout(r, 200));
+    await worker.stop();
+
+    // The failure is logged AND the job is queued for retry — not dropped.
+    const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Job handler failed');
+    expect(call).toBeDefined();
+    expect(queue.getJob(id).status).toBe(JOB_STATUS.RETRYING);
+    expect(queue.retryQueue).toContain(id);
+  });
+
+  it('logs increasing attempt counts across retries', async () => {
+    // Force immediate retries by neutralising the backoff delay.
+    worker.registerHandler('test_job', jest.fn().mockRejectedValue(new Error('always fails')));
+    worker.start();
+    const id = worker.enqueue('test_job', { tenantId: 't-attempts' });
+
+    // Wait for first failure, then rewind the backoff so the retry is ready.
+    await new Promise((r) => setTimeout(r, 150));
+    queue.getJob(id).delayMs = 0;
+    await new Promise((r) => setTimeout(r, 150));
+    await worker.stop();
+
+    const attempts = loggerErrorSpy.mock.calls
+      .filter((c) => c[1] === 'Job handler failed' && c[0].jobId === id)
+      .map((c) => c[0].attempt);
+    expect(attempts.length).toBeGreaterThanOrEqual(2);
+    expect(attempts[1]).toBeGreaterThan(attempts[0]);
+  });
+
+  it('scrubs the context through auditLogStore.redactValue (defence in depth)', async () => {
+    const auditLogStore = require('../services/auditLogStore');
+    const redactSpy = jest.spyOn(auditLogStore, 'redactValue');
+
+    const ctx = buildJobContext({
+      id: 'job-scrub', type: 'test_job', attempts: 1,
+      payload: { tenantId: 't-scrub', invoiceId: 'inv-scrub' },
+    });
+
+    expect(redactSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: 'job-scrub', tenantId: 't-scrub', invoiceId: 'inv-scrub' })
+    );
+    expect(ctx).toMatchObject({ jobId: 'job-scrub', tenantId: 't-scrub' });
+    redactSpy.mockRestore();
+  });
+
+  it('logs enriched context when a dequeued job has no registered handler', async () => {
+    worker.registerHandler('known_type', jest.fn());
+    worker.start();
+    // Bypass worker.enqueue's guard by enqueuing directly on the queue.
+    queue.enqueue('unknown_type', { tenantId: 't-unknown' });
+
+    await new Promise((r) => setTimeout(r, 150));
+    await worker.stop();
+
+    const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Job handler failed');
+    expect(call).toBeDefined();
+    expect(call[0]).toMatchObject({ jobType: 'unknown_type', tenantId: 't-unknown' });
+  });
+
+  it('logs and rejects defensively on an invalid job structure', async () => {
+    worker.registerHandler('t', jest.fn());
+    // Job with no id/type: the guard throws, the failure is logged, and the
+    // retry call then rejects because the job is unknown to the queue.
+    await expect(worker._processJob({ payload: {} })).rejects.toThrow('not found');
+
+    const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Job handler failed');
+    expect(call).toBeDefined();
+    expect(call[0].err).toBeInstanceOf(Error);
+  });
+
+  it('starts and logs when queue-level crash recovery itself throws', async () => {
+    const q = new JobQueue({ persistence: makePersistence() });
+    q.restoreFromPersistence = jest.fn().mockRejectedValue(new Error('catastrophic'));
+    const w = new BackgroundWorker({ jobQueue: q, pollIntervalMs: 20 });
+    w.registerHandler('t', jest.fn());
+
+    await expect(w.start()).resolves.toBeUndefined();
+    expect(w.isRunning).toBe(true);
+    await w.stop();
+
+    const call = loggerErrorSpy.mock.calls.find(
+      (c) => c[1] === '[worker] Crash recovery failed; starting with empty queue'
+    );
+    expect(call).toBeDefined();
+  });
+
+  it('logs through the poll-loop fallback when the retry itself fails', async () => {
+    // Handler cancels its own job then throws: the retry inside _processJob
+    // cannot find the job, so the rejection surfaces via _poll's catch.
+    worker.registerHandler('test_job', async (job) => {
+      queue.cancel(job.id);
+      throw new Error('handler failed after cancel');
+    });
+    worker.start();
+    const id = worker.enqueue('test_job', { tenantId: 't-fallback' });
+
+    await new Promise((r) => setTimeout(r, 150));
+    await worker.stop();
+
+    const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Unexpected error processing job');
+    expect(call).toBeDefined();
+    expect(call[0]).toMatchObject({ jobId: id, jobType: 'test_job', tenantId: 't-fallback' });
+  });
+
+  it('stops gracefully while a failing handler is in flight', async () => {
+    worker.registerHandler('test_job', async () => {
+      await new Promise((r) => setTimeout(r, 80));
+      throw new Error('late failure');
+    });
+    worker.start();
+    const id = worker.enqueue('test_job', { tenantId: 't-stop' });
+
+    // Wait past the poll interval so the job is in flight, then stop.
+    await new Promise((r) => setTimeout(r, 40));
+    await worker.stop(1000);
+
+    expect(worker.isRunning).toBe(false);
+    expect(worker.processingCount).toBe(0);
+    expect(queue.getJob(id).status).toBe(JOB_STATUS.RETRYING);
+    const call = loggerErrorSpy.mock.calls.find((c) => c[1] === 'Job handler failed');
+    expect(call[0]).toMatchObject({ jobId: id, tenantId: 't-stop' });
   });
 });

--- a/src/workers/worker.js
+++ b/src/workers/worker.js
@@ -22,6 +22,7 @@
 const JobQueue = require('./jobQueue');
 const logger = require('../logger');
 const metrics = require('../metrics');
+const auditLogStore = require('../services/auditLogStore');
 
 /**
  * Background worker that processes queued jobs.
@@ -206,7 +207,7 @@ class BackgroundWorker {
       this.processingCount += 1;
 
       this._processJob(job).catch((err) => {
-        logger.error({ err, jobId: job.id }, 'Unexpected error processing job');
+        logger.error({ err, ...buildJobContext(job) }, 'Unexpected error processing job');
       });
     }
 
@@ -237,6 +238,7 @@ class BackgroundWorker {
 
       this.jobQueue.ack(job.id);
     } catch (err) {
+      logger.error({ err, ...buildJobContext(job) }, 'Job handler failed');
       this.jobQueue.retry(job.id, err);
     } finally {
       this.processingCount -= 1;
@@ -246,21 +248,41 @@ class BackgroundWorker {
 
 
 /**
- * Build a compact execution context object for logging from a job record.
- * Only a safe subset of payload keys are copied to avoid leaking secrets.
+ * Allow-listed payload keys that are safe to surface in error logs.
+ * Everything else in the payload (webhook secrets, signing tokens, full
+ * invoice bodies, …) is deliberately dropped.
+ *
+ * @type {Set<string>}
+ */
+const CONTEXT_KEYS = new Set([
+  'tenantId', 'invoiceId', 'correlationId', 'performedBy', 'policyId', 'batchSize',
+]);
+
+/**
+ * Build a compact, log-safe execution context object from a job record.
+ *
+ * The context always carries `jobId`, `jobType`, and `attempt` (the attempt
+ * count at the time of failure). From the job payload, only the allow-listed
+ * {@link CONTEXT_KEYS} are copied — and only when their values are primitives
+ * (string/number/boolean/null), so nested objects can never smuggle secrets
+ * into logs. When present, `correlationId` links the failure back to the
+ * request that enqueued the job.
+ *
+ * As defence in depth, the assembled context is passed through the shared
+ * `redactValue` scrubber from `services/auditLogStore`, which masks any value
+ * whose key matches a sensitive pattern (password, secret, token, apiKey, …).
  *
  * @param {Object} job - Job record from the queue
- * @returns {Object} Context with jobId, jobType, attempt, and allowed payload keys
+ * @returns {Object} Redacted context with jobId, jobType, attempt, and allowed payload keys
  */
 function buildJobContext(job) {
-  if (!job || typeof job !== 'object') return {};
+  if (!job || typeof job !== 'object') { return {}; }
   const ctx = {
     jobId: job.id,
     jobType: job.type,
     attempt: job.attempts ?? job.attempt ?? 1,
   };
 
-  const CONTEXT_KEYS = new Set(['tenantId', 'invoiceId', 'correlationId', 'performedBy', 'policyId', 'batchSize']);
   const payload = job.payload || {};
   if (payload && typeof payload === 'object') {
     for (const k of CONTEXT_KEYS) {
@@ -273,7 +295,7 @@ function buildJobContext(job) {
       }
     }
   }
-  return ctx;
+  return auditLogStore.redactValue(ctx);
 }
 
 module.exports = BackgroundWorker;


### PR DESCRIPTION
Closes #603

## What changed

**`src/workers/worker.js`**
- When a job handler throws, `_processJob` now logs a structured `Job handler failed` error through `src/logger.js` *before* scheduling the retry. The log carries `err`, `jobId`, `jobType`, `attempt`, and a safe allow-listed subset of the payload: `tenantId`, `invoiceId`, `correlationId`, `performedBy`, `policyId`, `batchSize`.
- The `_poll` fallback log (`Unexpected error processing job`) now uses the same context builder instead of bare `jobId`.
- `buildJobContext()` (fully JSDoc'd) copies only allow-listed **primitive** payload values, and as defence in depth passes the assembled context through the shared `redactValue` scrubber reused from `src/services/auditLogStore.js`.
- Re-entrancy guard (`processingCount` / `maxConcurrency`), graceful `stop()`, and retry-via-queue behaviour are unchanged — each covered by an explicit test.
- When the enqueuing request put a `correlationId` on the payload, it is logged, so worker failures can be joined against the originating API request logs.

**`src/workers/jobWorker.test.js`** — new tests covering: enriched context on handler throw; tenant/invoice context without leaking other fields; secret-bearing payloads (`apiKey`, `token`, `secret`) never logged; correlationId passthrough; empty / missing / null / non-object payloads; non-primitive allow-listed values excluded; `redactValue` wiring; retry still scheduled after logging; increasing attempt counts across retries; graceful stop with a failing handler in flight; no-handler and invalid-job defensive paths; the poll-loop fallback path; crash-recovery failure logging.

**`README.md`** — new "Worker error-log context" subsection under Observability documenting the log shape, the allow-list, the redaction layer, and request correlation.

## Pre-existing breakage fixed along the way (the suite could not run without it)

- `src/metrics.js`: duplicate `footprintCacheHitsTotal` / `Misses` / `Evictions` declarations (merge artifact) made the module unparseable — every suite importing metrics failed with a SyntaxError. Removed the duplicate block.
- `src/workers/jobQueue.js`: the constructor never assigned `this._persistence` from `options.persistence`, although the class reads it in 8 places and the JSDoc documents the option — the persistence mirror and crash recovery were dead code and ~10 existing tests failed.
- `restoreFromPersistence()`: restored in-flight (PROCESSING) jobs were never reset to PENDING, so `_isReadyToProcess` rejected them forever, violating the documented at-least-once contract; a throwing `recoverUnackedJobs` also escaped instead of degrading to an empty queue. Both fixed.
- `src/workers/jobWorker.test.js`: four pre-existing tests stopped the worker before its 50 ms poll timer could ever fire (or omitted a second `dequeue()`), and one test left a 2 s handler in flight whose late `ack()` against a cleared queue leaked a stray error log into whichever test ran ~2 s later, making the suite flaky (~25% failure rate). Fixed the timings and drained the in-flight job; the suite is now stable across 8 consecutive runs.

## Security notes

- **No secrets or PII in logs.** Payloads are never logged wholesale. Only six allow-listed keys are copied, and only when their values are primitives — nested objects cannot smuggle secrets into logs. Keys such as `apiKey`, `token`, `secret`, `fullData` are dropped entirely (tested).
- **Defence in depth.** The assembled context additionally passes through `redactValue` from `auditLogStore` (patterns: password, secret, token, api-key, authorization, private-key, seed, mnemonic), so even a future allow-list mistake would be masked rather than leaked. The wiring is asserted by a spy test.
- The thrown `err` is serialized by pino's standard error serializer, matching existing logging practice in the codebase.

## Test results

```
PASS src/workers/jobWorker.test.js
Test Suites: 1 passed, 1 total
Tests:       123 passed, 123 total

-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------|---------|----------|---------|---------|-------------------
 worker.js |   98.78 |    96.82 |     100 |     100 | 201,214
-----------|---------|----------|---------|---------|-------------------
```

- `src/workers/worker.js` coverage: **98.78% statements / 96.82% branches / 100% functions / 100% lines** (≥ 95% requirement met). The two uncovered branch positions are defensive `isRunning` checks in the poll loop.
- The full `npm test` run has a large number of failures on `main` that are unrelated to this change (parse errors and missing modules in other route/service files, e.g. `src/routes/retention.js`). This PR strictly reduces the failure count: fixing `src/metrics.js` alone un-breaks every suite that imports metrics, and `src/workers/jobWorker.test.js` goes from unable-to-run to 123/123 green. Happy to file follow-up issues for the remaining pre-existing failures.
- `npm run lint`: clean on all touched files (`worker.js`, `jobQueue.js`, `jobWorker.test.js`, `metrics.js`, `README.md`). Remaining lint errors in the repo are in untouched files (including undefined identifiers in the unused `DurableJobQueue` class) and are left out of scope.
