### PR TITLE
feat(metrics): add cursor pagination to metrics listing endpoint

### DIFF
--- a/src/routes/sme/metrics.js
+++ b/src/routes/sme/metrics.js
@@ -9,6 +9,7 @@ const express = require('express');
 const router = express.Router();
 const { authenticateToken } = require('../../middleware/auth');
 const { extractTenant } = require('../../middleware/tenant');
+const { CursorError } = require('../../utils/cursorPagination');
 const invoiceService = require('../../services/invoiceService');
 
 
@@ -18,7 +19,17 @@ const invoiceService = require('../../services/invoiceService');
  *   get:
  *     operationId: getSmeMetrics
  *     summary: Get SME dashboard metrics
- *     description: Returns aggregated, tenant- and owner-scoped invoice metrics for the authenticated SME user.
+ *     description: |
+ *       Returns aggregated, tenant- and owner-scoped invoice metrics for the
+ *       authenticated SME user.
+ *
+ *       **Pagination**
+ *       Supply `limit` (1–100, default 20) and optionally `cursor` (the
+ *       `nextCursor` from a prior response) to page through individual
+ *       invoice rows while still receiving the aggregated counts.
+ *
+ *       When neither `cursor` nor `limit` is provided the response shape
+ *       is identical to the original (aggregated counts only).
  *     tags: [SME]
  *     security:
  *       - bearerAuth: []
@@ -28,6 +39,19 @@ const invoiceService = require('../../services/invoiceService');
  *         schema:
  *           type: string
  *         description: Tenant identifier (optional if supplied via JWT claim)
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *         description: Opaque cursor from the previous page's `nextCursor` field.
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Items per page (1–100, default 20).
  *     responses:
  *       200:
  *         description: Metrics retrieved successfully
@@ -59,6 +83,24 @@ const invoiceService = require('../../services/invoiceService');
  *                       format: date-time
  *                     version:
  *                       type: string
+ *                     invoices:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                       description: Paginated invoice rows (present when cursor or limit is supplied)
+ *                     total:
+ *                       type: integer
+ *                       description: Total matching invoices
+ *                     limit:
+ *                       type: integer
+ *                       description: Applied page size
+ *                     hasMore:
+ *                       type: boolean
+ *                       description: Whether there are more pages
+ *                     nextCursor:
+ *                       type: string
+ *                       nullable: true
+ *                       description: Opaque cursor for the next page
  *                 error:
  *                   type: object
  *                   nullable: true
@@ -66,7 +108,7 @@ const invoiceService = require('../../services/invoiceService');
  *                   type: string
  *                   format: date-time
  *       400:
- *         description: Bad Request - Missing tenant context
+ *         description: Bad Request - Missing tenant context or invalid cursor
  *       401:
  *         description: Unauthorized
  */
@@ -84,9 +126,42 @@ router.get('/metrics', authenticateToken, extractTenant, async (req, res, next) 
 
     const metrics = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
 
+    const { cursor, limit } = req.query;
+    const usePagination = cursor !== undefined || limit !== undefined;
+
+    if (!usePagination) {
+      return res.json({
+        data: metrics,
+        meta: {
+          timestamp: new Date().toISOString(),
+          version: '0.1.0'
+        },
+        error: null,
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    let result;
+    try {
+      result = await invoiceService.getSmeInvoiceList(tenantId, userId, { cursor, limit });
+    } catch (err) {
+      if (err instanceof CursorError) {
+        return res.status(400).json({
+          error: 'Bad Request',
+          message: err.message
+        });
+      }
+      throw err;
+    }
+
     return res.json({
       data: metrics,
       meta: {
+        invoices: result.invoices,
+        total: result.meta.total,
+        limit: result.meta.limit,
+        hasMore: result.meta.hasMore,
+        nextCursor: result.meta.nextCursor,
         timestamp: new Date().toISOString(),
         version: '0.1.0'
       },

--- a/src/services/invoiceService.js
+++ b/src/services/invoiceService.js
@@ -27,6 +27,7 @@
 
 const db = require('../db/knex');
 const { applyQueryOptions } = require('../utils/queryBuilder');
+const { encodeCursor, decodeCursor, CursorError } = require('../utils/cursorPagination');
 const logger = require('../logger');
 const AppError = require('../errors/AppError');
 const { LOCKED_STATUSES } = require('../middleware/patchInvoice');
@@ -596,6 +597,94 @@ async function getSmeInvoiceCounts(tenantId, userId) {
   return result;
 }
 
+/**
+ * Retrieves a cursor-paginated list of invoices for the SME dashboard,
+ * scoped to a single tenant and SME owner.
+ *
+ * Uses keyset pagination with `created_at DESC, id DESC` so the ordering
+ * is stable under concurrent inserts.  The cursor is opaque and HMAC-signed;
+ * malformed or tampered cursors throw {@link CursorError}.
+ *
+ * When no cursor is supplied the first page is returned.
+ * The caller controls page size via `limit` (1–100, default 20).
+ *
+ * @param {string} tenantId - Tenant identifier (required).
+ * @param {string} userId   - SME owner identifier (required).
+ * @param {object} [options={}]
+ * @param {string} [options.cursor] - Opaque cursor from a prior page.
+ * @param {number} [options.limit=20] - Max rows per page (clamped to 1–100).
+ * @returns {Promise<{invoices: object[], meta: {total: number, limit: number, hasMore: boolean, nextCursor: string|null}}>}
+ * @throws {TypeError}  When tenantId or userId is missing.
+ * @throws {CursorError} When the cursor is malformed, tampered, or expired.
+ */
+async function getSmeInvoiceList(tenantId, userId, { cursor, limit = 20 } = {}) {
+  if (!tenantId || typeof tenantId !== 'string') {
+    throw new TypeError('tenantId is required');
+  }
+  if (!userId || typeof userId !== 'string') {
+    throw new TypeError('userId is required');
+  }
+
+  const MAX_LIMIT = 100;
+  const safeLimit = Math.max(1, Math.min(MAX_LIMIT, parseInt(limit, 10) || 20));
+
+  const baseQuery = () =>
+    db('invoices')
+      .where({ tenant_id: tenantId, sme_id: userId })
+      .whereNull('deleted_at');
+
+  const countRow = await baseQuery().count('* as total').first();
+  const total = parseInt(countRow?.total ?? countRow?.['count(*)'] ?? 0, 10);
+
+  let cursorData = null;
+  if (cursor) {
+    try {
+      cursorData = decodeCursor(cursor, 'created_at');
+    } catch (err) {
+      if (err instanceof CursorError) {
+        throw err;
+      }
+      throw new CursorError('Invalid cursor');
+    }
+  }
+
+  let dataQuery = baseQuery()
+    .select('*')
+    .orderBy('created_at', 'desc')
+    .orderBy('id', 'desc')
+    .limit(safeLimit + 1);
+
+  if (cursorData) {
+    dataQuery = dataQuery.where(function () {
+      this.where('created_at', '<', cursorData.sortValue)
+        .orWhere(function () {
+          this.where('created_at', cursorData.sortValue)
+            .andWhere('id', '<', parseInt(String(cursorData.id), 10) || 0);
+        });
+    });
+  }
+
+  const rows = await dataQuery;
+
+  const hasMore = rows.length > safeLimit;
+  const pageRows = hasMore ? rows.slice(0, safeLimit) : rows;
+
+  let nextCursor = null;
+  if (hasMore && pageRows.length > 0) {
+    const lastRow = pageRows[pageRows.length - 1];
+    nextCursor = encodeCursor({
+      sortField: 'created_at',
+      sortValue: lastRow.created_at,
+      id: String(lastRow.id),
+    });
+  }
+
+  return {
+    invoices: pageRows,
+    meta: { total, limit: safeLimit, hasMore, nextCursor },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // KYC helpers (in-memory — retained for backward compat with existing tests)
 // ---------------------------------------------------------------------------
@@ -668,6 +757,7 @@ module.exports = {
   parseInvoiceMetadata,
   // SME dashboard metrics
   getSmeInvoiceCounts,
+  getSmeInvoiceList,
   STATUS_CATEGORY_MAP,
   // KYC helpers (in-memory)
   getInvoicesByKycStatus,

--- a/tests/sme.metrics.test.js
+++ b/tests/sme.metrics.test.js
@@ -159,4 +159,225 @@ describe('SME Metrics API', () => {
     expect(res.status).toBe(400);
     expect(res.body.error.message).toContain('Missing tenant context');
   });
+
+  // ── Cursor pagination tests ───────────────────────────────────────────────
+
+  describe('cursor pagination', () => {
+    test('returns aggregated counts only when no cursor or limit is provided (backward compat)', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'c1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'C1' },
+        { invoice_id: 'c2', sme_id: userId, tenant_id: tenantId, status: 'funded', amount: 200, customer: 'C2' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ open: 1, funded: 1, settled: 0, defaulted: 0 });
+      expect(res.body.meta.invoices).toBeUndefined();
+      expect(res.body.meta.nextCursor).toBeUndefined();
+      expect(res.body.meta.hasMore).toBeUndefined();
+    });
+
+    test('returns paginated invoices when limit is supplied', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'p1', sme_id: userId, tenant_id: tenantId, status: 'pending_verification', amount: 100, customer: 'P1' },
+        { invoice_id: 'p2', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 200, customer: 'P2' },
+        { invoice_id: 'p3', sme_id: userId, tenant_id: tenantId, status: 'funded', amount: 300, customer: 'P3' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=2')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ open: 2, funded: 1, settled: 0, defaulted: 0 });
+      expect(res.body.meta.invoices).toHaveLength(2);
+      expect(res.body.meta.limit).toBe(2);
+      expect(res.body.meta.total).toBe(3);
+      expect(res.body.meta.hasMore).toBe(true);
+      expect(res.body.meta.nextCursor).toBeTruthy();
+      expect(res.body.meta.timestamp).toBeDefined();
+    });
+
+    test('returns empty invoices list for a user with no invoices', async () => {
+      const newUserToken = jwt.sign({ id: 'empty_user', tenantId }, JWT_SECRET);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=5')
+        .set('Authorization', `Bearer ${newUserToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ open: 0, funded: 0, settled: 0, defaulted: 0 });
+      expect(res.body.meta.invoices).toEqual([]);
+      expect(res.body.meta.total).toBe(0);
+      expect(res.body.meta.hasMore).toBe(false);
+      expect(res.body.meta.nextCursor).toBeNull();
+    });
+
+    test('paginates across multiple pages correctly', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'mp1', sme_id: userId, tenant_id: tenantId, status: 'pending_verification', amount: 100, customer: 'MP1' },
+        { invoice_id: 'mp2', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 200, customer: 'MP2' },
+        { invoice_id: 'mp3', sme_id: userId, tenant_id: tenantId, status: 'funded', amount: 300, customer: 'MP3' },
+        { invoice_id: 'mp4', sme_id: userId, tenant_id: tenantId, status: 'settled', amount: 400, customer: 'MP4' },
+        { invoice_id: 'mp5', sme_id: userId, tenant_id: tenantId, status: 'paid', amount: 500, customer: 'MP5' },
+      ]);
+
+      const page1 = await request(app)
+        .get('/api/sme/metrics?limit=2')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(page1.status).toBe(200);
+      expect(page1.body.meta.invoices).toHaveLength(2);
+      expect(page1.body.meta.total).toBe(5);
+      expect(page1.body.meta.hasMore).toBe(true);
+      expect(page1.body.meta.nextCursor).toBeTruthy();
+      const page1Ids = page1.body.meta.invoices.map((i) => i.invoice_id);
+      expect(page1Ids).toEqual(['mp5', 'mp4']);
+
+      const page2 = await request(app)
+        .get(`/api/sme/metrics?limit=2&cursor=${page1.body.meta.nextCursor}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(page2.status).toBe(200);
+      expect(page2.body.meta.invoices).toHaveLength(2);
+      expect(page2.body.meta.total).toBe(5);
+      expect(page2.body.meta.hasMore).toBe(true);
+      expect(page2.body.meta.nextCursor).toBeTruthy();
+      const page2Ids = page2.body.meta.invoices.map((i) => i.invoice_id);
+      expect(page2Ids).toEqual(['mp3', 'mp2']);
+
+      const page3 = await request(app)
+        .get(`/api/sme/metrics?limit=2&cursor=${page2.body.meta.nextCursor}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(page3.status).toBe(200);
+      expect(page3.body.meta.invoices).toHaveLength(1);
+      expect(page3.body.meta.total).toBe(5);
+      expect(page3.body.meta.hasMore).toBe(false);
+      expect(page3.body.meta.nextCursor).toBeNull();
+      const page3Ids = page3.body.meta.invoices.map((i) => i.invoice_id);
+      expect(page3Ids).toEqual(['mp1']);
+    });
+
+    test('single page when items fit within limit', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'sp1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'SP1' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=10')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.invoices).toHaveLength(1);
+      expect(res.body.meta.total).toBe(1);
+      expect(res.body.meta.hasMore).toBe(false);
+      expect(res.body.meta.nextCursor).toBeNull();
+    });
+
+    test('clamps limit to maximum of 100', async () => {
+      const invoices = Array.from({ length: 50 }, (_, i) => ({
+        invoice_id: `clamp_${i}`,
+        sme_id: userId,
+        tenant_id: tenantId,
+        status: i % 2 === 0 ? 'verified' : 'funded',
+        amount: (i + 1) * 10,
+        customer: `Clamp${i}`,
+      }));
+      await db('invoices').insert(invoices);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=999')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.limit).toBe(100);
+      expect(res.body.meta.invoices).toHaveLength(50);
+      expect(res.body.meta.hasMore).toBe(false);
+    });
+
+    test('rejects malformed cursor with 400', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'mc1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'MC1' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=5&cursor=invalid-cursor-string')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Bad Request');
+      expect(res.body.message).toContain('Malformed cursor');
+    });
+
+    test('pagination respects tenant isolation', async () => {
+      const otherTenantId = 'other_tenant_pag';
+      await db('invoices').insert([
+        { invoice_id: 'ti1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'TI1' },
+        { invoice_id: 'ti2', sme_id: userId, tenant_id: otherTenantId, status: 'funded', amount: 200, customer: 'TI2' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=10')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.invoices).toHaveLength(1);
+      expect(res.body.meta.total).toBe(1);
+      expect(res.body.meta.invoices[0].invoice_id).toBe('ti1');
+    });
+
+    test('pagination respects owner isolation', async () => {
+      const otherUserId = 'other_user_pag';
+      const otherToken = jwt.sign({ id: otherUserId, tenantId }, JWT_SECRET);
+      await db('invoices').insert([
+        { invoice_id: 'oi1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'OI1' },
+        { invoice_id: 'oi2', sme_id: otherUserId, tenant_id: tenantId, status: 'funded', amount: 200, customer: 'OI2' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=10')
+        .set('Authorization', `Bearer ${otherToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.invoices).toHaveLength(1);
+      expect(res.body.meta.total).toBe(1);
+      expect(res.body.meta.invoices[0].invoice_id).toBe('oi2');
+    });
+
+    test('pagination excludes soft-deleted invoices', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'sd1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'SD1', deleted_at: new Date().toISOString() },
+        { invoice_id: 'sd2', sme_id: userId, tenant_id: tenantId, status: 'funded', amount: 200, customer: 'SD2' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=10')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.invoices).toHaveLength(1);
+      expect(res.body.meta.total).toBe(1);
+      expect(res.body.meta.invoices[0].invoice_id).toBe('sd2');
+    });
+
+    test('includes counts in data alongside paginated invoices', async () => {
+      await db('invoices').insert([
+        { invoice_id: 'ic1', sme_id: userId, tenant_id: tenantId, status: 'pending_verification', amount: 100, customer: 'IC1' },
+        { invoice_id: 'ic2', sme_id: userId, tenant_id: tenantId, status: 'funded', amount: 200, customer: 'IC2' },
+        { invoice_id: 'ic3', sme_id: userId, tenant_id: tenantId, status: 'settled', amount: 300, customer: 'IC3' },
+      ]);
+
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=2')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ open: 1, funded: 1, settled: 1, defaulted: 0 });
+      expect(res.body.meta.invoices).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
closes #652

## Summary

Adds cursor-based pagination to the `GET /api/sme/metrics` endpoint. The endpoint now accepts optional `cursor` and `limit` query parameters to page through individual invoice rows while continuing to return aggregated counts.

## Changes

### `src/services/invoiceService.js`
- Added `getSmeInvoiceList(tenantId, userId, { cursor, limit })` — keyset pagination on `created_at DESC, id DESC` with opaque HMAC-signed cursors
- Limit is bounded to 1–100 (default 20)
- Reuses existing `encodeCursor`/`decodeCursor` from `src/utils/cursorPagination.js`

### `src/routes/sme/metrics.js`
- Updated `GET /api/sme/metrics` to accept `cursor` and `limit` query parameters
- Backward compatible: when neither param is supplied, the response is identical to before (aggregated counts only)
- When pagination is active, response includes `meta.invoices` (paginated rows), `meta.total`, `meta.hasMore`, `meta.nextCursor`
- Malformed/tampered cursors return HTTP 400

### `tests/sme.metrics.test.js`
Added comprehensive test coverage:
- Backward compatibility (no params → counts only)
- Default/custom limit
- Full multi-page cursor traversal (3 pages)
- Empty set
- Single-page result
- Limit clamping (max 100)
- Invalid cursor rejection
- Tenant isolation
- Owner isolation
- Soft-delete exclusion
- Data integrity (counts alongside invoices)

## Item Shape

Individual invoice objects remain unchanged. The only addition to the response is new fields in `meta` when pagination is active.

## Verification

To run the tests:
```
npm test -- tests/sme.metrics.test.js
```