### PR TITLE
refactor(config): add typed invoice size accessor

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -15,6 +15,7 @@ const ConfigSchema = z
   .object({
     NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
     PORT: z.coerce.number().min(1).max(65535).default(3001),
+    INVOICE_FILE_MAX_SIZE: z.string().min(1).default('5mb'),
     JWT_SECRET: z.string().min(32), // No default for security
     JWT_ALGORITHMS: z.string().optional().default('HS256'), // Comma-separated allowlist, e.g. HS256,RS256
     JWT_ISSUER: z.string().optional(), // Optional issuer claim to enforce
@@ -146,6 +147,26 @@ function get() {
   return config;
 }
 
+/**
+ * Returns the validated invoice upload size limit.
+ *
+ * Route modules are loaded while the application is being assembled, before
+ * the boot-time validation call runs. During that narrow window, resolve the
+ * same value from the environment so route construction remains side-effect
+ * free; the normal startup validation still rejects invalid configuration.
+ *
+ * @returns {string} Maximum invoice upload size accepted by Express.
+ */
+function getInvoiceFileMaxSize() {
+  if (config) {
+    return /** @type {string} */ (config.INVOICE_FILE_MAX_SIZE);
+  }
+  const configuredValue = process.env.INVOICE_FILE_MAX_SIZE;
+  return typeof configuredValue === 'string' && configuredValue.length > 0
+    ? configuredValue
+    : '5mb';
+}
+
 const securityHeaders = {
   contentSecurityPolicy: {
     directives: {
@@ -185,6 +206,7 @@ const securityHeaders = {
 module.exports = {
   validate,
   get,
+  getInvoiceFileMaxSize,
   logRedactedSummary,
   ConfigSchema,
   securityHeaders,

--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -2,7 +2,7 @@
  * Tests for centralized config module.
  */
 
-const { validate, get, logRedactedSummary, ConfigSchema } = require('./index');
+const { validate, get, getInvoiceFileMaxSize, logRedactedSummary, ConfigSchema } = require('./index');
 
 describe('Config Validation', () => {
   const originalEnv = { ...process.env };
@@ -28,6 +28,7 @@ describe('Config Validation', () => {
     expect(config.JWT_ISSUER).toBe('liquifact-platform');
     expect(config.JWT_AUDIENCE).toBe('liquifact-client');
     expect(config.JWT_ALGORITHMS).toBe('HS256');
+    expect(config.INVOICE_FILE_MAX_SIZE).toBe('5mb');
   });
 
   test('overrides defaults', () => {
@@ -44,6 +45,31 @@ describe('Config Validation', () => {
     expect(config.JWT_ISSUER).toBe('custom-issuer');
     expect(config.JWT_AUDIENCE).toBe('custom-audience');
     expect(config.JWT_ALGORITHMS).toBe('HS256,HS384');
+  });
+
+  test('validates and exposes a custom invoice file size through the typed accessor', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    process.env.INVOICE_FILE_MAX_SIZE = '10mb';
+
+    validate();
+
+    expect(getInvoiceFileMaxSize()).toBe('10mb');
+  });
+
+  test('resolves the invoice file size before boot validation', () => {
+    jest.isolateModules(() => {
+      process.env.INVOICE_FILE_MAX_SIZE = '2mb';
+      const { getInvoiceFileMaxSize: resolveInvoiceFileMaxSize } = require('./index');
+
+      expect(resolveInvoiceFileMaxSize()).toBe('2mb');
+    });
+  });
+
+  test('rejects an empty invoice file size at boot validation', () => {
+    process.env.INVOICE_FILE_MAX_SIZE = '';
+
+    expect(() => validate()).toThrow(/INVOICE_FILE_MAX_SIZE/);
   });
 
   test('rejects short JWT_SECRET', () => {

--- a/src/routes/invoiceFile.js
+++ b/src/routes/invoiceFile.js
@@ -8,6 +8,7 @@ const express = require('express');
 const crypto = require('crypto');
 const storageService = require('../services/storage');
 const logger = require('../logger');
+const { getInvoiceFileMaxSize } = require('../config');
 const router = express.Router();
 
 /** PDF magic bytes. */
@@ -17,7 +18,7 @@ const PDF_MAGIC_BYTES = Buffer.from('%PDF');
  * Configurable upload size limit from env, defaults to 5mb.
  * @type {string}
  */
-const UPLOAD_SIZE_LIMIT = process.env.INVOICE_FILE_MAX_SIZE || '5mb';
+const UPLOAD_SIZE_LIMIT = getInvoiceFileMaxSize();
 
 /**
  * Computes the SHA-256 hash of a buffer.


### PR DESCRIPTION
## Summary

Adds typed configuration access for the invoice upload route, backed by the existing validated Zod config.

## Changes

- Add `INVOICE_FILE_MAX_SIZE` to `src/config/index.js` with the existing 5mb default.
- Export `getInvoiceFileMaxSize()`; it returns validated config after boot validation and preserves the narrow pre-boot environment fallback required while routes are assembled.
- Update `src/routes/invoiceFile.js` to use the accessor instead of reading `process.env` directly.
- Add tests for default, custom, pre-boot, and invalid-at-boot behavior.

## Testing / Verification

- `npx jest src/config/index.test.js -t 'invoice file size|empty invoice' --runInBand --forceExit` — **PASS** (3 passed).
- `npx eslint src/config/index.js src/config/index.test.js src/routes/invoiceFile.js` — **PASS**.
- `git diff --check` — **PASS**.
- `npm run lint`, `npm run typecheck:jsdoc`, `npm run build`, and the full Jest suite currently expose unrelated baseline failures documented in the local attempt packet; no changed-file lint errors remain.

Closes #632