### PR TITLE
feat(observability): add Soroban RPC latency histograms and retry-cause counters

### DIFF
--- a/src/services/soroban.test.js
+++ b/src/services/soroban.test.js
@@ -99,6 +99,28 @@ describe('Soroban Integration Wrapper', () => {
       expect(metricsText).not.toContain(secretLikeMethod);
     });
 
+    it('records an error latency outcome when the call fails with a non-transient error', async () => {
+      // Non-transient errors use outcome="error" distinct from
+      // "circuit_open" and "success" branches in callSorobanContract.
+      const operation = jest.fn().mockRejectedValue(new Error('Invalid arguments'));
+
+      await expect(
+        callSorobanContract(operation, {
+          maxRetries: 0,
+          baseDelay: 0,
+          maxDelay: 0,
+          metricMethod: 'contract_call',
+        })
+      ).rejects.toThrow('Invalid arguments');
+
+      const metricsText = await getMetricsText();
+      expect(metricsText).toMatch(
+        /soroban_rpc_call_duration_seconds_count\{method="contract_call",outcome="error"\} 1/
+      );
+      // Method and outcome are the only labels on the histogram — no extras.
+      expect(metricsText).not.toMatch(/soroban_rpc_call_duration_seconds_count\{[^}]*,[^}]*,[^}]*\}/);
+    });
+
     it('should fail immediately on non-transient error', async () => {
       const error = new Error('Invalid arguments');
       const operation = jest.fn().mockRejectedValue(error);


### PR DESCRIPTION
Closes #595

## Summary

Added Prometheus latency histograms and retry-cause counters for Soroban RPC calls while preserving existing retry behavior and keeping metric labels bounded and secure.

## Scope of this PR

The Soroban RPC latency histogram (`soroban_rpc_call_duration_seconds` with labels {method, outcome}), the retry-cause counter (`soroban_rpc_retry_causes_total` with label cause ∈ {timeout, 429, 5xx, unknown}), the callSorobanContract()/withRetry() instrumentation, JSDoc, README documentation, and most tests were already shipped in commit `948b0f43` on `main` before this PR. This PR adds the missing Jest test `records an error latency outcome when the call fails with a non-transient error` in `src/services/soroban.test.js` to explicitly satisfy the rejected-list requirement that a failed call records histogram with the bounded outcome label `error`.

## Changes Made

- Added Soroban RPC latency histogram test for the failure path (outcome=error)
- Confirmed retry-cause counters test coverage for timeout, 429, 5xx
- Confirmed prom-client shim path is wrapped in safe no-ops
- Confirmed no secrets/payloads/IDs leak into metric labels

## Files Changed

- src/services/soroban.test.js (added 1 test for failed-call latency recording)

## Files Already Changed in main (commit 948b0f43)

- src/metrics.js
- src/services/soroban.js
- tests/metrics.test.js
- src/services/soroban.test.js
- README.md

## Testing Performed

- npx jest src/services/soroban.test.js — 21 of 22 pass; the 1 failing test references `metrics.sorobanRetryBudgetExhaustedTotal` which is unrelated to Issue #595 (see Report section)
- npx eslint src/services/soroban.test.js — 1 pre-existing `computeBackoff` unused-var error unrelated to this PR

## Security Notes

- No request payloads in metric labels
- No secrets in metric labels
- Bounded label cardinality (method x outcome histogram; single cause counter)
- Retry logic unchanged
- Backoff unchanged (exponential backoff with ±20% jitter preserved)
- Prom-client fallback preserved as safe no-op

## Backwards Compatibility

Fully backwards compatible. Existing APIs and retry behavior remain unchanged.

## Unrelated Pre-Existing Issues (Reported Separately)

Per the strict execution rules of this PR, the following pre-existing failures are **not** fixed here — they are out of scope for Issue #595:

1. **`metrics.sorobanRetryBudgetExhaustedTotal` is undefined.** `src/services/soroban.js` withRetry() calls `metrics.sorobanRetryBudgetExhaustedTotal.inc()` but the counter is never defined in `src/metrics.js` and is not exported. The existing call site is guarded with a truthy check so it never throws, but the test `should increment the budget exhausted metric when budget is exceeded` in `src/services/soroban.test.js` fails with "Cannot use spyOn on a primitive value; undefined given". Recommend a follow-up PR to define this counter.
2. **`metrics.sorobanCircuitBreakerStateTransitionsTotal.labelNames` is undefined.** Test `sorobanCircuitBreakerStateTransitionsTotal has expected labelNames` in `tests/metrics.test.js` fails with `TypeError: Cannot read properties of undefined (reading 'labelNames')`. Looks like a shim-vs-registry mismatch in tests.
3. **`metrics.registry.metrics()` returns an object, not a string, in shim mode.** Test `returns Prometheus text before any transition` fails because the registry shim does not return a string. The real prom-client path is unaffected.