### PR TITLE
test(cors): cover success and error paths

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -71,7 +71,7 @@ const {
  */
 function handleCorsError(err, req, res, next) {
   if (isCorsOriginRejectedError(err)) {
-    res.status(403).json({ error: err.message });
+    res.status(403).json({ error: err.message, code: err.code });
     return;
   }
   next(err);

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -6,8 +6,11 @@ jest.mock('./services/invoiceService', () => ({
 }));
 
 const { createApp, handleCorsError } = require('./app');
-const { CORS_REJECTION_MESSAGE } = require('./config/cors');
-const { createCorsOptions } = require('./config/cors');
+const {
+  CORS_REJECTION_CODE,
+  CORS_REJECTION_MESSAGE,
+  createCorsOptions,
+} = require('./config/cors');
 const invoiceService = require('./services/invoiceService');
 
 function withEnv(env, fn) {
@@ -197,6 +200,7 @@ describe('LiquiFact app integration', () => {
         expect(response.statusCode).toBe(403);
         expect(response.body).toEqual({
           error: CORS_REJECTION_MESSAGE,
+          code: CORS_REJECTION_CODE,
         });
       }
     );
@@ -254,6 +258,7 @@ describe('LiquiFact app integration', () => {
         expect(response.statusCode).toBe(403);
         expect(response.body).toEqual({
           error: CORS_REJECTION_MESSAGE,
+          code: CORS_REJECTION_CODE,
         });
       }
     );

--- a/src/config/cors.js
+++ b/src/config/cors.js
@@ -28,6 +28,9 @@
  */
 const CORS_REJECTION_MESSAGE = 'CORS policy: origin is not allowed.';
 
+/** Machine-readable code returned for blocked-origin responses. */
+const CORS_REJECTION_CODE = 'CORS_ORIGIN_REJECTED';
+
 /** @type {string[]} Origins allowed when no env var is set during development. */
 const DEV_DEFAULT_ORIGINS = [
   'http://localhost:3000',
@@ -163,6 +166,7 @@ function isAllowedOrigin(origin, allowlist) {
  */
 function createCorsRejectionError(_origin) {
   const err = new Error(CORS_REJECTION_MESSAGE);
+  err.code = CORS_REJECTION_CODE;
   err.isCorsOriginRejected = true;
   err.isCorsOriginRejectedError = true;
   err.status = 403;
@@ -355,6 +359,7 @@ function createCorsOptions(env = process.env) {
 }
 
 module.exports = {
+  CORS_REJECTION_CODE,
   CORS_REJECTION_MESSAGE,
   DEV_DEFAULT_ORIGINS,
   createCorsOptions,

--- a/src/cors.endpoint.test.js
+++ b/src/cors.endpoint.test.js
@@ -1,0 +1,96 @@
+const request = require('supertest');
+
+const { createApp } = require('./app');
+const {
+  CORS_REJECTION_CODE,
+  CORS_REJECTION_MESSAGE,
+} = require('./config/cors');
+
+describe('CORS endpoint behavior', () => {
+  const allowedOrigin = 'https://app.example.com';
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalAllowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production';
+    process.env.CORS_ALLOWED_ORIGINS = allowedOrigin;
+  });
+
+  afterAll(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+  });
+
+  it('returns the health response for an allowed origin', async () => {
+    const response = await request(createApp())
+      .get('/health')
+      .set('Origin', allowedOrigin);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['access-control-allow-origin']).toBe(allowedOrigin);
+    expect(response.body).toEqual({
+      status: 'ok',
+      service: 'liquifact-api',
+      version: '0.1.0',
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('preserves the not-found response for an allowed origin', async () => {
+    const response = await request(createApp())
+      .get('/missing')
+      .set('Origin', allowedOrigin);
+
+    expect(response.status).toBe(404);
+    expect(response.headers['access-control-allow-origin']).toBe(allowedOrigin);
+    expect(response.body).toEqual({
+      error: 'Not found',
+      path: '/missing',
+    });
+  });
+
+  it('returns a stable error code when origin validation fails', async () => {
+    const response = await request(createApp())
+      .get('/health')
+      .set('Origin', 'https://blocked.example.com');
+
+    expect(response.status).toBe(403);
+    expect(CORS_REJECTION_CODE).toBe('CORS_ORIGIN_REJECTED');
+    expect(response.body.error).toBe(CORS_REJECTION_MESSAGE);
+    expect(response.body.code).toBe(CORS_REJECTION_CODE);
+  });
+
+  it('returns the same response for repeated preflight requests', async () => {
+    const app = createApp();
+    const sendPreflight = () =>
+      request(app)
+        .options('/health')
+        .set('Origin', allowedOrigin)
+        .set('Access-Control-Request-Method', 'GET');
+
+    const firstResponse = await sendPreflight();
+    const repeatedResponse = await sendPreflight();
+
+    for (const response of [firstResponse, repeatedResponse]) {
+      expect(response.status).toBe(204);
+      expect(response.body).toEqual({});
+      expect(response.headers['access-control-allow-origin']).toBe(allowedOrigin);
+    }
+
+    expect(repeatedResponse.headers['access-control-allow-methods']).toBe(
+      firstResponse.headers['access-control-allow-methods']
+    );
+    expect(repeatedResponse.headers['access-control-max-age']).toBe(
+      firstResponse.headers['access-control-max-age']
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add HTTP-level coverage for allowed-origin success and 404 responses
- cover blocked-origin validation with a stable `CORS_ORIGIN_REJECTED` code
- verify repeated preflight requests return the same successful response
- keep the existing `error` field unchanged while adding the machine-readable code

## Verification

- `npx jest src/config/cors.test.js src/cors.endpoint.test.js src/app.test.js --runInBand --forceExit --modulePathIgnorePatterns=dist --testNamePattern="CORS|origin|preflight|health response|not-found response"` - 92 passed
- `npx eslint src/app.js src/app.test.js src/config/cors.js src/cors.endpoint.test.js` - passed
- `npm run typecheck` - passed
- focused CORS coverage: 100% statements, lines, and functions; 97.87% branches

## Repository baseline

The repository-wide commands currently fail on `main` outside this change:

- `npm run lint`: 49 existing errors, including a merge marker parse error in `tests/idempotency.test.js`
- `npm run build`: TS5055 attempts to emit over the input `knexfile.js`
- `npm test`: unrelated app/server/OpenAPI/auth failures and Redis side effects; the run eventually exits on an existing `Invalid invoice ID` error

Closes #659
