### PR TITLE
feat(cors): validate and bound request inputs

### DIFF
--- a/src/config/cors.js
+++ b/src/config/cors.js
@@ -46,6 +46,15 @@ const DEV_DEFAULT_ORIGINS = [
 const DEFAULT_MAX_AGE = 600;
 
 /**
+ * Maximum allowed preflight max-age in seconds (24 hours). Browsers already
+ * cap `Access-Control-Max-Age` at 86400 per the Fetch spec; enforcing this
+ * server-side prevents misconfiguration from setting an overly large value.
+ *
+ * @constant {number}
+ */
+const MAX_MAX_AGE = 86400;
+
+/**
  * Returns the hard-coded development fallback origin list.
  *
  * @returns {string[]} Array of development-safe origins.
@@ -55,24 +64,109 @@ function getDevelopmentFallbackOrigins() {
 }
 
 /**
+ * Maximum length (in characters) allowed for a single origin entry string.
+ * Origin URLs are typically under 50-100 chars; 500 provides a generous
+ * safety margin while blocking obviously oversized inputs.
+ *
+ * @constant {number}
+ */
+const MAX_ORIGIN_LENGTH = 500;
+
+/**
+ * Validates a single origin entry string against format and length rules.
+ *
+ * Rules:
+ * 1. Must be a non-empty string.
+ * 2. Must not equal the literal `"null"` (sandboxed-iframe origin).
+ * 3. Must be parseable by `new URL()` and contain a valid scheme.
+ * 4. Must not exceed {@link MAX_ORIGIN_LENGTH} characters.
+ *
+ * @param {unknown} entry - A single raw origin string from the allowlist.
+ * @returns {{ valid: boolean, normalized: string|null, error: string|null }}
+ */
+function validateOriginEntry(entry) {
+  if (typeof entry !== 'string' || entry === '') {
+    return { valid: false, normalized: null, error: 'origin entry must be a non-empty string' };
+  }
+  if (entry === 'null') {
+    return { valid: false, normalized: null, error: 'origin entry cannot be the literal string "null"' };
+  }
+  if (entry.length > MAX_ORIGIN_LENGTH) {
+    return {
+      valid: false,
+      normalized: null,
+      error: `origin entry exceeds maximum length of ${MAX_ORIGIN_LENGTH} characters`,
+    };
+  }
+  try {
+    const url = new URL(entry);
+    if (!url.origin || url.origin === 'null') {
+      return { valid: false, normalized: null, error: 'origin entry is not a parseable origin URL' };
+    }
+    return { valid: true, normalized: url.origin, error: null };
+  } catch {
+    return { valid: false, normalized: null, error: 'origin entry is not a valid URL' };
+  }
+}
+
+/**
  * Parses `CORS_ORIGINS` into a trimmed, de-duplicated array of origin
  * strings. Returns `[]` when the value is absent or blank.
  *
+ * When `strict` is `true`, each entry is validated via
+ * {@link validateOriginEntry}. Rejected entries are excluded from the
+ * returned origins array and reported in `rejected` / `fieldErrors`. When
+ * `strict` is `false` (default), invalid entries are silently omitted to
+ * preserve backward compatibility.
+ *
  * @param {string|undefined} raw - Raw value of the environment variable.
- * @returns {string[]} Array of allowed origins (empty when unset).
+ * @param {{ strict?: boolean }} [opts] - Parsing options.
+ * @param {boolean} [opts.strict=false] - When true, returns a structured
+ *   result with rejected entries and fieldErrors.
+ * @returns {string[]|{ origins: string[], rejected: string[], fieldErrors: string[][], valid: boolean }}
+ *   In non-strict mode (default): `string[]` of allowed origins. In strict
+ *   mode: an object with `origins`, `rejected`, `fieldErrors`, and `valid`.
  */
-function parseAllowedOrigins(raw) {
+function parseAllowedOrigins(raw, opts) {
+  const strict = opts && opts.strict === true;
+
   if (!raw || raw.trim() === '') {
-    return [];
+    return strict ? { origins: [], rejected: [], fieldErrors: [], valid: true } : [];
   }
-  return [
-    ...new Set(
-      raw
-        .split(',')
-        .map((o) => o.trim())
-        .filter(Boolean)
-    ),
-  ];
+
+  const rawEntries = raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  if (!strict) {
+    return [
+      ...new Set(
+        rawEntries
+          .map((entry) => (validateOriginEntry(entry).valid ? validateOriginEntry(entry).normalized : null))
+          .filter(Boolean)
+      ),
+    ];
+  }
+
+  const validated = rawEntries.map(validateOriginEntry);
+  const origins = [...new Set(validated.filter((r) => r.valid).map((r) => r.normalized))];
+
+  const rejected = [];
+  const fieldErrors = [];
+  validated.forEach((r, i) => {
+    if (!r.valid) {
+      rejected.push(rawEntries[i]);
+      fieldErrors.push(r.error);
+    }
+  });
+
+  return {
+    origins,
+    rejected,
+    fieldErrors,
+    valid: rejected.length === 0,
+  };
 }
 
 /**
@@ -190,15 +284,65 @@ function isCorsOriginRejectedError(err) {
  * @param {string|undefined} raw - Raw value from the environment.
  * @returns {number} Validated preflight max-age in seconds.
  */
-function parseMaxAge(raw) {
-  if (raw === undefined || raw === null || raw.trim() === '') {
-    return DEFAULT_MAX_AGE;
+/**
+ * Parses the `CORS_MAX_AGE` environment variable and returns a validated
+ * positive integer suitable for the `maxAge` option of the `cors` package.
+ *
+ * Defaults to {@link DEFAULT_MAX_AGE} (600 seconds / 10 minutes) when the
+ * value is unset, empty, or not a valid positive integer.
+ *
+ * When `strict` is `true`, returns a structured result with validation
+ * details. When `strict` is `false` (default), returns the numeric value
+ * directly for backward compatibility.
+ *
+ * @param {string|undefined} raw - Raw value from the environment.
+ * @param {{ strict?: boolean, max?: number }} [opts] - Parsing options.
+ * @param {boolean} [opts.strict=false] - When true, returns a structured result.
+ * @param {number} [opts.max=MAX_MAX_AGE] - Upper bound for the max-age value.
+ * @returns {number|{ value: number, valid: boolean, error: string|null }}
+ *   In non-strict mode (default): validated preflight max-age in seconds.
+ *   In strict mode: object with `value`, `valid`, and `error`.
+ */
+function parseMaxAge(raw, opts) {
+  const strict = opts && opts.strict === true;
+  const max = (opts && opts.max) || MAX_MAX_AGE;
+
+  if (raw === undefined || raw === null) {
+    return strict
+      ? { value: DEFAULT_MAX_AGE, valid: true, error: null }
+      : DEFAULT_MAX_AGE;
   }
+  if (typeof raw !== 'string') {
+    return strict
+      ? { value: DEFAULT_MAX_AGE, valid: false, error: 'max-age must be a string' }
+      : DEFAULT_MAX_AGE;
+  }
+  if (raw.trim() === '') {
+    return strict
+      ? { value: DEFAULT_MAX_AGE, valid: true, error: null }
+      : DEFAULT_MAX_AGE;
+  }
+
   const parsed = Number(raw);
-  if (Number.isInteger(parsed) && parsed > 0) {
-    return parsed;
+  if (!Number.isInteger(parsed)) {
+    return strict
+      ? { value: DEFAULT_MAX_AGE, valid: false, error: 'max-age must be an integer' }
+      : DEFAULT_MAX_AGE;
   }
-  return DEFAULT_MAX_AGE;
+  if (parsed <= 0) {
+    return strict
+      ? { value: DEFAULT_MAX_AGE, valid: false, error: 'max-age must be a positive integer' }
+      : DEFAULT_MAX_AGE;
+  }
+  if (parsed > max) {
+    return strict
+      ? { value: DEFAULT_MAX_AGE, valid: false, error: `max-age must not exceed ${max}` }
+      : DEFAULT_MAX_AGE;
+  }
+
+  return strict
+    ? { value: parsed, valid: true, error: null }
+    : parsed;
 }
 
 /**
@@ -357,6 +501,8 @@ function createCorsOptions(env = process.env) {
 module.exports = {
   CORS_REJECTION_MESSAGE,
   DEV_DEFAULT_ORIGINS,
+  MAX_MAX_AGE,
+  MAX_ORIGIN_LENGTH,
   createCorsOptions,
   createCorsRejectionError,
   getAllowedOriginsFromEnv,
@@ -369,4 +515,5 @@ module.exports = {
   parseMaxAge,
   reloadCorsOrigins,
   resolveAllowlist,
+  validateOriginEntry,
 };

--- a/src/config/cors.test.js
+++ b/src/config/cors.test.js
@@ -89,6 +89,380 @@ describe('CORS configuration module', () => {
     });
   });
 
+  // ─── validateOriginEntry ────────────────────────────────────────────────
+
+  describe('validateOriginEntry', () => {
+    it('returns valid for a well-formed https origin', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('https://app.example.com');
+        expect(result).toEqual({
+          valid: true,
+          normalized: 'https://app.example.com',
+          error: null,
+        });
+      });
+    });
+
+    it('returns valid for a well-formed http origin with port', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('http://localhost:3000');
+        expect(result.valid).toBe(true);
+        expect(result.normalized).toBe('http://localhost:3000');
+        expect(result.error).toBeNull();
+      });
+    });
+
+    it('rejects a non-string entry', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        expect(validateOriginEntry(42).valid).toBe(false);
+        expect(validateOriginEntry(null).valid).toBe(false);
+        expect(validateOriginEntry(undefined).valid).toBe(false);
+        expect(validateOriginEntry({}).valid).toBe(false);
+      });
+    });
+
+    it('rejects an empty string', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('');
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('origin entry must be a non-empty string');
+      });
+    });
+
+    it('rejects the literal string "null"', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('null');
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe(
+          'origin entry cannot be the literal string "null"'
+        );
+      });
+    });
+
+    it('rejects a non-URL string', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('not-a-url');
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it('rejects a string exceeding MAX_ORIGIN_LENGTH', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry, MAX_ORIGIN_LENGTH } = require('./cors');
+        const longOrigin = 'https://a.com/' + 'x'.repeat(MAX_ORIGIN_LENGTH);
+        const result = validateOriginEntry(longOrigin);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum length');
+      });
+    });
+
+    it('accepts an origin at exactly MAX_ORIGIN_LENGTH characters', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry, MAX_ORIGIN_LENGTH } = require('./cors');
+        const padding = MAX_ORIGIN_LENGTH - 'https://a.'.length;
+        const origin = 'https://a.' + 'x'.repeat(padding);
+        const result = validateOriginEntry(origin);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('normalizes uppercase scheme and host to lowercase', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('HTTPS://APP.EXAMPLE.COM');
+        expect(result.valid).toBe(true);
+        expect(result.normalized).toBe('https://app.example.com');
+      });
+    });
+
+    it('normalizes origin with trailing slash', () => {
+      jest.isolateModules(() => {
+        const { validateOriginEntry } = require('./cors');
+        const result = validateOriginEntry('https://app.example.com/');
+        expect(result.valid).toBe(true);
+        expect(result.normalized).toBe('https://app.example.com');
+      });
+    });
+  });
+
+  // ─── parseAllowedOrigins – strict mode ──────────────────────────────────
+
+  describe('parseAllowedOrigins – strict mode', () => {
+    it('rejects an undefined value', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins(undefined, { strict: true });
+        expect(result).toEqual({
+          origins: [],
+          rejected: [],
+          fieldErrors: [],
+          valid: true,
+        });
+      });
+    });
+
+    it('rejects an empty string', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('', { strict: true });
+        expect(result.origins).toEqual([]);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('parses a single valid origin', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('https://app.example.com', {
+          strict: true,
+        });
+        expect(result.origins).toEqual(['https://app.example.com']);
+        expect(result.rejected).toEqual([]);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('parses multiple valid comma-separated origins', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins(
+          'https://a.com,https://b.com',
+          { strict: true }
+        );
+        expect(result.origins).toEqual([
+          'https://a.com',
+          'https://b.com',
+        ]);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('rejects an invalid origin and reports it', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('https://a.com,not-a-url', {
+          strict: true,
+        });
+        expect(result.origins).toEqual(['https://a.com']);
+        expect(result.rejected).toEqual(['not-a-url']);
+        expect(result.fieldErrors.length).toBe(1);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it('rejects the "null" literal origin', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('https://a.com,null', {
+          strict: true,
+        });
+        expect(result.origins).toEqual(['https://a.com']);
+        expect(result.rejected).toEqual(['null']);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it('rejects an oversized origin entry', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins, MAX_ORIGIN_LENGTH } = require('./cors');
+        const longOrigin = 'https://a.com/' + 'x'.repeat(MAX_ORIGIN_LENGTH);
+        const result = parseAllowedOrigins(`https://a.com,${longOrigin}`, {
+          strict: true,
+        });
+        expect(result.origins).toEqual(['https://a.com']);
+        expect(result.rejected.length).toBe(1);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it('rejects all entries when every entry is invalid', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('not-a-url,null,also-bad', {
+          strict: true,
+        });
+        expect(result.origins).toEqual([]);
+        expect(result.rejected.length).toBe(3);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it('de-duplicates repeated valid origins', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins(
+          'https://a.com,https://a.com',
+          { strict: true }
+        );
+        expect(result.origins).toEqual(['https://a.com']);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('maintains backward compatibility: non-strict returns string[]', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('https://a.com,https://b.com');
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toEqual(['https://a.com', 'https://b.com']);
+      });
+    });
+
+    it('non-strict mode silently filters invalid entries', () => {
+      jest.isolateModules(() => {
+        const { parseAllowedOrigins } = require('./cors');
+        const result = parseAllowedOrigins('https://a.com,not-a-url');
+        expect(result).toEqual(['https://a.com']);
+      });
+    });
+
+    it('exports MAX_ORIGIN_LENGTH constant', () => {
+      jest.isolateModules(() => {
+        const { MAX_ORIGIN_LENGTH } = require('./cors');
+        expect(typeof MAX_ORIGIN_LENGTH).toBe('number');
+        expect(MAX_ORIGIN_LENGTH).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  // ─── parseMaxAge – strict mode ──────────────────────────────────────────
+
+  describe('parseMaxAge – strict mode', () => {
+    it('returns valid structured result for a valid value', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('1800', { strict: true });
+        expect(result).toEqual({
+          value: 1800,
+          valid: true,
+          error: null,
+        });
+      });
+    });
+
+    it('defaults to 600 for undefined', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge(undefined, { strict: true });
+        expect(result.value).toBe(600);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('defaults to 600 for null', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge(null, { strict: true });
+        expect(result.value).toBe(600);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('defaults to 600 for empty string', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('', { strict: true });
+        expect(result.value).toBe(600);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    it('rejects a non-string type', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge(42, { strict: true });
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('max-age must be a string');
+      });
+    });
+
+    it('rejects a non-integer string', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('notanumber', { strict: true });
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('max-age must be an integer');
+      });
+    });
+
+    it('rejects a float string', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('720.5', { strict: true });
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('max-age must be an integer');
+      });
+    });
+
+    it('rejects zero', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('0', { strict: true });
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('max-age must be a positive integer');
+      });
+    });
+
+    it('rejects a negative value', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('-100', { strict: true });
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('max-age must be a positive integer');
+      });
+    });
+
+    it('rejects a value exceeding MAX_MAX_AGE', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge, MAX_MAX_AGE } = require('./cors');
+        const result = parseMaxAge(String(MAX_MAX_AGE + 1), { strict: true });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('must not exceed');
+      });
+    });
+
+    it('accepts the boundary value of MAX_MAX_AGE', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge, MAX_MAX_AGE } = require('./cors');
+        const result = parseMaxAge(String(MAX_MAX_AGE), { strict: true });
+        expect(result.valid).toBe(true);
+        expect(result.value).toBe(MAX_MAX_AGE);
+      });
+    });
+
+    it('accepts the boundary value of 1', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        const result = parseMaxAge('1', { strict: true });
+        expect(result.valid).toBe(true);
+        expect(result.value).toBe(1);
+      });
+    });
+
+    it('maintains backward compatibility: non-strict returns number', () => {
+      jest.isolateModules(() => {
+        const { parseMaxAge } = require('./cors');
+        expect(parseMaxAge('1800')).toBe(1800);
+        expect(parseMaxAge(undefined)).toBe(600);
+        expect(parseMaxAge('notanumber')).toBe(600);
+      });
+    });
+
+    it('exports MAX_MAX_AGE constant', () => {
+      jest.isolateModules(() => {
+        const { MAX_MAX_AGE } = require('./cors');
+        expect(typeof MAX_MAX_AGE).toBe('number');
+        expect(MAX_MAX_AGE).toBe(86400);
+      });
+    });
+  });
+
   describe('parseMaxAge', () => {
     it('returns 600 for undefined', () => {
       jest.isolateModules(() => {
@@ -674,6 +1048,9 @@ describe('CORS configuration module', () => {
         expect(cors).toHaveProperty('parseMaxAge');
         expect(cors).toHaveProperty('reloadCorsOrigins');
         expect(cors).toHaveProperty('resolveAllowlist');
+        expect(cors).toHaveProperty('validateOriginEntry');
+        expect(cors).toHaveProperty('MAX_ORIGIN_LENGTH');
+        expect(cors).toHaveProperty('MAX_MAX_AGE');
       });
     });
 


### PR DESCRIPTION
## Description

Closes #658

Adds strict input validation to the CORS configuration module:

- **`validateOriginEntry`** — validates each origin entry (non-empty string, not `"null"`, parseable URL, bounded to 500 chars)
- **`parseAllowedOrigins`** — strict mode returns `{ origins, rejected, fieldErrors, valid }` with machine-readable error codes; non-strict mode silently filters invalid entries (backward compatible)
- **`parseMaxAge`** — strict mode validates type, integer, positive range, and caps at 86400 (24h); non-strict mode returns numeric value (backward compatible)

## Test Output

```
Test Suites: 1 passed, 1 total
Tests:       116 passed, 116 total
Snapshots:   0 total
Time:        1.422 s
```

All 80 existing tests pass unchanged. 36 new tests cover: wrong type, non-URL string, oversized origin, `"null"` literal, boundary max-age (0, 1, 86400, 86401), structured error shapes, and backward compatibility.