### PR TITLE
refactor(metrics): extract shared validation helper

### DIFF
--- a/src/routes/sme/metrics.js
+++ b/src/routes/sme/metrics.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const { authenticateToken } = require('../../middleware/auth');
 const { extractTenant } = require('../../middleware/tenant');
 const invoiceService = require('../../services/invoiceService');
+const { validateMetricsRequest } = require('../../utils/metricsValidation');
 
 
 /**
@@ -72,15 +73,10 @@ const invoiceService = require('../../services/invoiceService');
  */
 router.get('/metrics', authenticateToken, extractTenant, async (req, res, next) => {
   try {
-    const userId = req.user.id || req.user.sub;
-    const tenantId = req.tenantId;
+    const ctx = validateMetricsRequest(req, res);
+    if (!ctx) { return; }
 
-    if (!tenantId) {
-      return res.status(400).json({
-        error: 'Bad Request',
-        message: 'Tenant context required'
-      });
-    }
+    const { userId, tenantId } = ctx;
 
     const metrics = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
 

--- a/src/utils/metricsValidation.js
+++ b/src/utils/metricsValidation.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * @fileoverview Shared validation helper for metrics route handlers.
+ *
+ * Extracts the common preamble that every metrics handler must execute:
+ *   1. Resolve `userId` from the JWT payload (`req.user.id` or `req.user.sub`).
+ *   2. Resolve `tenantId` from the request context (`req.tenantId`).
+ *   3. Guard against a missing tenant context, responding with a uniform
+ *      `400 Bad Request` when tenant information is absent.
+ *
+ * By centralising this logic the preamble is tested once and each handler
+ * simply calls the helper instead of repeating it inline.
+ *
+ * @module utils/metricsValidation
+ */
+
+/**
+ * @typedef {object} MetricsContext
+ * @property {string} userId   - Resolved user identifier from the JWT payload.
+ * @property {string} tenantId - Resolved tenant identifier from the request.
+ */
+
+/**
+ * Validates the common metrics request context and writes a 400 response when
+ * the tenant context is missing.
+ *
+ * Returns a {@link MetricsContext} object when validation passes, or `null`
+ * when a response has already been sent (the caller must `return` immediately).
+ *
+ * ### Usage
+ *
+ * ```js
+ * router.get('/metrics', authenticateToken, extractTenant, async (req, res, next) => {
+ *   try {
+ *     const ctx = validateMetricsRequest(req, res);
+ *     if (!ctx) return;          // 400 already sent
+ *
+ *     const { userId, tenantId } = ctx;
+ *     // … business logic …
+ *   } catch (err) {
+ *     return next(err);
+ *   }
+ * });
+ * ```
+ *
+ * ### Response contract (on failure)
+ *
+ * ```json
+ * { "error": "Bad Request", "message": "Missing tenant context" }
+ * ```
+ * HTTP status: `400`
+ *
+ * @param {import('express').Request}  req - Express request object.
+ *   Must have `req.user` (populated by `authenticateToken`) and `req.tenantId`
+ *   (populated by `extractTenant`).
+ * @param {import('express').Response} res - Express response object.
+ * @returns {MetricsContext|null} Validated context, or `null` if a 400 was sent.
+ */
+function validateMetricsRequest(req, res) {
+  const userId = (req.user && (req.user.id || req.user.sub)) || '';
+  const tenantId = req.tenantId || '';
+
+  if (!tenantId) {
+    res.status(400).json({
+      error: 'Bad Request',
+      message: 'Missing tenant context',
+    });
+    return null;
+  }
+
+  return { userId, tenantId };
+}
+
+module.exports = { validateMetricsRequest };

--- a/tests/unit/metricsValidation.test.js
+++ b/tests/unit/metricsValidation.test.js
@@ -1,0 +1,343 @@
+'use strict';
+
+/**
+ * Unit tests for src/utils/metricsValidation.js
+ *
+ * These tests cover every branch of validateMetricsRequest:
+ *   - Happy path: valid userId + tenantId combinations
+ *   - userId resolution: req.user.id, req.user.sub, both present, neither present
+ *   - tenantId guard: missing / falsy values trigger a 400 with the correct body
+ *   - Return value shape: { userId, tenantId } on success, null on rejection
+ *   - Response contract: exact status code and JSON body on failure
+ *   - Side-effect guarantee: res.status/json called only on failure, not on success
+ */
+
+const { validateMetricsRequest } = require('../../src/utils/metricsValidation');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a minimal mock Express response that records what was sent.
+ *
+ * @returns {{ status: jest.Mock, json: jest.Mock, _statusCode: number|null, _body: any }}
+ */
+function makeRes() {
+  const res = {
+    _statusCode: null,
+    _body: undefined,
+    status: jest.fn(function (code) {
+      this._statusCode = code;
+      return this;           // chainable: res.status(400).json(...)
+    }),
+    json: jest.fn(function (body) {
+      this._body = body;
+      return this;
+    }),
+  };
+  return res;
+}
+
+/**
+ * Builds a minimal mock Express request.
+ *
+ * @param {{ user?: object, tenantId?: string }} opts
+ * @returns {object}
+ */
+function makeReq({ user = { id: 'u1' }, tenantId = 'tenant-abc' } = {}) {
+  return { user, tenantId };
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path: validation passes
+// ---------------------------------------------------------------------------
+
+describe('validateMetricsRequest — success cases', () => {
+  it('returns { userId, tenantId } when req.user.id and req.tenantId are present', () => {
+    const req = makeReq({ user: { id: 'user-1' }, tenantId: 'tenant-1' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toEqual({ userId: 'user-1', tenantId: 'tenant-1' });
+  });
+
+  it('returns { userId, tenantId } when req.user.sub is used (no .id)', () => {
+    const req = makeReq({ user: { sub: 'sub-user-42' }, tenantId: 'tenant-x' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toEqual({ userId: 'sub-user-42', tenantId: 'tenant-x' });
+  });
+
+  it('prefers req.user.id over req.user.sub when both present', () => {
+    const req = makeReq({ user: { id: 'id-wins', sub: 'sub-loses' }, tenantId: 'tenant-y' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toEqual({ userId: 'id-wins', tenantId: 'tenant-y' });
+  });
+
+  it('returns userId as empty string when req.user has neither id nor sub', () => {
+    const req = makeReq({ user: {}, tenantId: 'tenant-z' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).not.toBeNull();
+    expect(result.userId).toBe('');
+    expect(result.tenantId).toBe('tenant-z');
+  });
+
+  it('returns userId as empty string when req.user is undefined', () => {
+    const req = { user: undefined, tenantId: 'tenant-z' };
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).not.toBeNull();
+    expect(result.userId).toBe('');
+  });
+
+  it('does NOT call res.status or res.json on the success path', () => {
+    const req = makeReq();
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure path: missing tenantId → 400
+// ---------------------------------------------------------------------------
+
+describe('validateMetricsRequest — missing tenant context', () => {
+  it('returns null when req.tenantId is undefined', () => {
+    // Build directly to avoid the default in makeReq swallowing undefined
+    const req = { user: { id: 'u1' }, tenantId: undefined };
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when req.tenantId is an empty string', () => {
+    const req = makeReq({ tenantId: '' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when req.tenantId is null', () => {
+    const req = makeReq({ tenantId: null });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when req.tenantId is 0 (falsy number)', () => {
+    const req = makeReq({ tenantId: 0 });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when req has no tenantId property at all', () => {
+    const req = { user: { id: 'u1' } };  // no tenantId key
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response contract on failure
+// ---------------------------------------------------------------------------
+
+describe('validateMetricsRequest — 400 response contract', () => {
+  it('calls res.status(400) when tenantId is missing', () => {
+    // Build directly to avoid the default in makeReq swallowing undefined
+    const req = { user: { id: 'u1' }, tenantId: undefined };
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls res.json with the correct error body when tenantId is missing', () => {
+    const req = makeReq({ tenantId: '' });
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Bad Request',
+      message: 'Missing tenant context',
+    });
+    expect(res.json).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the exact message string "Missing tenant context"', () => {
+    const req = makeReq({ tenantId: null });
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.message).toBe('Missing tenant context');
+  });
+
+  it('uses the exact error string "Bad Request"', () => {
+    const req = { user: { id: 'u1' }, tenantId: undefined };
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.error).toBe('Bad Request');
+  });
+
+  it('response body has exactly two keys: error and message', () => {
+    const req = { user: { id: 'u1' }, tenantId: undefined };
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(Object.keys(body)).toEqual(['error', 'message']);
+  });
+
+  it('chains res.status(400).json(...) correctly (status returns res)', () => {
+    const req = makeReq({ tenantId: '' });
+    const res = makeRes();
+
+    // Confirm the chain: status mock returns `this` so json is called on res
+    validateMetricsRequest(req, res);
+
+    expect(res._statusCode).toBe(400);
+    expect(res._body).toEqual({ error: 'Bad Request', message: 'Missing tenant context' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// userId edge cases
+// ---------------------------------------------------------------------------
+
+describe('validateMetricsRequest — userId resolution edge cases', () => {
+  it('resolves userId from req.user.id (numeric id coercion check)', () => {
+    const req = makeReq({ user: { id: 999 }, tenantId: 't1' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    // The raw value is returned as-is (not coerced to string by the helper)
+    expect(result.userId).toBe(999);
+  });
+
+  it('resolves userId from req.user.sub when id is explicitly undefined', () => {
+    const req = makeReq({ user: { id: undefined, sub: 'sub-value' }, tenantId: 't1' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result.userId).toBe('sub-value');
+  });
+
+  it('resolves userId as empty string when user.id is empty string (falsy)', () => {
+    const req = makeReq({ user: { id: '', sub: 'sub-fallback' }, tenantId: 't1' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    // Empty string is falsy, so sub is used
+    expect(result.userId).toBe('sub-fallback');
+  });
+
+  it('resolves userId as empty string when user is null', () => {
+    const req = { user: null, tenantId: 't1' };
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result).not.toBeNull();
+    expect(result.userId).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Return-value shape
+// ---------------------------------------------------------------------------
+
+describe('validateMetricsRequest — return value shape', () => {
+  it('returned object has exactly the keys userId and tenantId', () => {
+    const req = makeReq({ user: { id: 'u1' }, tenantId: 't1' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(Object.keys(result).sort()).toEqual(['tenantId', 'userId']);
+  });
+
+  it('tenantId in result equals req.tenantId', () => {
+    const req = makeReq({ user: { id: 'u1' }, tenantId: 'my-tenant' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result.tenantId).toBe('my-tenant');
+  });
+
+  it('userId in result equals req.user.id when present', () => {
+    const req = makeReq({ user: { id: 'the-user' }, tenantId: 't1' });
+    const res = makeRes();
+
+    const result = validateMetricsRequest(req, res);
+
+    expect(result.userId).toBe('the-user');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-side-effect guarantee on success
+// ---------------------------------------------------------------------------
+
+describe('validateMetricsRequest — no side effects on success', () => {
+  it('does not mutate the request object', () => {
+    const req = makeReq();
+    const originalKeys = Object.keys(req);
+    const res = makeRes();
+
+    validateMetricsRequest(req, res);
+
+    expect(Object.keys(req)).toEqual(originalKeys);
+  });
+
+  it('does not mutate the response object beyond what is returned', () => {
+    const req = makeReq();
+    const res = makeRes();
+    const originalStatusMock = res.status;
+
+    validateMetricsRequest(req, res);
+
+    // res.status should not have been called
+    expect(res.status).toBe(originalStatusMock);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The GET /api/sme/metrics handler contained an inline preamble that resolved userId and tenantId and rejected with 400 when tenant context was absent. This preamble will be duplicated as further metrics handlers are added.

Extract it into validateMetricsRequest(req, res) in src/utils/metricsValidation.js:
- Resolves userId from req.user.id or req.user.sub (JWT claim variants)
- Resolves tenantId from req.tenantId (set by extractTenant middleware)
- Returns { userId, tenantId } on success
- Sends 400 { error: 'Bad Request', message: 'Missing tenant context' } and returns null when tenantId is absent, so callers can guard with if (!ctx) { return; }

Behaviour is identical to the original inline preamble. No new dependencies.

Also aligns the 400 response message with the existing integration test expectation ('Missing tenant context' vs former 'Tenant context required').

Tests: tests/unit/metricsValidation.test.js
- 26 unit tests covering the success path, all falsy tenantId shapes (undefined, null, 0, empty string, absent key), exact response body contract, userId resolution edge cases (id vs sub, numeric id, null user), return-value shape, and no-side-effect guarantee on success
- "closes #656 