### PR TITLE
test(escrow-map): cover cacheEnabled:false and defaultEnvironment fal…

### DIFF
--- a/tests/escrowMap.test.js
+++ b/tests/escrowMap.test.js
@@ -160,6 +160,21 @@ describe('escrowMap – resolveEscrowAddress', () => {
     process.env.NODE_ENV = originalNodeEnv;
   });
 
+  it('falls back to the "development" environment when defaultEnvironment is omitted entirely', () => {
+    delete process.env.NODE_ENV;
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'development', isActive: true },
+      ],
+      allowlistEnabled: false,
+      // defaultEnvironment intentionally omitted
+    });
+    _resetCache();
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
   // ── allowlistEnabled behavior ─────────────────────────────────────────────
 
   it('resolves normally when allowlistEnabled is true and address is in the mappings', () => {
@@ -346,6 +361,32 @@ describe('escrowMap – module-level cache', () => {
     const second = resolveEscrowAddress('inv_001');
     expect(first).toBe(ADDR_A);
     expect(second).toBe(ADDR_A); // still cached
+  });
+
+  it('rebuilds on every call when cacheEnabled is false, without waiting for TTL or calling _resetCache()', () => {
+    setConfig({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_A, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+      cacheEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_A);
+
+    // Swap env directly — no _resetCache() call. With cacheEnabled: false,
+    // _getConfig() must re-parse on every call regardless of cacheTtlSeconds.
+    process.env.ESCROW_ADDR_BY_INVOICE = JSON.stringify({
+      mappings: [
+        { invoiceId: 'inv_001', escrowAddress: ADDR_B, environment: 'test', isActive: true },
+      ],
+      defaultEnvironment: 'test',
+      allowlistEnabled: false,
+      cacheEnabled: false,
+    });
+
+    expect(resolveEscrowAddress('inv_001')).toBe(ADDR_B);
   });
 
   it('picks up the new config after _resetCache()', () => {


### PR DESCRIPTION
Closes #578

---

## Summary

`src/config/escrowMap.js` resolves an `invoiceId` to its on-chain `LiquifactEscrow` contract address (and the reverse: contract address → `invoiceId`), and sits on the capital-movement path used by `src/routes/invest.js` and `src/services/investService.js`. A resolution mistake here routes investor funds to the wrong contract, so this issue asked for dedicated coverage of resolution, allowlist gating, environment filtering, and TTL cache behavior.

**Note:** `tests/escrowMap.test.js` already exists on `main` with 32 passing tests and 96.72% coverage on this module — the "no dedicated test file" premise in the issue is stale. Rather than duplicate that coverage, this PR is a small additive change that closes the two remaining gaps to reach 100%:

- `cacheEnabled: false` forcing an immediate config rebuild on every call (previously untested branch, `escrowMap.js:167-168`).
- The `defaultEnvironment` fallback to `"development"` when omitted from config entirely (previously untested branch, `escrowMap.js:107`).

## Config schema / resolution rules (for reviewers)

```jsonc
// ESCROW_ADDR_BY_INVOICE
{
  "mappings": [
    {
      "invoiceId": "inv_001",
      "escrowAddress": "GABC...123",   // must pass isValidStellarAddress (G or C StrKey)
      "environment": "production",
      "isActive": true
    }
  ],
  "defaultEnvironment": "production", // used when NODE_ENV is unset; falls back to "development" if also absent
  "allowlistEnabled": true,           // currently informational only — see note below
  "cacheEnabled": true,               // false = re-parse env on every call
  "cacheTtlSeconds": 300              // config rebuilds after this many seconds
}


Resolution rules (resolveEscrowAddress / resolveInvoiceByAddress):

A match requires invoiceId (or escrowAddress for reverse lookup) and isActive !== false and environment === currentEnvironment (NODE_ENV, falling back to defaultEnvironment, falling back to "development").
No match → EscrowNotFoundError (forward) or null (reverse). There is no default-address fallback in either direction, regardless of allowlistEnabled.
Malformed ESCROW_ADDR_BY_INVOICE JSON, a non-array mappings, or any mapping with a missing invoiceId / invalid escrowAddress → EscrowMapConfigError at first use (fails closed, never silently drops the bad entry).
Observation, not fixed here: allowlistEnabled is parsed into config but not read anywhere else in the module or its callers — the fail-closed "must be an explicit active mapping" behavior is unconditional, not gated by this flag. Tests assert this explicitly (allowlistEnabled: false still blocks unmapped addresses) so a future change can't accidentally wire the flag up as a bypass without a test failing.
Test plan

> backend@1.0.0 test
> jest --runInBand --forceExit tests/escrowMap.test.js

 PASS  tests/escrowMap.test.js
  escrowMap – resolveEscrowAddress
    √ resolves a known active mapping to its address (3 ms)
    √ throws EscrowNotFoundError for an unknown invoiceId (21 ms)
    √ error message includes the invoiceId (2 ms)
    √ throws EscrowNotFoundError for an inactive mapping (isActive: false) (1 ms)
    √ treats missing isActive field as active (truthy default)
    √ resolves only the mapping whose environment matches NODE_ENV
    √ throws when the mapping exists but for a different environment (1 ms)
    √ falls back to defaultEnvironment when NODE_ENV is not set (1 ms)
    √ falls back to the "development" environment when defaultEnvironment is omitted entirely (1 ms)
    √ resolves normally when allowlistEnabled is true and address is in the mappings (1 ms)
    √ throws EscrowNotFoundError when allowlistEnabled is true and invoiceId is not in mappings (5 ms)
    √ still throws for an inactive mapping even when allowlistEnabled is true (1 ms)
    √ throws EscrowNotFoundError when ESCROW_ADDR_BY_INVOICE is not set
    √ throws EscrowNotFoundError when mappings array is empty
    √ picks the correct address when multiple active mappings are present
  escrowMap – config validation (EscrowMapConfigError)
    √ throws EscrowMapConfigError for malformed JSON (1 ms)
    √ error message mentions JSON when config is malformed
    √ throws EscrowMapConfigError when mappings is not an array
    √ throws EscrowMapConfigError when a mapping is missing invoiceId (1 ms)
    √ throws EscrowMapConfigError for an invalid Stellar escrowAddress (1 ms)
    √ throws EscrowMapConfigError for a G... address (only C... allowed for contracts) (1 ms)
  escrowMap – module-level cache
    √ returns the same address on repeated calls without re-reading env (cache hit)
    √ rebuilds on every call when cacheEnabled is false, without waiting for TTL or calling _resetCache()
    √ picks up the new config after _resetCache() (3 ms)
    √ fails closed after cache reset when new config is malformed JSON (1 ms)
  escrowMap – resolveInvoiceByAddress (reverse lookup)
    √ resolves a known active contract address to its invoiceId (1 ms)
    √ returns null for an unknown contract address (allowlist-disabled address) (1 ms)
    √ returns null when ESCROW_ADDR_BY_INVOICE is not set (1 ms)
    √ returns null for inactive mapping addresses (1 ms)
    √ returns null when mapping exists for a different environment
    √ resolves only the mapping for the current environment
    √ returns null for malformed contract addresses
    √ does not fabricate invoice IDs for unmapped contracts when allowlistEnabled is false (1 ms)
    √ refreshes reverse index after cache TTL expires (5 ms)

Test Suites: 1 passed, 1 total
Tests:       34 passed, 34 total
Coverage on src/config/escrowMap.js: 100% statements / 100% branches / 100% functions / 100% lines (up from 96.72%/95.34% before this PR).

npm run lint: no new issues introduced by this change (tests/escrowMap.test.js is clean). The full repo lint run has ~49 pre-existing errors/8 warnings in unrelated files, present before this change.

Notes
No production code was changed — this is a test-only PR.
Security checklist per the issue: no default-address fallback ✅, allowlist cannot be bypassed (verified with allowlistEnabled: false explicitly) ✅, malformed config fails closed ✅.
Unrelated, worth a separate look: tests/idempotency.test.js:83 fails to parse (Unexpected token <<), consistent with committed merge-conflict markers. Also, package.json/package-lock.json list chessify-protocol as a dependency — it's unused anywhere in source and pulls in unrelated Next.js/React/Stacks-wallet/Ethereum-wallet packages (@stacks/wallet-sdk, wagmi, viem). Neither is touched by this PR; flagging for maintainer visibility.

