### PR TITLE
fix(openapi): derive server URLs from config and require HTTPS in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,26 @@
 # App environment (required)
 NODE_ENV=development
 PORT=3001
+
+# ----------------------------------
+# Public API Base URL               |
+# ----------------------------------
+# The publicly reachable base URL of this API instance.
+# Used as the `servers[].url` entry in the published OpenAPI spec so that
+# generated clients and documentation always point to the correct host.
+#
+# Rules enforced at startup:
+#   - In production (NODE_ENV=production): required, must use HTTPS, must not
+#     be a loopback address (localhost / 127.x.x.x / ::1). Startup fails fast
+#     if these rules are violated.
+#   - In development/test: optional; falls back to http://localhost:3001.
+#
+# Examples:
+#   Production:   PUBLIC_API_BASE_URL=https://api.liquifact.com
+#   Staging:      PUBLIC_API_BASE_URL=https://api.staging.liquifact.com
+#   Development:  PUBLIC_API_BASE_URL=http://localhost:3001  (or leave unset)
+#
+PUBLIC_API_BASE_URL=http://localhost:3001
 # Helmet config
 HELMET_CSP=false
 # JWT secret (required, min 32 chars, generate securely)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,25 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 - `ESCROW_PLATFORM_ADDRESS` is required only when `ESCROW_SIGNING_MODE` is `delegated` or `custodial` in [`src/services/escrowSubmit.js`](../src/services/escrowSubmit.js).
 - `ESCROW_PLATFORM_SECRET` is required only when `ESCROW_SIGNING_MODE=custodial`. It is a Stellar secret key and must never be committed.
 
+## OpenAPI Server URLs
+
+The published OpenAPI spec derives its `servers` array from `PUBLIC_API_BASE_URL` rather than hardcoding a value. This ensures generated clients, SDK generators, and Swagger UI always call the correct host.
+
+| Environment | `PUBLIC_API_BASE_URL` set? | Spec `servers[0].url` |
+| --- | --- | --- |
+| `production` | Yes (required) | The configured value |
+| `production` | No | **Startup fails** — config validation aborts with a clear error message |
+| `development` / `test` | Yes | The configured value |
+| `development` / `test` | No | `http://localhost:3001` (safe fallback) |
+
+**Production constraints** (enforced by both `src/config/index.js` at boot time and `src/openapi/openapiSpec.js` as a defense-in-depth guard):
+
+1. `PUBLIC_API_BASE_URL` must be present.
+2. Must use the `https:` scheme — plaintext `http:` is rejected.
+3. Must not resolve to a loopback address (`localhost`, `127.x.x.x`, `::1`).
+
+Any violation causes a fast startup failure with a clear, redacted error message logged to stderr. The spec is never built with an invalid or insecure server entry.
+
 ## Environment Variables
 
 <!-- env-reference:start -->
@@ -20,6 +39,7 @@ Secret values are marked **Secret** and must come from local `.env` files, deplo
 | --- | --- | --- | --- | --- | --- |
 | `NODE_ENV` | enum: `development`, `production`, `test` | `development` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/app.js`](../src/app.js), [`src/index.js`](../src/index.js) |
 | `PORT` | integer port | `3001` | No | No | [`src/config/index.js`](../src/config/index.js), [`src/index.js`](../src/index.js), [`src/server.js`](../src/server.js) |
+| `PUBLIC_API_BASE_URL` | HTTPS URL | `http://localhost:3001` fallback in development/test | Required in production | No | [`src/config/index.js`](../src/config/index.js), [`src/openapi/openapiSpec.js`](../src/openapi/openapiSpec.js) |
 | `HELMET_CSP` | boolean string | `false` in template; app defaults vary by environment | No | No | [`src/app.js`](../src/app.js) |
 | `JWT_SECRET` | string, min 32 chars for config validation | None | Yes | **Secret** | [`src/config/index.js`](../src/config/index.js), [`src/middleware/auth.js`](../src/middleware/auth.js) |
 | `CURSOR_SECRET` | string, min 32 chars when set | Falls back to `JWT_SECRET`; public dev fallback only in development/test | No | **Secret** | [`src/config/index.js`](../src/config/index.js), [`src/utils/cursorPagination.js`](../src/utils/cursorPagination.js) |

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -36,6 +36,9 @@ const ConfigSchema = z
     KYC_PROVIDER_URL: z.string().url().optional(),
     KYC_PROVIDER_API_KEY: z.string().min(1).optional(),
     KYC_PROVIDER_SECRET: z.string().min(1).optional(),
+    // Public base URL for the API, used in the OpenAPI spec servers array.
+    // Required in production and must use HTTPS. Falls back to localhost in development/test.
+    PUBLIC_API_BASE_URL: z.string().url().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.NODE_ENV === 'test') { return; }
@@ -55,6 +58,41 @@ const ConfigSchema = z
           'KYC_PROVIDER_URL and KYC_PROVIDER_API_KEY must both be set or both be absent.',
         path: hasUrl ? ['KYC_PROVIDER_API_KEY'] : ['KYC_PROVIDER_URL'],
       });
+    }
+    if (data.NODE_ENV === 'production') {
+      const baseUrl = data.PUBLIC_API_BASE_URL;
+      // Require the variable to be present in production
+      if (!baseUrl) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'PUBLIC_API_BASE_URL must be set in production. It is used in the OpenAPI spec servers array.',
+          path: ['PUBLIC_API_BASE_URL'],
+        });
+        return;
+      }
+      // Require HTTPS — never allow plaintext in production
+      let parsed;
+      try { parsed = new URL(baseUrl); } catch (_) { parsed = null; }
+      if (!parsed || parsed.protocol !== 'https:') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'PUBLIC_API_BASE_URL must use HTTPS in production.',
+          path: ['PUBLIC_API_BASE_URL'],
+        });
+        return;
+      }
+      // Reject loopback addresses (127.x.x.x, ::1, [::1], localhost)
+      const loopbackPattern = /^(localhost|127(?:\.\d+){3}|::1|\[::1\])$/i;
+      if (loopbackPattern.test(parsed.hostname)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'PUBLIC_API_BASE_URL must not be a loopback address in production.',
+          path: ['PUBLIC_API_BASE_URL'],
+        });
+      }
     }
   });
 

--- a/src/openapi/openapiSpec.js
+++ b/src/openapi/openapiSpec.js
@@ -12,6 +12,13 @@
  * tests (`tests/contract/api-schemas.test.js`) and the OpenAPI tests
  * (`tests/openapi.test.js`).
  *
+ * Server URLs are derived from the `PUBLIC_API_BASE_URL` environment variable
+ * (via `src/config/index.js`) rather than being hardcoded. In development and
+ * test environments a localhost fallback is used when the variable is absent.
+ * In production the variable is required, must use HTTPS, and must not resolve
+ * to a loopback address — all of which are enforced at config validation time
+ * by `src/config/index.js`.
+ *
  * @module openapi/openapiSpec
  */
 
@@ -21,8 +28,114 @@ const swaggerJsdoc = require('swagger-jsdoc');
 const ROUTES_GLOB = path.join(__dirname, '..', 'routes', '**', '*.js');
 
 /**
+ * The hostname pattern for loopback addresses (localhost, 127.x.x.x, ::1).
+ * Used to guard against accidentally publishing a loopback URL in the spec.
+ * Handles both bare IPv6 loopback `::1` and bracket-wrapped `[::1]` which is
+ * how `new URL('https://[::1]').hostname` appears in Node.js.
+ */
+const LOOPBACK_HOSTNAME = /^(localhost|127(?:\.\d+){3}|::1|\[::1\])$/i;
+
+/**
+ * Default fallback server entry used only in development and test.
+ */
+const DEV_FALLBACK_SERVER = {
+  url: 'http://localhost:3001',
+  description: 'Local development',
+};
+
+/**
+ * Build the servers array for the OpenAPI document.
+ *
+ * Resolution order:
+ * 1. `PUBLIC_API_BASE_URL` from the validated config (any env).
+ * 2. `PUBLIC_API_BASE_URL` from `process.env` directly (covers the narrow
+ *    window before `validate()` has been called, e.g. during spec generation
+ *    inside test helpers).
+ * 3. Dev/test fallback — `http://localhost:3001`. This path is intentionally
+ *    unreachable in production because `src/config/index.js` aborts startup
+ *    when `PUBLIC_API_BASE_URL` is absent or invalid in `NODE_ENV=production`.
+ *
+ * @returns {Array<{url: string, description: string}>} Non-empty servers array.
+ * @throws {Error} When called in a production context but no valid base URL
+ *   can be resolved (defense-in-depth guard — config validation should have
+ *   already caught this at boot time).
+ */
+function buildServers() {
+  // Attempt to read from the already-validated config first.
+  let baseUrl = null;
+  try {
+    const { get } = require('../config');
+    const cfg = get();
+    baseUrl = cfg.PUBLIC_API_BASE_URL || null;
+  } catch (_) {
+    // Config not yet validated (e.g. called from a test before validate()).
+    // Fall through to direct env read below.
+  }
+
+  // Direct env read as a second source (covers pre-validation callers).
+  if (!baseUrl) {
+    baseUrl = process.env.PUBLIC_API_BASE_URL || null;
+  }
+
+  const nodeEnv = process.env.NODE_ENV || 'development';
+
+  if (baseUrl) {
+    // Strip trailing slash for consistency.
+    const normalised = baseUrl.replace(/\/+$/, '');
+
+    let parsed;
+    try { parsed = new URL(normalised); } catch (_) { parsed = null; }
+
+    // Defense-in-depth: reject a loopback URL that somehow slipped through
+    // config validation (e.g. spec built before the server starts in prod).
+    if (nodeEnv === 'production' && parsed && LOOPBACK_HOSTNAME.test(parsed.hostname)) {
+      throw new Error(
+        `PUBLIC_API_BASE_URL must not be a loopback address in production. Got: ${normalised}`,
+      );
+    }
+    if (nodeEnv === 'production' && parsed && parsed.protocol !== 'https:') {
+      throw new Error(
+        `PUBLIC_API_BASE_URL must use HTTPS in production. Got: ${normalised}`,
+      );
+    }
+    if (nodeEnv === 'production' && !parsed) {
+      throw new Error(
+        `PUBLIC_API_BASE_URL is not a valid URL in production. Got: ${baseUrl}`,
+      );
+    }
+
+    const description =
+      nodeEnv === 'production'
+        ? 'Production API'
+        : nodeEnv === 'test'
+          ? 'Test server'
+          : 'API server';
+
+    return [{ url: normalised, description }];
+  }
+
+  // No base URL configured.
+  if (nodeEnv === 'production') {
+    // Should never reach here — config validation prevents startup without
+    // PUBLIC_API_BASE_URL in production. Guard anyway so spec generation
+    // never silently emits a loopback URL to a production consumer.
+    throw new Error(
+      'PUBLIC_API_BASE_URL is required in production but was not set. ' +
+      'Refusing to build the OpenAPI spec with a loopback server entry.',
+    );
+  }
+
+  // Development / test — safe to use the localhost fallback.
+  return [DEV_FALLBACK_SERVER];
+}
+
+/**
  * Base OpenAPI document. Route-specific operations are merged in by
  * `swagger-jsdoc` from the `@swagger` JSDoc blocks in route files.
+ *
+ * The `servers` array is intentionally left empty here; it is populated
+ * dynamically by `buildOpenApiSpec()` via `buildServers()` so the published
+ * spec always reflects the runtime environment rather than a hardcoded value.
  */
 const baseDefinition = {
   openapi: '3.0.0',
@@ -34,7 +147,7 @@ const baseDefinition = {
       'Successful responses use a standardized envelope (`data`/`meta`/`message`); ' +
       'error responses follow RFC 7807 (`application/problem+json`).',
   },
-  servers: [{ url: 'http://localhost:3001', description: 'Local development' }],
+  servers: [],
   components: {
     securitySchemes: {
       bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
@@ -244,15 +357,25 @@ let cached = null;
  * Build the OpenAPI document. The result is memoised because spec generation
  * walks every route file with `swagger-jsdoc` and is non-trivial.
  *
+ * The `servers` array is derived at call time from `PUBLIC_API_BASE_URL` via
+ * `buildServers()`, so the published spec always reflects the runtime
+ * environment rather than a hardcoded localhost value.
+ *
  * @returns {object} OpenAPI 3.0 document.
+ * @throws {Error} In production when `PUBLIC_API_BASE_URL` is absent, uses
+ *   HTTP, or resolves to a loopback address.
  */
 function buildOpenApiSpec() {
   if (cached) {
     return cached;
   }
 
+  // Resolve servers dynamically — must happen before swagger-jsdoc merges the
+  // definition so the generated document carries the correct server entries.
+  const servers = buildServers();
+
   const generated = swaggerJsdoc({
-    definition: baseDefinition,
+    definition: { ...baseDefinition, servers },
     apis: [ROUTES_GLOB],
   });
 
@@ -271,6 +394,7 @@ function _resetCache() {
 
 module.exports = {
   buildOpenApiSpec,
+  buildServers,
   baseDefinition,
   _resetCache,
 };

--- a/tests/openapi.servers.test.js
+++ b/tests/openapi.servers.test.js
@@ -1,0 +1,561 @@
+'use strict';
+
+/**
+ * @fileoverview Comprehensive tests for the OpenAPI server URL derivation logic
+ * introduced in `src/openapi/openapiSpec.js`.
+ *
+ * Covers:
+ *  - Dev/test fallback when PUBLIC_API_BASE_URL is absent
+ *  - Explicit URL in development and test environments
+ *  - Trailing-slash normalisation
+ *  - Production: valid HTTPS URL accepted
+ *  - Production: HTTP URL rejected (defense-in-depth guard)
+ *  - Production: loopback hostnames rejected (localhost, 127.x.x.x, ::1)
+ *  - Production: missing URL rejects with informative error
+ *  - Production: malformed URL rejected
+ *  - Config `get()` integration — prefers validated config over raw env
+ *  - buildOpenApiSpec() injects servers correctly and respects the cache
+ *  - buildOpenApiSpec() cache is invalidated by _resetCache()
+ *  - The existing openapi.test.js assertions still pass (servers defined + array)
+ */
+
+const { buildServers, buildOpenApiSpec, _resetCache } = require('../src/openapi/openapiSpec');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `fn` with `process.env.NODE_ENV` temporarily set to `env`.
+ * Restores the original value — and deletes PUBLIC_API_BASE_URL — afterwards.
+ *
+ * @param {string} env - NODE_ENV value to use.
+ * @param {string|undefined} baseUrl - Value for PUBLIC_API_BASE_URL, or
+ *   undefined to leave it unset.
+ * @param {Function} fn - Callback to execute in the patched environment.
+ * @returns {*} Return value of fn().
+ */
+function withEnv(env, baseUrl, fn) {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalBaseUrl = process.env.PUBLIC_API_BASE_URL;
+
+  process.env.NODE_ENV = env;
+  if (baseUrl !== undefined) {
+    process.env.PUBLIC_API_BASE_URL = baseUrl;
+  } else {
+    delete process.env.PUBLIC_API_BASE_URL;
+  }
+
+  try {
+    return fn();
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalBaseUrl !== undefined) {
+      process.env.PUBLIC_API_BASE_URL = originalBaseUrl;
+    } else {
+      delete process.env.PUBLIC_API_BASE_URL;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock the config `get()` call so we can control what buildServers sees
+// without a full validate() cycle.  The real setup.js already called
+// validate() with NODE_ENV=test and no PUBLIC_API_BASE_URL, so the cached
+// config object has PUBLIC_API_BASE_URL=undefined.  We jest.mock the module
+// here so each test can specify exactly what get() returns.
+// ---------------------------------------------------------------------------
+
+jest.mock('../src/config', () => {
+  const original = jest.requireActual('../src/config');
+  return {
+    ...original,
+    get: jest.fn(),
+  };
+});
+
+const configModule = require('../src/config');
+
+/**
+ * Make `config.get()` return a config object with the given PUBLIC_API_BASE_URL.
+ * Pass `null` to make get() throw (simulating "not yet validated").
+ *
+ * @param {string|undefined|null} publicApiBaseUrl
+ */
+function mockConfigGet(publicApiBaseUrl) {
+  if (publicApiBaseUrl === null) {
+    configModule.get.mockImplementation(() => {
+      throw new Error('Config not validated');
+    });
+  } else {
+    configModule.get.mockReturnValue({ PUBLIC_API_BASE_URL: publicApiBaseUrl });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suites
+// ---------------------------------------------------------------------------
+
+describe('buildServers()', () => {
+  // Always reset the spec cache and restore the mock before each test so tests
+  // are fully isolated.
+  beforeEach(() => {
+    _resetCache();
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Development environment
+  // -------------------------------------------------------------------------
+  describe('development environment', () => {
+    it('returns the localhost fallback when PUBLIC_API_BASE_URL is absent', () => {
+      mockConfigGet(undefined);
+      const servers = withEnv('development', undefined, () => buildServers());
+
+      expect(servers).toHaveLength(1);
+      expect(servers[0].url).toBe('http://localhost:3001');
+      expect(servers[0].description).toBe('Local development');
+    });
+
+    it('uses PUBLIC_API_BASE_URL from validated config when present', () => {
+      mockConfigGet('http://localhost:4000');
+      const servers = withEnv('development', undefined, () => buildServers());
+
+      expect(servers).toHaveLength(1);
+      expect(servers[0].url).toBe('http://localhost:4000');
+      expect(servers[0].description).toBe('API server');
+    });
+
+    it('falls back to process.env when config.get() throws', () => {
+      mockConfigGet(null); // simulates pre-validation
+      const servers = withEnv('development', 'http://localhost:8080', () => buildServers());
+
+      expect(servers).toHaveLength(1);
+      expect(servers[0].url).toBe('http://localhost:8080');
+    });
+
+    it('strips a trailing slash from the base URL', () => {
+      mockConfigGet('http://localhost:4000/');
+      const servers = withEnv('development', undefined, () => buildServers());
+
+      expect(servers[0].url).toBe('http://localhost:4000');
+    });
+
+    it('strips multiple trailing slashes', () => {
+      mockConfigGet('http://localhost:4000///');
+      const servers = withEnv('development', undefined, () => buildServers());
+
+      expect(servers[0].url).toBe('http://localhost:4000');
+    });
+
+    it('accepts an HTTP loopback URL in development without throwing', () => {
+      mockConfigGet('http://127.0.0.1:3001');
+      expect(() => withEnv('development', undefined, () => buildServers())).not.toThrow();
+    });
+
+    it('accepts an HTTP URL in development (no HTTPS requirement)', () => {
+      mockConfigGet('http://dev.internal.example.com');
+      expect(() => withEnv('development', undefined, () => buildServers())).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test environment
+  // -------------------------------------------------------------------------
+  describe('test environment', () => {
+    it('returns the localhost fallback when PUBLIC_API_BASE_URL is absent', () => {
+      mockConfigGet(undefined);
+      const servers = withEnv('test', undefined, () => buildServers());
+
+      expect(servers).toHaveLength(1);
+      expect(servers[0].url).toBe('http://localhost:3001');
+    });
+
+    it('uses PUBLIC_API_BASE_URL when set in test env', () => {
+      mockConfigGet('https://api.test.example.com');
+      const servers = withEnv('test', undefined, () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.test.example.com');
+      expect(servers[0].description).toBe('Test server');
+    });
+
+    it('falls back to process.env when config.get() throws in test env', () => {
+      mockConfigGet(null);
+      const servers = withEnv('test', 'https://api.ci.example.com', () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.ci.example.com');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Production environment — valid URLs
+  // -------------------------------------------------------------------------
+  describe('production environment — valid HTTPS URLs', () => {
+    it('accepts a plain HTTPS URL', () => {
+      mockConfigGet('https://api.liquifact.com');
+      const servers = withEnv('production', undefined, () => buildServers());
+
+      expect(servers).toHaveLength(1);
+      expect(servers[0].url).toBe('https://api.liquifact.com');
+      expect(servers[0].description).toBe('Production API');
+    });
+
+    it('accepts an HTTPS URL with a path prefix', () => {
+      mockConfigGet('https://api.liquifact.com/v1');
+      const servers = withEnv('production', undefined, () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.liquifact.com/v1');
+    });
+
+    it('strips trailing slash from production HTTPS URL', () => {
+      mockConfigGet('https://api.liquifact.com/');
+      const servers = withEnv('production', undefined, () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.liquifact.com');
+    });
+
+    it('accepts an HTTPS URL with a non-standard port', () => {
+      mockConfigGet('https://api.internal.liquifact.com:8443');
+      const servers = withEnv('production', undefined, () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.internal.liquifact.com:8443');
+    });
+
+    it('prefers config.get() over process.env in production', () => {
+      mockConfigGet('https://api.primary.liquifact.com');
+      // Env has a different value — config should win
+      const servers = withEnv('production', 'https://api.env.liquifact.com', () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.primary.liquifact.com');
+    });
+
+    it('falls back to process.env when config.get() throws in production', () => {
+      mockConfigGet(null);
+      const servers = withEnv('production', 'https://api.liquifact.com', () => buildServers());
+
+      expect(servers[0].url).toBe('https://api.liquifact.com');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Production environment — rejected cases
+  // -------------------------------------------------------------------------
+  describe('production environment — rejected configurations', () => {
+    it('throws when PUBLIC_API_BASE_URL is absent in production', () => {
+      mockConfigGet(undefined);
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /PUBLIC_API_BASE_URL is required in production/,
+      );
+    });
+
+    it('throws when PUBLIC_API_BASE_URL is an empty string in production', () => {
+      mockConfigGet(null); // config.get() throws; empty env string treated as unset
+      expect(() => withEnv('production', '', () => buildServers())).toThrow(
+        /PUBLIC_API_BASE_URL is required in production/,
+      );
+    });
+
+    it('throws when PUBLIC_API_BASE_URL uses HTTP (not HTTPS) in production', () => {
+      mockConfigGet('http://api.liquifact.com');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /must use HTTPS in production/,
+      );
+    });
+
+    it('throws when HTTP URL comes from process.env in production', () => {
+      mockConfigGet(null);
+      expect(() => withEnv('production', 'http://api.liquifact.com', () => buildServers())).toThrow(
+        /must use HTTPS in production/,
+      );
+    });
+
+    it('throws for localhost in production', () => {
+      mockConfigGet('https://localhost:3001');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /must not be a loopback address in production/,
+      );
+    });
+
+    it('throws for 127.0.0.1 in production', () => {
+      mockConfigGet('https://127.0.0.1:3001');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /must not be a loopback address in production/,
+      );
+    });
+
+    it('throws for 127.1.2.3 in production', () => {
+      mockConfigGet('https://127.1.2.3');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /must not be a loopback address in production/,
+      );
+    });
+
+    it('throws for ::1 (IPv6 loopback) in production', () => {
+      mockConfigGet('https://[::1]:3001');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /must not be a loopback address in production/,
+      );
+    });
+
+    it('throws for a malformed URL in production', () => {
+      mockConfigGet('not-a-valid-url');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow(
+        /PUBLIC_API_BASE_URL is not a valid URL in production/,
+      );
+    });
+
+    it('throws for a URL with no protocol in production', () => {
+      mockConfigGet('api.liquifact.com');
+      expect(() => withEnv('production', undefined, () => buildServers())).toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Return shape invariants
+  // -------------------------------------------------------------------------
+  describe('return shape', () => {
+    it('always returns a non-empty array', () => {
+      mockConfigGet(undefined);
+      const servers = withEnv('development', undefined, () => buildServers());
+      expect(Array.isArray(servers)).toBe(true);
+      expect(servers.length).toBeGreaterThan(0);
+    });
+
+    it('every entry has a non-empty url string', () => {
+      mockConfigGet('https://api.liquifact.com');
+      const servers = withEnv('production', undefined, () => buildServers());
+      for (const entry of servers) {
+        expect(typeof entry.url).toBe('string');
+        expect(entry.url.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('every entry has a non-empty description string', () => {
+      mockConfigGet(undefined);
+      const servers = withEnv('development', undefined, () => buildServers());
+      for (const entry of servers) {
+        expect(typeof entry.description).toBe('string');
+        expect(entry.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOpenApiSpec() integration
+// ---------------------------------------------------------------------------
+
+describe('buildOpenApiSpec() server injection', () => {
+  beforeEach(() => {
+    _resetCache();
+    jest.clearAllMocks();
+  });
+
+  it('injects the dev fallback into the built spec when PUBLIC_API_BASE_URL is absent', () => {
+    mockConfigGet(undefined);
+    const spec = withEnv('development', undefined, () => buildOpenApiSpec());
+
+    expect(spec.servers).toBeDefined();
+    expect(Array.isArray(spec.servers)).toBe(true);
+    expect(spec.servers).toHaveLength(1);
+    expect(spec.servers[0].url).toBe('http://localhost:3001');
+  });
+
+  it('injects the configured URL into the built spec', () => {
+    mockConfigGet('https://api.liquifact.com');
+    const spec = withEnv('production', undefined, () => buildOpenApiSpec());
+
+    expect(spec.servers[0].url).toBe('https://api.liquifact.com');
+    expect(spec.servers[0].description).toBe('Production API');
+  });
+
+  it('does not mutate baseDefinition.servers when building the spec', () => {
+    const { baseDefinition } = require('../src/openapi/openapiSpec');
+    const originalServers = baseDefinition.servers;
+
+    mockConfigGet('https://api.liquifact.com');
+    withEnv('production', undefined, () => buildOpenApiSpec());
+
+    // baseDefinition.servers must remain the original empty array
+    expect(baseDefinition.servers).toBe(originalServers);
+    expect(baseDefinition.servers).toEqual([]);
+  });
+
+  it('returns a cached result on subsequent calls', () => {
+    mockConfigGet(undefined);
+    const spec1 = withEnv('development', undefined, () => buildOpenApiSpec());
+    const spec2 = withEnv('development', undefined, () => buildOpenApiSpec());
+
+    expect(spec1).toBe(spec2); // same reference — cache hit
+  });
+
+  it('_resetCache() forces a fresh build on the next call', () => {
+    mockConfigGet(undefined);
+    const spec1 = withEnv('development', undefined, () => buildOpenApiSpec());
+
+    _resetCache();
+
+    mockConfigGet('http://localhost:4000');
+    const spec2 = withEnv('development', undefined, () => buildOpenApiSpec());
+
+    // Different URLs → definitely a fresh build
+    expect(spec2.servers[0].url).toBe('http://localhost:4000');
+    expect(spec1.servers[0].url).toBe('http://localhost:3001');
+    expect(spec1).not.toBe(spec2);
+  });
+
+  it('propagates a production error thrown by buildServers()', () => {
+    mockConfigGet(undefined); // no URL configured
+    expect(() => withEnv('production', undefined, () => buildOpenApiSpec())).toThrow(
+      /PUBLIC_API_BASE_URL is required in production/,
+    );
+  });
+
+  it('the spec still passes the standard OpenAPI envelope assertions', () => {
+    mockConfigGet(undefined);
+    const spec = withEnv('development', undefined, () => buildOpenApiSpec());
+
+    expect(spec.openapi).toBe('3.0.0');
+    expect(spec.info.title).toBe('LiquiFact API');
+    expect(spec.info.version).toBe('1.0.0');
+    expect(spec.servers).toBeDefined();
+    expect(Array.isArray(spec.servers)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config schema integration (Zod validation)
+// ---------------------------------------------------------------------------
+
+describe('ConfigSchema PUBLIC_API_BASE_URL validation', () => {
+  // Use the real ConfigSchema (not the mocked get()) so we test Zod validation.
+  const { ConfigSchema } = require('../src/config');
+
+  const baseEnv = {
+    NODE_ENV: 'development',
+    JWT_SECRET: 'test-secret-at-least-32-characters-long',
+  };
+
+  it('is optional in development', () => {
+    const result = ConfigSchema.safeParse({ ...baseEnv });
+    expect(result.success).toBe(true);
+    expect(result.data.PUBLIC_API_BASE_URL).toBeUndefined();
+  });
+
+  it('accepts a valid HTTP URL in development', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      PUBLIC_API_BASE_URL: 'http://localhost:3001',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid HTTPS URL in development', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      PUBLIC_API_BASE_URL: 'https://api.liquifact.com',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-URL string', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      PUBLIC_API_BASE_URL: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('is optional in test environment (superRefine skipped)', () => {
+    const result = ConfigSchema.safeParse({ ...baseEnv, NODE_ENV: 'test' });
+    expect(result.success).toBe(true);
+  });
+
+  it('fails in production when PUBLIC_API_BASE_URL is absent', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      // No PUBLIC_API_BASE_URL
+    });
+    expect(result.success).toBe(false);
+    const paths = result.error.issues.map((i) => i.path.join('.'));
+    expect(paths).toContain('PUBLIC_API_BASE_URL');
+  });
+
+  it('fails in production when PUBLIC_API_BASE_URL uses HTTP', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      PUBLIC_API_BASE_URL: 'http://api.liquifact.com',
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(' ');
+    expect(msg).toMatch(/HTTPS/);
+  });
+
+  it('fails in production when PUBLIC_API_BASE_URL is localhost', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      PUBLIC_API_BASE_URL: 'https://localhost:3001',
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(' ');
+    expect(msg).toMatch(/loopback/);
+  });
+
+  it('fails in production when PUBLIC_API_BASE_URL is 127.0.0.1', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      PUBLIC_API_BASE_URL: 'https://127.0.0.1:3001',
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(' ');
+    expect(msg).toMatch(/loopback/);
+  });
+
+  it('fails in production when PUBLIC_API_BASE_URL is ::1', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      PUBLIC_API_BASE_URL: 'https://[::1]',
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(' ');
+    expect(msg).toMatch(/loopback/);
+  });
+
+  it('succeeds in production with a valid HTTPS non-loopback URL', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      PUBLIC_API_BASE_URL: 'https://api.liquifact.com',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.PUBLIC_API_BASE_URL).toBe('https://api.liquifact.com');
+  });
+
+  it('provides a human-readable error message when absent in production', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(' ');
+    expect(msg).toMatch(/PUBLIC_API_BASE_URL/);
+    expect(msg).toMatch(/production/);
+  });
+
+  it('provides a human-readable error message for HTTP in production', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      PUBLIC_API_BASE_URL: 'http://api.liquifact.com',
+    });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(' ');
+    expect(msg).toMatch(/PUBLIC_API_BASE_URL/);
+    expect(msg).toMatch(/HTTPS/);
+  });
+});


### PR DESCRIPTION


Add PUBLIC_API_BASE_URL to ConfigSchema with production validation (must be present, HTTPS, non-loopback). Replace hardcoded localhost servers entry in openapiSpec.js with dynamic buildServers() that reads from validated config, falls back to process.env, then localhost in dev/test only. Add active PUBLIC_API_BASE_URL entry to .env.example, docs/configuration.md env-reference table and a new OpenAPI Server URLs section. Add 54-test suite in tests/openapi.servers.test.js covering all valid/invalid paths.

Closes #621