### PR TITLE
feat(config): validate and bound request inputs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -51,6 +51,7 @@ const retentionRoutes = require('./routes/retention');
 const invoiceStateRoutes = require('./routes/invoiceStateRoutes');
 const adminEscrowRoutes = require('./routes/adminEscrow');
 const adminWebhooksRoutes = require('./routes/adminWebhooks');
+const adminConfigRoutes = require('./routes/adminConfig');
 const kycRoutes = require('./routes/kyc');
 const reconciliationRoutes = require('./routes/reconciliation');
 const v1Routes = require('./routes/v1');
@@ -359,6 +360,7 @@ function createApp() {
   mountFeatureRouter(app, '/api/admin/audit', auditTrailRoutes);
   mountFeatureRouter(app, '/api/admin/escrow', adminEscrowRoutes);
   mountFeatureRouter(app, '/api/admin/webhooks', adminWebhooksRoutes);
+  mountFeatureRouter(app, '/api/admin/config', adminConfigRoutes);
   mountFeatureRouter(app, '/api/admin/reconciliation', reconciliationRoutes);
   mountFeatureRouter(app, '/v1', v1Routes);
 

--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * @fileoverview Admin route for runtime configuration writes.
+ *
+ * POST /api/admin/config
+ *   Accepts a `{ section, config }` body, validates it strictly with the
+ *   section-specific Zod schema from `src/schemas/config.js`, and returns the
+ *   validated configuration back to the caller.
+ *
+ *   Validation failures are rejected with a structured RFC 7807
+ *   `application/problem+json` 400 response containing machine-readable
+ *   `fieldErrors` so clients can map errors back to specific form fields.
+ *
+ * GET /api/admin/config/sections
+ *   Returns the list of valid section names accepted by the POST endpoint.
+ *
+ * Access: Admin-only (JWT bearer or API key). Tenant-scoped.
+ *
+ * @module routes/adminConfig
+ */
+
+const express = require('express');
+const { adminStack } = require('../middleware/stacks');
+const {
+  runtimeConfigSchema,
+  validateBody,
+  CONFIG_SECTIONS,
+} = require('../schemas/config');
+const logger = require('../logger');
+
+const router = express.Router();
+
+// ── Apply admin auth + tenant extraction to every route ──────────────────────
+router.use(...adminStack);
+
+// ── POST /api/admin/config ────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /api/admin/config:
+ *   post:
+ *     operationId: updateRuntimeConfig
+ *     summary: Write a runtime configuration section
+ *     description: |
+ *       Validates and accepts a configuration update for one of the supported
+ *       runtime config sections.  All fields are strictly validated:
+ *       - Unknown keys are rejected (400).
+ *       - Strings are length-bounded.
+ *       - Numeric values are range-checked.
+ *       - Categorical fields are allowlisted.
+ *
+ *       A machine-readable `fieldErrors` map is returned on any validation
+ *       failure so that clients can highlight the offending fields.
+ *
+ *       **Access**: Admin-only (JWT bearer or API key). Tenant-scoped.
+ *
+ *     tags: [AdminConfig]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [section, config]
+ *             properties:
+ *               section:
+ *                 type: string
+ *                 enum: [webhook, reconciliation, kyc, retention, fraudThresholds]
+ *                 description: The configuration section to update.
+ *               config:
+ *                 type: object
+ *                 description: Section-specific configuration payload.
+ *     responses:
+ *       200:
+ *         description: Configuration validated and accepted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 section:
+ *                   type: string
+ *                 config:
+ *                   type: object
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Validation error — body contains invalid or missing fields.
+ *         content:
+ *           application/problem+json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 type:  { type: string }
+ *                 title: { type: string }
+ *                 status: { type: integer }
+ *                 detail: { type: string }
+ *                 code:   { type: string }
+ *                 fieldErrors:
+ *                   type: object
+ *                   additionalProperties: { type: string }
+ *       401:
+ *         $ref: '#/components/responses/Problem401'
+ *       403:
+ *         $ref: '#/components/responses/Problem403'
+ */
+router.post('/', validateBody(runtimeConfigSchema), (req, res) => {
+  // validateBody attaches the parsed, coerced payload to req.validated
+  const { section, config: validatedConfig } = req.validated;
+
+  logger.info(
+    {
+      tenantId: req.tenantId,
+      section,
+      adminClient: req.apiClient?.clientId || req.user?.sub,
+    },
+    'Admin runtime config update accepted',
+  );
+
+  return res.status(200).json({
+    section,
+    config: validatedConfig,
+    message: `Configuration section '${section}' validated and accepted.`,
+  });
+});
+
+// ── GET /api/admin/config/sections ───────────────────────────────────────────
+
+/**
+ * @swagger
+ * /api/admin/config/sections:
+ *   get:
+ *     operationId: listConfigSections
+ *     summary: List valid configuration section names
+ *     description: |
+ *       Returns the list of section names accepted by
+ *       `POST /api/admin/config`.
+ *     tags: [AdminConfig]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Section list retrieved.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 sections:
+ *                   type: array
+ *                   items: { type: string }
+ *       401:
+ *         $ref: '#/components/responses/Problem401'
+ *       403:
+ *         $ref: '#/components/responses/Problem403'
+ */
+router.get('/sections', (req, res) => {
+  return res.status(200).json({ sections: CONFIG_SECTIONS });
+});
+
+module.exports = router;

--- a/src/schemas/config.js
+++ b/src/schemas/config.js
@@ -1,0 +1,384 @@
+'use strict';
+
+/**
+ * @fileoverview Strict Zod schemas for runtime config write payloads.
+ *
+ * Exposes named schemas for every admin-writable configuration surface:
+ *  - `webhookConfigSchema`     — webhook delivery and retry settings
+ *  - `reconciliationConfigSchema` — reconciliation run scheduling
+ *  - `kycConfigSchema`         — KYC provider connection settings
+ *  - `retentionConfigSchema`   — data-retention and legal-hold rules
+ *  - `fraudThresholdsSchema`   — per-tenant fraud & manual-review ceilings
+ *  - `runtimeConfigSchema`     — top-level union accepted by POST /api/admin/config
+ *
+ * Security guarantees applied to every schema:
+ *  - `.strict()` — unknown keys are rejected (prevents prototype-pollution payloads).
+ *  - String length bounds — prevents oversized inputs reaching the store.
+ *  - Numeric range checks — ensures values are within safe operating boundaries.
+ *  - Enum allowlists — rejects arbitrary strings for categorical fields.
+ *
+ * Re-exports the shared helpers from `src/schemas/invoice.js` so callers only
+ * need one import for middleware + error formatting.
+ *
+ * @module schemas/config
+ */
+
+const { z } = require('zod');
+const { validateBody, parseValidationErrors } = require('./invoice');
+
+// ── Shared primitives ────────────────────────────────────────────────────────
+
+/**
+ * A non-empty string bounded to `maxLen` characters, with whitespace trimmed.
+ * Kept as a reusable helper for future schema fields that need named-string bounds.
+ *
+ * @param {number} maxLen - Maximum character count after trimming.
+ * @param {string} label  - Field name used in error messages.
+ * @returns {import('zod').ZodString}
+ */
+function _boundedString(maxLen, label) {
+  return z
+    .string({ invalid_type_error: `${label} must be a string` })
+    .min(1, { message: `${label} must not be empty` })
+    .max(maxLen, { message: `${label} must not exceed ${maxLen} characters` })
+    .transform((v) => v.trim());
+}
+
+/**
+ * A URL string bounded to 2048 characters.
+ *
+ * @param {string} label - Field name used in error messages.
+ * @returns {import('zod').ZodEffects}
+ */
+function boundedUrl(label) {
+  return z
+    .string({ invalid_type_error: `${label} must be a string` })
+    .max(2048, { message: `${label} must not exceed 2048 characters` })
+    .url({ message: `${label} must be a valid URL` });
+}
+
+/**
+ * A finite positive integer within [min, max].
+ *
+ * @param {number} min - Minimum value (inclusive).
+ * @param {number} max - Maximum value (inclusive).
+ * @param {string} label - Field name used in error messages.
+ * @returns {import('zod').ZodNumber}
+ */
+function boundedInt(min, max, label) {
+  return z
+    .number({ invalid_type_error: `${label} must be a number` })
+    .int({ message: `${label} must be an integer` })
+    .min(min, { message: `${label} must be at least ${min}` })
+    .max(max, { message: `${label} must be at most ${max}` });
+}
+
+/**
+ * A finite positive number within [min, max] (not necessarily an integer).
+ *
+ * @param {number} min - Minimum value (inclusive).
+ * @param {number} max - Maximum value (inclusive).
+ * @param {string} label - Field name used in error messages.
+ * @returns {import('zod').ZodNumber}
+ */
+function boundedNumber(min, max, label) {
+  return z
+    .number({ invalid_type_error: `${label} must be a number` })
+    .finite({ message: `${label} must be a finite number` })
+    .min(min, { message: `${label} must be at least ${min}` })
+    .max(max, { message: `${label} must be at most ${max}` });
+}
+
+// ── Webhook config schema ────────────────────────────────────────────────────
+
+/**
+ * Schema for webhook delivery and retry configuration writes.
+ *
+ * Fields:
+ *  - `url`            — Delivery endpoint (HTTPS URL, max 2048 chars).
+ *  - `secret`         — HMAC signing secret (min 16 chars, max 256 chars).
+ *  - `events`         — Non-empty array of event-name strings (max 50 items,
+ *                       each up to 100 chars).
+ *  - `maxRetries`     — Max delivery attempts: integer in [0, 10].
+ *  - `timeoutMs`      — Per-attempt timeout: integer in [500, 30000] ms.
+ *  - `enabled`        — Boolean toggle (optional, defaults to true).
+ *
+ * @type {import('zod').ZodObject}
+ */
+const webhookConfigSchema = z
+  .object({
+    url: boundedUrl('url'),
+
+    secret: z
+      .string({ invalid_type_error: 'secret must be a string' })
+      .min(16, { message: 'secret must be at least 16 characters' })
+      .max(256, { message: 'secret must not exceed 256 characters' }),
+
+    events: z
+      .array(
+        z
+          .string({ invalid_type_error: 'each event name must be a string' })
+          .min(1, { message: 'event name must not be empty' })
+          .max(100, { message: 'event name must not exceed 100 characters' }),
+        { invalid_type_error: 'events must be an array' },
+      )
+      .min(1, { message: 'events must contain at least one entry' })
+      .max(50, { message: 'events must not exceed 50 entries' }),
+
+    maxRetries: boundedInt(0, 10, 'maxRetries').optional(),
+
+    timeoutMs: boundedInt(500, 30000, 'timeoutMs').optional(),
+
+    enabled: z.boolean({ invalid_type_error: 'enabled must be a boolean' }).optional(),
+  })
+  .strict(); // reject unknown keys
+
+// ── Reconciliation config schema ─────────────────────────────────────────────
+
+/**
+ * Schema for reconciliation run scheduling configuration writes.
+ *
+ * Fields:
+ *  - `batchSize`          — Invoices per batch: integer in [1, 500].
+ *  - `maxDriftSeconds`    — Acceptable ledger-to-DB drift: integer in [0, 3600].
+ *  - `scheduleExpression` — Cron or rate expression (max 100 chars).
+ *  - `enabled`            — Boolean toggle (optional).
+ *
+ * @type {import('zod').ZodObject}
+ */
+const reconciliationConfigSchema = z
+  .object({
+    batchSize: boundedInt(1, 500, 'batchSize').optional(),
+
+    maxDriftSeconds: boundedInt(0, 3600, 'maxDriftSeconds').optional(),
+
+    scheduleExpression: z
+      .string({ invalid_type_error: 'scheduleExpression must be a string' })
+      .min(1, { message: 'scheduleExpression must not be empty' })
+      .max(100, { message: 'scheduleExpression must not exceed 100 characters' })
+      .optional(),
+
+    enabled: z.boolean({ invalid_type_error: 'enabled must be a boolean' }).optional(),
+  })
+  .strict()
+  .refine((d) => Object.keys(d).length > 0, {
+    message: 'At least one reconciliation config field must be provided',
+  });
+
+// ── KYC config schema ────────────────────────────────────────────────────────
+
+/**
+ * Schema for KYC provider connection configuration writes.
+ *
+ * Fields:
+ *  - `providerUrl`  — Provider API base URL (HTTPS, max 2048 chars).
+ *  - `apiKey`       — Provider API key (min 8 chars, max 256 chars).
+ *  - `timeoutMs`    — HTTP timeout for provider calls: integer in [500, 30000] ms.
+ *  - `retries`      — Max provider retries: integer in [0, 5].
+ *
+ * Cross-field rule: `providerUrl` and `apiKey` must both be provided together
+ * (or neither if the intent is to clear the configuration via separate logic).
+ *
+ * @type {import('zod').ZodObject}
+ */
+const kycConfigSchema = z
+  .object({
+    providerUrl: boundedUrl('providerUrl'),
+
+    apiKey: z
+      .string({ invalid_type_error: 'apiKey must be a string' })
+      .min(8, { message: 'apiKey must be at least 8 characters' })
+      .max(256, { message: 'apiKey must not exceed 256 characters' }),
+
+    timeoutMs: boundedInt(500, 30000, 'timeoutMs').optional(),
+
+    retries: boundedInt(0, 5, 'retries').optional(),
+  })
+  .strict();
+
+// ── Retention config schema ──────────────────────────────────────────────────
+
+/**
+ * Schema for data-retention and legal-hold configuration writes.
+ *
+ * Fields:
+ *  - `retentionDays`      — Retention window: integer in [1, 3650] (≤ 10 years).
+ *  - `purgeEnabled`       — Boolean toggle (optional).
+ *  - `batchSize`          — Rows per purge batch: integer in [1, 1000].
+ *  - `purgeCron`          — Cron expression for scheduled purges (max 100 chars).
+ *  - `legalHoldReasons`   — Allowlisted reason codes (max 20 items,
+ *                           each string up to 100 chars).
+ *
+ * @type {import('zod').ZodObject}
+ */
+const retentionConfigSchema = z
+  .object({
+    retentionDays: boundedInt(1, 3650, 'retentionDays').optional(),
+
+    purgeEnabled: z.boolean({ invalid_type_error: 'purgeEnabled must be a boolean' }).optional(),
+
+    batchSize: boundedInt(1, 1000, 'batchSize').optional(),
+
+    purgeCron: z
+      .string({ invalid_type_error: 'purgeCron must be a string' })
+      .min(1, { message: 'purgeCron must not be empty' })
+      .max(100, { message: 'purgeCron must not exceed 100 characters' })
+      .optional(),
+
+    legalHoldReasons: z
+      .array(
+        z
+          .string({ invalid_type_error: 'each legalHoldReason must be a string' })
+          .min(1, { message: 'legalHoldReason must not be empty' })
+          .max(100, { message: 'legalHoldReason must not exceed 100 characters' }),
+        { invalid_type_error: 'legalHoldReasons must be an array' },
+      )
+      .max(20, { message: 'legalHoldReasons must not exceed 20 entries' })
+      .optional(),
+  })
+  .strict()
+  .refine((d) => Object.keys(d).length > 0, {
+    message: 'At least one retention config field must be provided',
+  });
+
+// ── Fraud thresholds schema ──────────────────────────────────────────────────
+
+/**
+ * Schema for per-tenant fraud and manual-review threshold configuration writes.
+ *
+ * Fields:
+ *  - `fraudCeiling`             — Amounts above this are auto-rejected:
+ *                                 finite positive number in [1, 1_000_000_000].
+ *  - `manualReviewThreshold`    — Amounts at or above this need human review:
+ *                                 finite positive number in [1, 1_000_000_000].
+ *
+ * Cross-field rule: `manualReviewThreshold` must be ≤ `fraudCeiling` when
+ * both fields are supplied, so the manual-review band remains reachable.
+ *
+ * @type {import('zod').ZodObject}
+ */
+const fraudThresholdsSchema = z
+  .object({
+    fraudCeiling: boundedNumber(1, 1_000_000_000, 'fraudCeiling').optional(),
+
+    manualReviewThreshold: boundedNumber(1, 1_000_000_000, 'manualReviewThreshold').optional(),
+  })
+  .strict()
+  .refine((d) => Object.keys(d).length > 0, {
+    message: 'At least one fraud threshold field must be provided',
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.fraudCeiling !== undefined &&
+      data.manualReviewThreshold !== undefined &&
+      data.manualReviewThreshold > data.fraudCeiling
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'manualReviewThreshold must not exceed fraudCeiling',
+        path: ['manualReviewThreshold'],
+      });
+    }
+  });
+
+// ── Top-level runtime config schema ─────────────────────────────────────────
+
+/**
+ * Valid configuration section names accepted by POST /api/admin/config.
+ * @type {readonly string[]}
+ */
+const CONFIG_SECTIONS = /** @type {const} */ ([
+  'webhook',
+  'reconciliation',
+  'kyc',
+  'retention',
+  'fraudThresholds',
+]);
+
+/**
+ * Schema for the top-level POST /api/admin/config request body.
+ *
+ * Shape:
+ * ```json
+ * {
+ *   "section": "webhook",
+ *   "config": { ...section-specific fields... }
+ * }
+ * ```
+ *
+ * - `section` is an enum of allowed configuration sections.
+ * - `config` is validated by the section-specific schema via `.superRefine()`.
+ * - Unknown top-level keys are rejected.
+ *
+ * @type {import('zod').ZodObject}
+ */
+const runtimeConfigSchema = z
+  .object({
+    /** The configuration section being written. */
+    section: z.enum(
+      /** @type {[string, ...string[]]} */ (CONFIG_SECTIONS),
+      {
+        invalid_type_error: 'section must be a string',
+        required_error: 'section is required',
+        errorMap: () => ({
+          message: `section must be one of: ${CONFIG_SECTIONS.join(', ')}`,
+        }),
+      },
+    ),
+
+    /** Section-specific configuration payload. Validated per-section below. */
+    config: z
+      .record(z.unknown(), { invalid_type_error: 'config must be an object' })
+      .refine((v) => v !== null && typeof v === 'object' && !Array.isArray(v), {
+        message: 'config must be a plain object',
+      }),
+  })
+  .strict() // reject unknown top-level keys
+  .superRefine((data, ctx) => {
+    const sectionSchemas = {
+      webhook: webhookConfigSchema,
+      reconciliation: reconciliationConfigSchema,
+      kyc: kycConfigSchema,
+      retention: retentionConfigSchema,
+      fraudThresholds: fraudThresholdsSchema,
+    };
+
+    const sectionSchema = sectionSchemas[data.section];
+    if (!sectionSchema) {
+      // Enum check above already handles this; belt-and-suspenders guard.
+      return;
+    }
+
+    const result = sectionSchema.safeParse(data.config);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          ...issue,
+          // Prefix path with "config." so field errors are navigable
+          path: ['config', ...issue.path],
+        });
+      }
+    }
+  });
+
+// ── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // Section schemas (exported for direct use in tests and sub-route validation)
+  webhookConfigSchema,
+  reconciliationConfigSchema,
+  kycConfigSchema,
+  retentionConfigSchema,
+  fraudThresholdsSchema,
+
+  // Top-level schema consumed by the admin config route
+  runtimeConfigSchema,
+
+  // Re-exported helpers
+  validateBody,
+  parseValidationErrors,
+
+  // Constants
+  CONFIG_SECTIONS,
+};

--- a/tests/unit/adminConfig.validation.test.js
+++ b/tests/unit/adminConfig.validation.test.js
@@ -1,0 +1,1009 @@
+'use strict';
+
+/**
+ * @fileoverview Comprehensive tests for config input validation.
+ *
+ * Covers:
+ *  - src/schemas/config.js — all section schemas and the top-level
+ *    runtimeConfigSchema (valid payloads, missing fields, wrong types,
+ *    oversized strings, boundary numbers, unknown-key rejection)
+ *  - POST /api/admin/config — route integration via supertest
+ *    (auth, 200 on valid, 400 + fieldErrors on invalid)
+ *  - GET /api/admin/config/sections — lists valid section names
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret-at-least-32-characters-long-string-for-jest';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock('../../src/db/knex', () => jest.fn());
+jest.mock('../../src/logger', () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+jest.mock('../../src/metrics', () => ({
+  webhookReplayTotal: { inc: jest.fn() },
+  registry: { contentType: 'text/plain', metrics: jest.fn().mockResolvedValue('') },
+}));
+jest.mock('prom-client', () => ({
+  Counter:  class { constructor() {} inc() {} },
+  Gauge:    class { constructor() {} set() {} },
+  Registry: class {
+    constructor() { this.contentType = 'text/plain'; }
+    metrics() { return ''; }
+  },
+  collectDefaultMetrics: () => {},
+}), { virtual: true });
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+const express  = require('express');
+const request  = require('supertest');
+const jwt      = require('jsonwebtoken');
+
+const {
+  webhookConfigSchema,
+  reconciliationConfigSchema,
+  kycConfigSchema,
+  retentionConfigSchema,
+  fraudThresholdsSchema,
+  runtimeConfigSchema,
+  parseValidationErrors,
+  CONFIG_SECTIONS,
+} = require('../../src/schemas/config');
+
+const adminConfigRouter = require('../../src/routes/adminConfig');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const JWT_SECRET = process.env.JWT_SECRET;
+
+/** Mint a valid admin JWT for test requests. */
+function makeAdminToken(sub = 'admin-user', tenantId = 'tenant_test') {
+  return jwt.sign({ sub, tenantId, role: 'admin' }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+/**
+ * Build a minimal Express app that mounts the adminConfig router.
+ * Injects a stub tenant so tests don't need a real DB.
+ */
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Stub tenant extraction — the real middleware reads from the DB
+  app.use((req, _res, next) => {
+    if (!req.tenantId) { req.tenantId = 'tenant_test'; }
+    next();
+  });
+
+  app.use('/api/admin/config', adminConfigRouter);
+
+  // Generic error handler
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+
+  return app;
+}
+
+const APP = buildApp();
+const TOKEN = makeAdminToken();
+const AUTH  = `Bearer ${TOKEN}`;
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SECTION 1 — Schema unit tests (no HTTP layer)
+// ═════════════════════════════════════════════════════════════════════════════
+
+// ── webhookConfigSchema ───────────────────────────────────────────────────────
+
+describe('webhookConfigSchema', () => {
+  const VALID = {
+    url: 'https://example.com/hook',
+    secret: 'supersecret-16chars',
+    events: ['invoice.created', 'invoice.paid'],
+  };
+
+  it('accepts a minimal valid payload', () => {
+    const r = webhookConfigSchema.safeParse(VALID);
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts all optional fields', () => {
+    const r = webhookConfigSchema.safeParse({
+      ...VALID,
+      maxRetries: 3,
+      timeoutMs: 5000,
+      enabled: true,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects missing url', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, url: undefined });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects invalid url', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, url: 'not-a-url' });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.url).toBeDefined();
+  });
+
+  it('rejects url exceeding 2048 chars', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, url: 'https://x.com/' + 'a'.repeat(2050) });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects secret shorter than 16 chars', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, secret: 'tooshort' });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.secret).toMatch(/16/);
+  });
+
+  it('rejects secret exceeding 256 chars', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, secret: 'a'.repeat(257) });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.secret).toMatch(/256/);
+  });
+
+  it('rejects empty events array', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, events: [] });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.events).toBeDefined();
+  });
+
+  it('rejects events array with more than 50 items', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, events: Array(51).fill('evt') });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an event name exceeding 100 chars', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, events: ['a'.repeat(101)] });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects maxRetries below 0', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, maxRetries: -1 });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects maxRetries above 10', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, maxRetries: 11 });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts maxRetries at boundary values 0 and 10', () => {
+    expect(webhookConfigSchema.safeParse({ ...VALID, maxRetries: 0 }).success).toBe(true);
+    expect(webhookConfigSchema.safeParse({ ...VALID, maxRetries: 10 }).success).toBe(true);
+  });
+
+  it('rejects timeoutMs below 500', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, timeoutMs: 499 });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects timeoutMs above 30000', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, timeoutMs: 30001 });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts timeoutMs at boundary values 500 and 30000', () => {
+    expect(webhookConfigSchema.safeParse({ ...VALID, timeoutMs: 500 }).success).toBe(true);
+    expect(webhookConfigSchema.safeParse({ ...VALID, timeoutMs: 30000 }).success).toBe(true);
+  });
+
+  it('rejects unknown keys', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, unknownField: 'boom' });
+    expect(r.success).toBe(false);
+    // Zod v4 strict() emits unrecognized_keys at path [] → mapped to '_root'
+    const errs = parseValidationErrors(r.error);
+    expect(errs._root).toMatch(/unknownField/);
+  });
+
+  it('rejects non-boolean enabled', () => {
+    const r = webhookConfigSchema.safeParse({ ...VALID, enabled: 'yes' });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ── reconciliationConfigSchema ────────────────────────────────────────────────
+
+describe('reconciliationConfigSchema', () => {
+  it('accepts a single field update', () => {
+    const r = reconciliationConfigSchema.safeParse({ batchSize: 50 });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts all valid fields together', () => {
+    const r = reconciliationConfigSchema.safeParse({
+      batchSize: 100,
+      maxDriftSeconds: 300,
+      scheduleExpression: '0 2 * * *',
+      enabled: false,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty object', () => {
+    const r = reconciliationConfigSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects batchSize below 1', () => {
+    const r = reconciliationConfigSchema.safeParse({ batchSize: 0 });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects batchSize above 500', () => {
+    const r = reconciliationConfigSchema.safeParse({ batchSize: 501 });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts batchSize at boundary values 1 and 500', () => {
+    expect(reconciliationConfigSchema.safeParse({ batchSize: 1 }).success).toBe(true);
+    expect(reconciliationConfigSchema.safeParse({ batchSize: 500 }).success).toBe(true);
+  });
+
+  it('rejects maxDriftSeconds below 0', () => {
+    const r = reconciliationConfigSchema.safeParse({ maxDriftSeconds: -1 });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects maxDriftSeconds above 3600', () => {
+    const r = reconciliationConfigSchema.safeParse({ maxDriftSeconds: 3601 });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects scheduleExpression exceeding 100 chars', () => {
+    const r = reconciliationConfigSchema.safeParse({ scheduleExpression: 'x'.repeat(101) });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown keys', () => {
+    const r = reconciliationConfigSchema.safeParse({ batchSize: 10, extra: true });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ── kycConfigSchema ───────────────────────────────────────────────────────────
+
+describe('kycConfigSchema', () => {
+  const VALID = {
+    providerUrl: 'https://kyc.provider.com/api',
+    apiKey: 'kyc-apikey-minimum8',
+  };
+
+  it('accepts a minimal valid payload', () => {
+    expect(kycConfigSchema.safeParse(VALID).success).toBe(true);
+  });
+
+  it('accepts optional fields', () => {
+    const r = kycConfigSchema.safeParse({ ...VALID, timeoutMs: 10000, retries: 3 });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects missing providerUrl', () => {
+    const r = kycConfigSchema.safeParse({ apiKey: VALID.apiKey });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects non-URL providerUrl', () => {
+    const r = kycConfigSchema.safeParse({ ...VALID, providerUrl: 'not-a-url' });
+    expect(r.success).toBe(false);
+    expect(parseValidationErrors(r.error).providerUrl).toBeDefined();
+  });
+
+  it('rejects apiKey shorter than 8 chars', () => {
+    const r = kycConfigSchema.safeParse({ ...VALID, apiKey: 'short' });
+    expect(r.success).toBe(false);
+    expect(parseValidationErrors(r.error).apiKey).toMatch(/8/);
+  });
+
+  it('rejects apiKey exceeding 256 chars', () => {
+    const r = kycConfigSchema.safeParse({ ...VALID, apiKey: 'k'.repeat(257) });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects retries above 5', () => {
+    const r = kycConfigSchema.safeParse({ ...VALID, retries: 6 });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts retries at boundary values 0 and 5', () => {
+    expect(kycConfigSchema.safeParse({ ...VALID, retries: 0 }).success).toBe(true);
+    expect(kycConfigSchema.safeParse({ ...VALID, retries: 5 }).success).toBe(true);
+  });
+
+  it('rejects unknown keys', () => {
+    const r = kycConfigSchema.safeParse({ ...VALID, hackField: 'x' });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ── retentionConfigSchema ─────────────────────────────────────────────────────
+
+describe('retentionConfigSchema', () => {
+  it('accepts a single field update', () => {
+    expect(retentionConfigSchema.safeParse({ retentionDays: 365 }).success).toBe(true);
+  });
+
+  it('accepts all valid fields together', () => {
+    const r = retentionConfigSchema.safeParse({
+      retentionDays: 90,
+      purgeEnabled: true,
+      batchSize: 200,
+      purgeCron: '0 3 * * 0',
+      legalHoldReasons: ['litigation', 'regulatory'],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty object', () => {
+    expect(retentionConfigSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects retentionDays below 1', () => {
+    expect(retentionConfigSchema.safeParse({ retentionDays: 0 }).success).toBe(false);
+  });
+
+  it('rejects retentionDays above 3650', () => {
+    expect(retentionConfigSchema.safeParse({ retentionDays: 3651 }).success).toBe(false);
+  });
+
+  it('accepts retentionDays at boundary values 1 and 3650', () => {
+    expect(retentionConfigSchema.safeParse({ retentionDays: 1 }).success).toBe(true);
+    expect(retentionConfigSchema.safeParse({ retentionDays: 3650 }).success).toBe(true);
+  });
+
+  it('rejects batchSize above 1000', () => {
+    expect(retentionConfigSchema.safeParse({ batchSize: 1001 }).success).toBe(false);
+  });
+
+  it('rejects purgeCron exceeding 100 chars', () => {
+    expect(retentionConfigSchema.safeParse({ purgeCron: 'x'.repeat(101) }).success).toBe(false);
+  });
+
+  it('rejects legalHoldReasons with more than 20 items', () => {
+    const r = retentionConfigSchema.safeParse({ legalHoldReasons: Array(21).fill('r') });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a legalHoldReason exceeding 100 chars', () => {
+    const r = retentionConfigSchema.safeParse({ legalHoldReasons: ['a'.repeat(101)] });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown keys', () => {
+    const r = retentionConfigSchema.safeParse({ retentionDays: 30, unknown: true });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ── fraudThresholdsSchema ─────────────────────────────────────────────────────
+
+describe('fraudThresholdsSchema', () => {
+  it('accepts updating only fraudCeiling', () => {
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: 5000000 }).success).toBe(true);
+  });
+
+  it('accepts updating only manualReviewThreshold', () => {
+    expect(fraudThresholdsSchema.safeParse({ manualReviewThreshold: 500000 }).success).toBe(true);
+  });
+
+  it('accepts both fields when manualReview <= fraudCeiling', () => {
+    const r = fraudThresholdsSchema.safeParse({
+      fraudCeiling: 10000000,
+      manualReviewThreshold: 1000000,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts equal fraudCeiling and manualReviewThreshold', () => {
+    const r = fraudThresholdsSchema.safeParse({
+      fraudCeiling: 1000000,
+      manualReviewThreshold: 1000000,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty object', () => {
+    expect(fraudThresholdsSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects fraudCeiling below 1', () => {
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: 0 }).success).toBe(false);
+  });
+
+  it('rejects fraudCeiling above 1_000_000_000', () => {
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: 1_000_000_001 }).success).toBe(false);
+  });
+
+  it('accepts fraudCeiling at boundary values 1 and 1_000_000_000', () => {
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: 1 }).success).toBe(true);
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: 1_000_000_000 }).success).toBe(true);
+  });
+
+  it('rejects non-finite fraudCeiling (Infinity)', () => {
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: Infinity }).success).toBe(false);
+  });
+
+  it('rejects non-finite fraudCeiling (NaN)', () => {
+    expect(fraudThresholdsSchema.safeParse({ fraudCeiling: NaN }).success).toBe(false);
+  });
+
+  it('rejects manualReviewThreshold > fraudCeiling', () => {
+    const r = fraudThresholdsSchema.safeParse({
+      fraudCeiling: 1000,
+      manualReviewThreshold: 2000,
+    });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs['manualReviewThreshold']).toMatch(/fraudCeiling/i);
+  });
+
+  it('rejects unknown keys', () => {
+    const r = fraudThresholdsSchema.safeParse({ fraudCeiling: 5000, extra: 'field' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects string values', () => {
+    const r = fraudThresholdsSchema.safeParse({ fraudCeiling: 'ten-thousand' });
+    expect(r.success).toBe(false);
+    expect(parseValidationErrors(r.error).fraudCeiling).toBeDefined();
+  });
+});
+
+// ── runtimeConfigSchema ───────────────────────────────────────────────────────
+
+describe('runtimeConfigSchema', () => {
+  it('accepts a valid webhook section payload', () => {
+    const r = runtimeConfigSchema.safeParse({
+      section: 'webhook',
+      config: {
+        url: 'https://example.com/hook',
+        secret: 'supersecret-16chars',
+        events: ['invoice.created'],
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a valid fraudThresholds section payload', () => {
+    const r = runtimeConfigSchema.safeParse({
+      section: 'fraudThresholds',
+      config: { fraudCeiling: 5000000 },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects missing section field', () => {
+    const r = runtimeConfigSchema.safeParse({
+      config: { fraudCeiling: 5000000 },
+    });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.section).toBeDefined();
+  });
+
+  it('rejects unknown section value', () => {
+    const r = runtimeConfigSchema.safeParse({
+      section: 'unknownSection',
+      config: { foo: 'bar' },
+    });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.section).toBeDefined();
+  });
+
+  it('rejects missing config field', () => {
+    const r = runtimeConfigSchema.safeParse({ section: 'webhook' });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs.config).toBeDefined();
+  });
+
+  it('rejects unknown top-level keys', () => {
+    const r = runtimeConfigSchema.safeParse({
+      section: 'retention',
+      config: { retentionDays: 90 },
+      extraKey: 'bad',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('propagates section-level field errors with "config." prefix', () => {
+    const r = runtimeConfigSchema.safeParse({
+      section: 'webhook',
+      config: {
+        url: 'https://example.com/hook',
+        secret: 'tooshort',   // < 16 chars — should fail
+        events: ['invoice.created'],
+      },
+    });
+    expect(r.success).toBe(false);
+    const errs = parseValidationErrors(r.error);
+    expect(errs['config.secret']).toBeDefined();
+  });
+
+  it('propagates unknown-key error from inner section schema', () => {
+    const r = runtimeConfigSchema.safeParse({
+      section: 'kyc',
+      config: {
+        providerUrl: 'https://kyc.example.com',
+        apiKey: 'validapikey-8chars',
+        unknownField: 'oops',
+      },
+    });
+    expect(r.success).toBe(false);
+    // Zod v4 strict() emits unrecognized_keys at path ['config'] → 'config'
+    const errs = parseValidationErrors(r.error);
+    expect(errs['config']).toMatch(/unknownField/);
+  });
+
+  it('lists all expected sections in CONFIG_SECTIONS', () => {
+    const expected = ['webhook', 'reconciliation', 'kyc', 'retention', 'fraudThresholds'];
+    expect(CONFIG_SECTIONS).toEqual(expect.arrayContaining(expected));
+    expect(CONFIG_SECTIONS).toHaveLength(expected.length);
+  });
+});
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SECTION 2 — HTTP integration tests (POST /api/admin/config)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/admin/config', () => {
+  // ── Auth ───────────────────────────────────────────────────────────────────
+
+  describe('authentication', () => {
+    it('returns 401 when no Authorization header is supplied', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .send({ section: 'webhook', config: {} });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when the JWT is malformed', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', 'Bearer not.a.jwt')
+        .send({ section: 'webhook', config: {} });
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts a valid Bearer token', async () => {
+      // Body is invalid but we want to verify auth passes (expect 400, not 401)
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'webhook', config: { url: 'bad', secret: 'short', events: [] } });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Valid payloads ──────────────────────────────────────────────────────────
+
+  describe('valid payloads — 200 responses', () => {
+    it('accepts a valid webhook config and echoes it back', async () => {
+      const payload = {
+        section: 'webhook',
+        config: {
+          url: 'https://hooks.example.com/delivery',
+          secret: 'a-valid-secret-that-is-long-enough',
+          events: ['invoice.created', 'invoice.paid'],
+          maxRetries: 5,
+          timeoutMs: 10000,
+          enabled: true,
+        },
+      };
+
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send(payload);
+
+      expect(res.status).toBe(200);
+      expect(res.body.section).toBe('webhook');
+      expect(res.body.config.url).toBe(payload.config.url);
+      expect(res.body.message).toMatch(/webhook/i);
+    });
+
+    it('accepts a valid reconciliation config', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'reconciliation',
+          config: { batchSize: 100, enabled: true },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.section).toBe('reconciliation');
+    });
+
+    it('accepts a valid kyc config', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'kyc',
+          config: {
+            providerUrl: 'https://kyc.provider.example.com',
+            apiKey: 'validapikey-min8',
+            retries: 2,
+          },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.section).toBe('kyc');
+    });
+
+    it('accepts a valid retention config', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'retention',
+          config: { retentionDays: 365, purgeEnabled: false },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.section).toBe('retention');
+    });
+
+    it('accepts a valid fraudThresholds config', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'fraudThresholds',
+          config: { fraudCeiling: 10000000, manualReviewThreshold: 1000000 },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.section).toBe('fraudThresholds');
+    });
+  });
+
+  // ── Missing fields ──────────────────────────────────────────────────────────
+
+  describe('missing required fields — 400 responses', () => {
+    it('returns 400 with fieldError for missing section', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ config: { fraudCeiling: 5000000 } });
+
+      expect(res.status).toBe(400);
+      expect(res.body.status).toBe(400);
+      expect(res.body.fieldErrors.section).toBeDefined();
+    });
+
+    it('returns 400 with fieldError for missing config', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'webhook' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors.config).toBeDefined();
+    });
+
+    it('returns 400 with machine-readable code VALIDATION_ERROR', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({});
+
+      expect(res.status).toBe(400);
+      // validateBody returns RFC 7807 shape
+      expect(res.body.type).toContain('validation-error');
+      expect(res.body.title).toMatch(/validation/i);
+    });
+  });
+
+  // ── Wrong types ─────────────────────────────────────────────────────────────
+
+  describe('wrong types — 400 responses', () => {
+    it('returns 400 when section is a number', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 42, config: {} });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors.section).toBeDefined();
+    });
+
+    it('returns 400 when config is an array instead of object', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'retention', config: [1, 2, 3] });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when a numeric field receives a string', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'fraudThresholds',
+          config: { fraudCeiling: 'ten-million' },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors['config.fraudCeiling']).toBeDefined();
+    });
+
+    it('returns 400 when boolean field receives a string', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'webhook',
+          config: {
+            url: 'https://hooks.example.com',
+            secret: 'a-valid-secret-at-least-16chars',
+            events: ['invoice.created'],
+            enabled: 'yes',       // should be boolean
+          },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors['config.enabled']).toBeDefined();
+    });
+  });
+
+  // ── Oversized strings ───────────────────────────────────────────────────────
+
+  describe('oversized strings — 400 responses', () => {
+    it('returns 400 when webhook secret exceeds 256 chars', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'webhook',
+          config: {
+            url: 'https://hooks.example.com',
+            secret: 's'.repeat(257),
+            events: ['invoice.created'],
+          },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors['config.secret']).toMatch(/256/);
+    });
+
+    it('returns 400 when an event name exceeds 100 chars', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'webhook',
+          config: {
+            url: 'https://hooks.example.com',
+            secret: 'valid-secret-minimum-16',
+            events: ['e'.repeat(101)],
+          },
+        });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when KYC apiKey exceeds 256 chars', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'kyc',
+          config: {
+            providerUrl: 'https://kyc.example.com',
+            apiKey: 'k'.repeat(257),
+          },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors['config.apiKey']).toMatch(/256/);
+    });
+
+    it('returns 400 when scheduleExpression exceeds 100 chars', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'reconciliation',
+          config: { scheduleExpression: 'x'.repeat(101) },
+        });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Boundary numbers ────────────────────────────────────────────────────────
+
+  describe('boundary numbers', () => {
+    it('accepts retentionDays at exact lower bound (1)', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'retention', config: { retentionDays: 1 } });
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts retentionDays at exact upper bound (3650)', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'retention', config: { retentionDays: 3650 } });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects retentionDays one above upper bound (3651)', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'retention', config: { retentionDays: 3651 } });
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts fraudCeiling at exact lower bound (1)', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'fraudThresholds', config: { fraudCeiling: 1 } });
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts fraudCeiling at exact upper bound (1_000_000_000)', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'fraudThresholds', config: { fraudCeiling: 1_000_000_000 } });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects fraudCeiling one above upper bound', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'fraudThresholds', config: { fraudCeiling: 1_000_000_001 } });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects manualReviewThreshold > fraudCeiling', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'fraudThresholds',
+          config: { fraudCeiling: 1000, manualReviewThreshold: 2000 },
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors['config.manualReviewThreshold']).toMatch(/fraudCeiling/i);
+    });
+  });
+
+  // ── Unknown fields ──────────────────────────────────────────────────────────
+
+  describe('unknown fields — 400 responses', () => {
+    it('returns 400 for unknown top-level key', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'retention',
+          config: { retentionDays: 30 },
+          injectedTopLevel: 'evil',   // unknown key — strict() rejects
+        });
+      expect(res.status).toBe(400);
+      // _root is the mapped path for top-level unrecognized_keys
+      expect(res.body.fieldErrors._root).toMatch(/injectedTopLevel/);
+    });
+
+    it('returns 400 for unknown key inside config object', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'kyc',
+          config: {
+            providerUrl: 'https://kyc.example.com',
+            apiKey: 'validapikey-min8',
+            injectedField: 'DROP TABLE users;',
+          },
+        });
+
+      expect(res.status).toBe(400);
+      // Zod v4 strict() reports unrecognized_keys at path ['config'] → 'config'
+      expect(res.body.fieldErrors['config']).toMatch(/injectedField/);
+    });
+
+    it('returns 400 for unknown section name', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'superSecretSection', config: { anything: true } });
+
+      expect(res.status).toBe(400);
+      expect(res.body.fieldErrors.section).toBeDefined();
+    });
+  });
+
+  // ── Response shape ──────────────────────────────────────────────────────────
+
+  describe('400 response shape (RFC 7807)', () => {
+    it('returns application/json content-type', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.headers['content-type']).toMatch(/json/);
+    });
+
+    it('includes type, title, status, detail, and fieldErrors', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({ section: 'fraudThresholds', config: { fraudCeiling: 'bad' } });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        type: expect.stringContaining('validation-error'),
+        title: expect.any(String),
+        status: 400,
+        detail: expect.any(String),
+        fieldErrors: expect.any(Object),
+      });
+    });
+
+    it('fieldErrors keys are navigable dot-notation paths', async () => {
+      const res = await request(APP)
+        .post('/api/admin/config')
+        .set('Authorization', AUTH)
+        .send({
+          section: 'webhook',
+          config: { url: 'bad-url', secret: 'short', events: [] },
+        });
+
+      expect(res.status).toBe(400);
+      // At least one key must start with "config."
+      const keys = Object.keys(res.body.fieldErrors);
+      const hasPrefixed = keys.some((k) => k.startsWith('config.'));
+      expect(hasPrefixed).toBe(true);
+    });
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SECTION 3 — GET /api/admin/config/sections
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('GET /api/admin/config/sections', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(APP).get('/api/admin/config/sections');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with sections array when authenticated', async () => {
+    const res = await request(APP)
+      .get('/api/admin/config/sections')
+      .set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.sections)).toBe(true);
+    expect(res.body.sections).toContain('webhook');
+    expect(res.body.sections).toContain('fraudThresholds');
+    expect(res.body.sections).toHaveLength(CONFIG_SECTIONS.length);
+  });
+});


### PR DESCRIPTION
Add strict Zod input validation for all admin-writable config sections.

- src/schemas/config.js: five section schemas (webhook, reconciliation, kyc, retention, fraudThresholds) plus a top-level runtimeConfigSchema. Every schema uses .strict() to reject unknown keys; strings are length- bounded; numerics are range-checked; categoricals use enum allowlists. Validation failures produce a machine-readable fieldErrors map.

- src/routes/adminConfig.js: POST /api/admin/config validates the incoming body via validateBody(runtimeConfigSchema) and returns an RFC 7807 400 problem+json response (type, title, status, detail, fieldErrors) on any failure. GET /api/admin/config/sections lists valid section names. Both routes are protected by adminStack.

- src/app.js: mount adminConfigRoutes at /api/admin/config.

- tests/unit/adminConfig.validation.test.js: 104 tests covering all five section schemas (valid payloads, missing fields, wrong types, oversized strings, boundary numbers, unknown-key injection) and HTTP integration tests for auth, 200/400 paths, and RFC 7807 shape.

All 104 tests pass. ESLint clean.
"closes #663 