### PR TITLE
feat(indexer): add cursor pagination to indexer listing endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -53,6 +53,7 @@ const adminEscrowRoutes = require('./routes/adminEscrow');
 const adminWebhooksRoutes = require('./routes/adminWebhooks');
 const kycRoutes = require('./routes/kyc');
 const reconciliationRoutes = require('./routes/reconciliation');
+const adminIndexerRoutes = require('./routes/adminIndexer');
 const v1Routes = require('./routes/v1');
 const {
   mountFeatureRouter,
@@ -360,6 +361,7 @@ function createApp() {
   mountFeatureRouter(app, '/api/admin/escrow', adminEscrowRoutes);
   mountFeatureRouter(app, '/api/admin/webhooks', adminWebhooksRoutes);
   mountFeatureRouter(app, '/api/admin/reconciliation', reconciliationRoutes);
+  mountFeatureRouter(app, '/api/admin/indexer', adminIndexerRoutes);
   mountFeatureRouter(app, '/v1', v1Routes);
 
   assertNoDuplicateRouterMounts();

--- a/src/routes/adminIndexer.js
+++ b/src/routes/adminIndexer.js
@@ -1,0 +1,303 @@
+'use strict';
+
+/**
+ * @fileoverview Admin indexer events listing endpoint.
+ *
+ * Exposes a cursor-paginated read over the `escrow_events` table so operators
+ * can inspect indexed Soroban / Horizon contract events without querying the
+ * database directly.
+ *
+ * Route:  GET /api/admin/indexer/events
+ * Access: Admin-only (JWT bearer or API key).
+ *
+ * @module routes/adminIndexer
+ */
+
+const express = require('express');
+
+const router = express.Router();
+const { listIndexerEvents, INDEXER_SORT_FIELDS } = require('../services/indexerService');
+const { CursorError } = require('../utils/cursorPagination');
+const { adminStack } = require('../middleware/stacks');
+const responseHelper = require('../utils/responseHelper');
+const logger = require('../logger');
+
+/**
+ * Maximum page size clamped by the service layer.
+ * @constant {number}
+ */
+const MAX_LIMIT = 100;
+
+// Apply admin auth (JWT or API key) + tenant extraction to every route in this
+// file.
+router.use(...adminStack);
+
+/**
+ * Validates and normalises query parameters for the events listing endpoint.
+ *
+ * @param {object} query - Express `req.query` object.
+ * @returns {{ isValid: boolean, fieldErrors: Record<string,string>, params: object }}
+ */
+function _parseQuery(query) {
+  const fieldErrors = {};
+  const params = { filters: {}, sorting: {}, pagination: {} };
+
+  const { invoiceId, eventType, contractId, sortBy, order, cursor, page, limit } = query;
+
+  // ── Filters ───────────────────────────────────────────────────────────────
+  if (invoiceId !== undefined) {
+    if (typeof invoiceId === 'string' && /^[a-zA-Z0-9_-]{1,128}$/.test(invoiceId.trim())) {
+      params.filters.invoiceId = invoiceId.trim();
+    } else {
+      fieldErrors.invoiceId = 'invoiceId must be 1–128 alphanumeric/underscore/hyphen characters';
+    }
+  }
+
+  if (eventType !== undefined) {
+    if (typeof eventType === 'string' && eventType.trim().length > 0 && eventType.trim().length <= 128) {
+      params.filters.eventType = eventType.trim();
+    } else {
+      fieldErrors.eventType = 'eventType must be a non-empty string (max 128 chars)';
+    }
+  }
+
+  if (contractId !== undefined) {
+    if (typeof contractId === 'string' && /^C[A-Z2-7]{55}$/.test(contractId.trim())) {
+      params.filters.contractId = contractId.trim();
+    } else {
+      fieldErrors.contractId = 'contractId must be a valid Stellar contract address (C… 56 chars)';
+    }
+  }
+
+  // ── Sorting ───────────────────────────────────────────────────────────────
+  if (sortBy !== undefined) {
+    if (INDEXER_SORT_FIELDS.includes(sortBy)) {
+      params.sorting.sortBy = sortBy;
+    } else {
+      fieldErrors.sortBy = `sortBy must be one of: ${INDEXER_SORT_FIELDS.join(', ')}`;
+    }
+  }
+
+  if (order !== undefined) {
+    const lowerOrder = String(order).toLowerCase();
+    if (lowerOrder === 'asc' || lowerOrder === 'desc') {
+      params.sorting.order = lowerOrder;
+    } else {
+      fieldErrors.order = 'order must be "asc" or "desc"';
+    }
+  }
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+  if (cursor !== undefined) {
+    if (typeof cursor === 'string' && cursor.length > 0 && cursor.length <= 2048) {
+      params.pagination.cursor = cursor;
+    } else {
+      fieldErrors.cursor = 'cursor must be a non-empty string (max 2048 chars)';
+    }
+  }
+
+  // page is only relevant when no cursor is provided
+  if (cursor === undefined && page !== undefined) {
+    const val = parseInt(page, 10);
+    if (!isNaN(val) && val >= 1) {
+      params.pagination.page = val;
+    } else {
+      fieldErrors.page = 'page must be an integer >= 1';
+    }
+  }
+
+  if (limit !== undefined) {
+    const val = parseInt(limit, 10);
+    if (!isNaN(val) && val >= 1 && val <= MAX_LIMIT) {
+      params.pagination.limit = val;
+    } else {
+      fieldErrors.limit = `limit must be an integer between 1 and ${MAX_LIMIT}`;
+    }
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors,
+    params,
+  };
+}
+
+/**
+ * @swagger
+ * /api/admin/indexer/events:
+ *   get:
+ *     operationId: listIndexerEvents
+ *     summary: List indexed escrow events (admin, cursor-paginated)
+ *     description: |
+ *       Returns a bounded, cursor-paginated list of rows from the
+ *       `escrow_events` table ordered by `observed_at DESC` by default.
+ *
+ *       **Access**: Admin-only (JWT bearer or API key).
+ *
+ *       **Pagination modes**
+ *
+ *       | Mode | Parameters | Notes |
+ *       |------|-----------|-------|
+ *       | Cursor (recommended) | `cursor` + `limit` | Stable under inserts; use `nextCursor` from the previous response |
+ *       | Offset (legacy) | `page` + `limit` | Backward-compatible; may drift on busy datasets |
+ *
+ *       When `cursor` is supplied, `page` is ignored.
+ *       Cursors are opaque and HMAC-signed — any modification returns 400.
+ *       Cursors are tied to a specific `sortBy` field; switching sort mid-
+ *       pagination requires starting from the first page (no `cursor`).
+ *
+ *       **`event_body` is not included in list rows** to keep payloads small.
+ *     tags: [Indexer]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: invoiceId
+ *         schema:
+ *           type: string
+ *           maxLength: 128
+ *         description: Filter by invoice ID
+ *       - in: query
+ *         name: eventType
+ *         schema:
+ *           type: string
+ *           maxLength: 128
+ *         description: Filter by event type
+ *       - in: query
+ *         name: contractId
+ *         schema:
+ *           type: string
+ *         description: Filter by Stellar contract address
+ *       - in: query
+ *         name: sortBy
+ *         schema:
+ *           type: string
+ *           enum: [observed_at, ledger_sequence]
+ *           default: observed_at
+ *         description: Field to sort by. Must stay constant across cursor pages.
+ *       - in: query
+ *         name: order
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *           default: desc
+ *         description: Sort order. Must stay constant across cursor pages.
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *           maxLength: 2048
+ *         description: |
+ *           Opaque HMAC-signed cursor returned as `nextCursor` in a previous
+ *           response.  When present, offset-based `page` is ignored.
+ *           A malformed or tampered cursor returns 400.
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Page number (offset mode only; ignored when `cursor` is supplied)
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Items per page (applies to both pagination modes)
+ *     responses:
+ *       200:
+ *         description: Indexer events retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       event_id:       { type: string }
+ *                       invoice_id:     { type: string }
+ *                       event_type:     { type: string }
+ *                       ledger_sequence: { type: integer }
+ *                       paging_token:   { type: string, nullable: true }
+ *                       contract_id:    { type: string, nullable: true }
+ *                       tx_hash:        { type: string, nullable: true }
+ *                       observed_at:    { type: string, format: date-time }
+ *                       created_at:     { type: string, format: date-time }
+ *                 meta:
+ *                   type: object
+ *                   properties:
+ *                     total:      { type: integer }
+ *                     limit:      { type: integer }
+ *                     hasMore:    { type: boolean }
+ *                     nextCursor: { type: string, nullable: true }
+ *       400:
+ *         description: |
+ *           Invalid query parameters or malformed/tampered cursor.
+ *         $ref: '#/components/responses/Problem400'
+ *       401:
+ *         $ref: '#/components/responses/Problem401'
+ *       403:
+ *         $ref: '#/components/responses/Problem403'
+ */
+router.get('/events', async (req, res, next) => {
+  try {
+    // ── 1. Parse and validate query parameters ──────────────────────────────
+    const { isValid, fieldErrors, params } = _parseQuery(req.query);
+
+    if (!isValid) {
+      return res.status(400).json(
+        responseHelper.error('Query parameters contain invalid values.', 'VALIDATION_ERROR', fieldErrors),
+      );
+    }
+
+    // ── 2. Call service ─────────────────────────────────────────────────────
+    let result;
+    try {
+      result = await listIndexerEvents({
+        filters: params.filters,
+        sorting: params.sorting,
+        pagination: params.pagination,
+        dbClient: req._dbClient, // injectable in tests
+      });
+    } catch (err) {
+      // CursorError is a client error (malformed/tampered cursor) → 400
+      if (err instanceof CursorError) {
+        return res.status(400).json(
+          responseHelper.error(
+            'Query parameters contain invalid values.',
+            'VALIDATION_ERROR',
+            { cursor: err.message },
+          ),
+        );
+      }
+      throw err;
+    }
+
+    // ── 3. Logging ──────────────────────────────────────────────────────────
+    logger.info(
+      {
+        requestId: req.id,
+        count: result.data.length,
+        total: result.meta.total,
+        hasMore: result.meta.hasMore,
+        usedCursor: Boolean(params.pagination.cursor),
+      },
+      'Indexer events retrieved',
+    );
+
+    // ── 4. Respond ──────────────────────────────────────────────────────────
+    return res.status(200).json({
+      ...responseHelper.success(result.data, result.meta),
+      message: 'Indexer events retrieved successfully.',
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+module.exports = router;

--- a/src/services/indexerService.js
+++ b/src/services/indexerService.js
@@ -1,0 +1,270 @@
+'use strict';
+
+/**
+ * @fileoverview Indexer listing service — paginated reads from escrow_events.
+ *
+ * Exposes {@link listIndexerEvents} which returns a bounded, cursor-paginated
+ * slice of rows from the `escrow_events` table.  The same keyset strategy
+ * used by the marketplace is applied here, ensuring stable, scalable reads
+ * even as the event log grows unboundedly.
+ *
+ * Sort fields
+ * ───────────
+ * | sortBy             | Column mapped         |
+ * |--------------------|-----------------------|
+ * | `observed_at`      | `observed_at`         |
+ * | `ledger_sequence`  | `ledger_sequence`     |
+ *
+ * The default sort is `observed_at DESC` (newest events first), which matches
+ * typical operator / monitoring use-cases.
+ *
+ * Security
+ * ────────
+ * - No tenant isolation is required here because escrow events are admin-level
+ *   data that is not partitioned by tenant.  The calling route enforces admin
+ *   auth via `adminStack`.
+ * - Filter constraints (invoiceId, eventType) are applied to every query and
+ *   cannot be bypassed via cursor content.
+ * - Cursors are HMAC-signed; any tampering causes a {@link CursorError} which
+ *   the route maps to HTTP 400.
+ * - Sort-field mismatch between the cursor and the current request is detected
+ *   and rejected before the query is built.
+ *
+ * @module services/indexerService
+ */
+
+const db = require('../db/knex');
+const { encodeCursor, decodeCursor } = require('../utils/cursorPagination');
+
+/**
+ * Allowed sort fields for the indexer listing endpoint.
+ * Changing this list must be accompanied by index changes.
+ *
+ * @type {readonly string[]}
+ */
+const INDEXER_SORT_FIELDS = Object.freeze(['observed_at', 'ledger_sequence']);
+
+/**
+ * Default sort field (newest events first).
+ * @type {string}
+ */
+const DEFAULT_SORT_FIELD = 'observed_at';
+
+/**
+ * Default sort order.
+ * @type {string}
+ */
+const DEFAULT_ORDER = 'desc';
+
+/**
+ * Maximum page size that a caller may request.
+ * Clamped server-side regardless of the `limit` query param.
+ * @type {number}
+ */
+const MAX_PAGE_SIZE = 100;
+
+/**
+ * Default page size when `limit` is not supplied.
+ * @type {number}
+ */
+const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Columns selected from `escrow_events`.
+ * `event_body` is intentionally excluded from the list response to keep
+ * payloads small; callers that need the body should fetch a specific event.
+ *
+ * @type {string[]}
+ */
+const SELECT_COLUMNS = [
+  'event_id',
+  'invoice_id',
+  'event_type',
+  'ledger_sequence',
+  'paging_token',
+  'contract_id',
+  'tx_hash',
+  'observed_at',
+  'created_at',
+];
+
+/**
+ * Applies optional filter predicates to a Knex query builder.
+ * Extracted so the same conditions are used for both the count query and the
+ * data query, preventing drift between the two.
+ *
+ * @param {import('knex').QueryBuilder} qb - Knex query builder (mutated in place).
+ * @param {object} filters
+ * @param {string} [filters.invoiceId]  - Exact-match filter on `invoice_id`.
+ * @param {string} [filters.eventType]  - Exact-match filter on `event_type`.
+ * @param {string} [filters.contractId] - Exact-match filter on `contract_id`.
+ * @returns {import('knex').QueryBuilder}
+ */
+function _applyFilters(qb, filters) {
+  if (filters.invoiceId) {
+    qb.where('invoice_id', filters.invoiceId);
+  }
+  if (filters.eventType) {
+    qb.where('event_type', filters.eventType);
+  }
+  if (filters.contractId) {
+    qb.where('contract_id', filters.contractId);
+  }
+  return qb;
+}
+
+/**
+ * Retrieves a paginated list of escrow events with optional filtering.
+ *
+ * Supports two pagination modes:
+ *
+ * **Cursor mode (recommended)**: supply `pagination.cursor` from a previous
+ * response's `nextCursor` field.  The cursor encodes the keyset anchor and is
+ * HMAC-signed to prevent tampering.
+ *
+ * **Offset mode (legacy)**: supply `pagination.page` and `pagination.limit`
+ * without `pagination.cursor`.  Less stable under inserts but backward-
+ * compatible.
+ *
+ * @param {object}  options
+ * @param {object}  [options.filters={}]
+ * @param {string}  [options.filters.invoiceId]  - Filter by invoice ID.
+ * @param {string}  [options.filters.eventType]  - Filter by event type.
+ * @param {string}  [options.filters.contractId] - Filter by contract ID.
+ * @param {object}  [options.sorting={}]
+ * @param {string}  [options.sorting.sortBy='observed_at']  - Sort field.
+ * @param {string}  [options.sorting.order='desc']          - Sort order.
+ * @param {object}  [options.pagination={}]
+ * @param {string}  [options.pagination.cursor]  - Opaque cursor (cursor mode).
+ * @param {number}  [options.pagination.page=1]  - 1-based page number (offset mode).
+ * @param {number}  [options.pagination.limit=20] - Page size (1–100).
+ * @param {import('knex').Knex} [options.dbClient] - Injectable Knex client (for tests).
+ *
+ * @returns {Promise<{ data: object[], meta: object }>}
+ *   `meta` always contains `{ total, limit, hasMore, nextCursor }`.
+ *   In offset mode it also contains `{ page, totalPages }`.
+ *
+ * @throws {CursorError} When the cursor is malformed or tampered (route maps to HTTP 400).
+ * @throws {Error}       On unexpected database errors.
+ */
+async function listIndexerEvents({
+  filters = {},
+  sorting = {},
+  pagination = {},
+  dbClient,
+} = {}) {
+  const knex = dbClient || db;
+
+  // ── Resolve validated query parameters ───────────────────────────────────
+  const limit = Math.max(1, Math.min(MAX_PAGE_SIZE, parseInt(pagination.limit) || DEFAULT_PAGE_SIZE));
+
+  const sortField = INDEXER_SORT_FIELDS.includes(sorting.sortBy)
+    ? sorting.sortBy
+    : DEFAULT_SORT_FIELD;
+
+  const order = sorting.order === 'asc' ? 'asc' : DEFAULT_ORDER;
+
+  // ── Base query factory ────────────────────────────────────────────────────
+  const baseQuery = () => knex('escrow_events');
+
+  // ── Total count (filter-aware, always offset-independent) ─────────────────
+  const countQ = baseQuery();
+  _applyFilters(countQ, filters);
+  const countRow = await countQ.count('* as total').first();
+  const total = parseInt(countRow.total ?? countRow['count(*)'] ?? 0, 10);
+
+  const useCursor = Boolean(pagination.cursor);
+
+  // ── Cursor-based keyset pagination ────────────────────────────────────────
+  if (useCursor) {
+    // decodeCursor validates HMAC and sort-field match; throws CursorError on
+    // failure.  The route layer catches CursorError and maps it to HTTP 400.
+    const decoded = decodeCursor(pagination.cursor, sortField);
+    const { sortValue, id: lastId } = decoded;
+
+    const dataQ = baseQuery().select(SELECT_COLUMNS);
+    _applyFilters(dataQ, filters);
+
+    // Keyset predicate:
+    //   ASC:  (sortField > lastValue) OR (sortField = lastValue AND event_id > lastId)
+    //   DESC: (sortField < lastValue) OR (sortField = lastValue AND event_id < lastId)
+    const cmpOp = order === 'asc' ? '>' : '<';
+    dataQ.where(function () {
+      this.where(sortField, cmpOp, sortValue)
+        .orWhere(function () {
+          this.where(sortField, '=', sortValue).where('event_id', cmpOp, lastId);
+        });
+    });
+
+    // Primary sort on sortField, secondary tiebreaker on event_id
+    dataQ.orderBy(sortField, order).orderBy('event_id', order);
+
+    // Fetch one extra to determine hasMore without a second COUNT query
+    const rows = await dataQ.limit(limit + 1);
+    const hasMore = rows.length > limit;
+    const data = hasMore ? rows.slice(0, limit) : rows;
+
+    let nextCursor = null;
+    if (hasMore && data.length > 0) {
+      const lastRow = data[data.length - 1];
+      nextCursor = encodeCursor({
+        sortField,
+        sortValue: lastRow[sortField],
+        id: String(lastRow.event_id),
+      });
+    }
+
+    return {
+      data,
+      meta: {
+        total,
+        limit,
+        hasMore,
+        nextCursor,
+      },
+    };
+  }
+
+  // ── Offset-based pagination (legacy, backward-compatible) ─────────────────
+  const page = Math.max(1, parseInt(pagination.page) || 1);
+  const offset = (page - 1) * limit;
+
+  const dataQ = baseQuery().select(SELECT_COLUMNS);
+  _applyFilters(dataQ, filters);
+  dataQ.orderBy(sortField, order).orderBy('event_id', order);
+
+  const pagedRows = await dataQ.limit(limit + 1).offset(offset);
+  const pagedHasMore = pagedRows.length > limit;
+  const pagedData = pagedHasMore ? pagedRows.slice(0, limit) : pagedRows;
+
+  let pagedNextCursor = null;
+  if (pagedHasMore && pagedData.length > 0) {
+    const lastRow = pagedData[pagedData.length - 1];
+    pagedNextCursor = encodeCursor({
+      sortField,
+      sortValue: lastRow[sortField],
+      id: String(lastRow.event_id),
+    });
+  }
+
+  return {
+    data: pagedData,
+    meta: {
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+      hasMore: pagedHasMore,
+      nextCursor: pagedNextCursor,
+    },
+  };
+}
+
+module.exports = {
+  listIndexerEvents,
+  INDEXER_SORT_FIELDS,
+  DEFAULT_SORT_FIELD,
+  DEFAULT_ORDER,
+  MAX_PAGE_SIZE,
+  DEFAULT_PAGE_SIZE,
+};

--- a/src/utils/cursorPagination.js
+++ b/src/utils/cursorPagination.js
@@ -9,7 +9,12 @@ const crypto = require('crypto');
 
 const DEV_CURSOR_SECRET = 'dev-cursor-secret-change-in-prod';
 
-const ALLOWED_SORT_FIELDS = Object.freeze(['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at']);
+const ALLOWED_SORT_FIELDS = Object.freeze([
+  // Marketplace / invoice fields
+  'yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at',
+  // Indexer (escrow_events) fields
+  'ledger_sequence', 'observed_at',
+]);
 
 /**
  * Resolves the HMAC secret used to sign and verify opaque cursors.

--- a/tests/indexerListing.test.js
+++ b/tests/indexerListing.test.js
@@ -1,0 +1,760 @@
+'use strict';
+
+/**
+ * @fileoverview Comprehensive tests for the indexer listing endpoint (#667).
+ *
+ * Coverage:
+ *  - listIndexerEvents service: cursor mode, offset mode, filters, edge cases
+ *  - adminIndexer route: auth, query validation, CursorError→400, responses
+ *  - cursorPagination: new indexer sort fields (observed_at, ledger_sequence)
+ *  - Edge cases: empty set, exact-page boundary, over-limit clamp, invalid cursor
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a minimal fake escrow_events row.
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+function makeEvent(overrides = {}) {
+  const id = overrides.event_id || `evt_${Math.random().toString(36).slice(2)}`;
+  return {
+    event_id: id,
+    invoice_id: 'inv_001',
+    event_type: 'escrow_created',
+    ledger_sequence: 100,
+    paging_token: '100-1',
+    contract_id: null,
+    tx_hash: null,
+    observed_at: new Date('2026-01-01T00:00:00Z'),
+    created_at: new Date('2026-01-01T00:00:01Z'),
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a lightweight fake Knex-like client backed by an in-memory array.
+ * Supports the chained API used by listIndexerEvents.
+ *
+ * @param {object[]} rows - The full "table" rows.
+ * @returns {Function} Fake knex client.
+ */
+function makeFakeKnex(rows = []) {
+  function buildQuery(allRows) {
+    let _filters = {};
+    let _order = [];
+    let _limit = null;
+    let _offset = 0;
+    let _isCount = false;
+
+    const q = {
+      select() { return q; },
+      where(fieldOrFn, val) {
+        if (typeof fieldOrFn === 'function') { return q; } // keyset fn — skip in fake
+        if (typeof fieldOrFn === 'object') { Object.assign(_filters, fieldOrFn); }
+        else { _filters[fieldOrFn] = val; }
+        return q;
+      },
+      orderBy(col, dir) { _order.push({ col, dir: dir || 'asc' }); return q; },
+      limit(n) { _limit = n; return q; },
+      offset(n) { _offset = n; return q; },
+      count() { _isCount = true; return q; },
+      first() {
+        const filtered = _applyFilters(allRows, _filters);
+        return Promise.resolve({ total: filtered.length, 'count(*)': filtered.length });
+      },
+      then(resolve, reject) {
+        return _run().then(resolve, reject);
+      },
+    };
+
+    function _applyFilters(r, filters) {
+      return r.filter((row) =>
+        Object.entries(filters).every(([k, v]) => String(row[k]) === String(v))
+      );
+    }
+
+    function _run() {
+      let r = _applyFilters(allRows, _filters);
+      if (_isCount) {
+        return Promise.resolve([{ total: r.length, 'count(*)': r.length }]);
+      }
+      for (const { col, dir } of [..._order].reverse()) {
+        r = [...r].sort((a, b) => {
+          const av = a[col]; const bv = b[col];
+          const cmp = String(av) < String(bv) ? -1 : String(av) > String(bv) ? 1 : 0;
+          return dir === 'desc' ? -cmp : cmp;
+        });
+      }
+      if (_offset) r = r.slice(_offset);
+      if (_limit !== null) r = r.slice(0, _limit);
+      return Promise.resolve(r);
+    }
+
+    return q;
+  }
+
+  return jest.fn(() => buildQuery(rows));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 1: Service unit tests (src/services/indexerService.js)
+// Uses injected fake dbClient — no DB required.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('indexerService – listIndexerEvents()', () => {
+  let listIndexerEvents;
+  let INDEXER_SORT_FIELDS;
+  let encodeCursor;
+  let decodeCursor;
+  let CursorError;
+
+  beforeAll(() => {
+    // Load modules once in beforeAll so Jest's module mocking is fully resolved
+    ({ listIndexerEvents, INDEXER_SORT_FIELDS } = require('../src/services/indexerService'));
+    ({ encodeCursor, decodeCursor, CursorError } = require('../src/utils/cursorPagination'));
+  });
+
+  // ── offset-mode pagination ──────────────────────────────────────────────
+
+  describe('offset-mode pagination', () => {
+    test('returns all rows when count <= limit (no hasMore)', async () => {
+      const events = [makeEvent({ event_id: 'e1' }), makeEvent({ event_id: 'e2' })];
+      const result = await listIndexerEvents({ dbClient: makeFakeKnex(events) });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.meta.hasMore).toBe(false);
+      expect(result.meta.nextCursor).toBeNull();
+      expect(result.meta.total).toBe(2);
+    });
+
+    test('hasMore is true when rows exceed limit', async () => {
+      const events = Array.from({ length: 25 }, (_, i) => makeEvent({ event_id: `e${i}` }));
+      const result = await listIndexerEvents({
+        pagination: { limit: 5, page: 1 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.data).toHaveLength(5);
+      expect(result.meta.hasMore).toBe(true);
+      expect(result.meta.nextCursor).not.toBeNull();
+    });
+
+    test('page 2 returns the correct slice metadata', async () => {
+      const events = Array.from({ length: 10 }, (_, i) =>
+        makeEvent({ event_id: `e${i}`, observed_at: new Date(2026, 0, i + 1) })
+      );
+      const result = await listIndexerEvents({
+        pagination: { limit: 4, page: 2 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.page).toBe(2);
+      expect(result.meta.totalPages).toBe(3); // ceil(10/4)
+    });
+
+    test('over-limit clamp: limit > 100 is clamped to 100', async () => {
+      const events = Array.from({ length: 5 }, (_, i) => makeEvent({ event_id: `e${i}` }));
+      const result = await listIndexerEvents({
+        pagination: { limit: 9999 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.limit).toBe(100);
+    });
+
+    test('exact-page boundary: exactly limit rows → hasMore false', async () => {
+      const events = Array.from({ length: 10 }, (_, i) => makeEvent({ event_id: `e${i}` }));
+      const result = await listIndexerEvents({
+        pagination: { limit: 10 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.data).toHaveLength(10);
+      expect(result.meta.hasMore).toBe(false);
+    });
+
+    test('empty result set → empty data, hasMore false, total 0', async () => {
+      const result = await listIndexerEvents({ dbClient: makeFakeKnex([]) });
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.hasMore).toBe(false);
+      expect(result.meta.nextCursor).toBeNull();
+      expect(result.meta.total).toBe(0);
+    });
+
+    test('default limit is 20 when none supplied', async () => {
+      const result = await listIndexerEvents({ dbClient: makeFakeKnex([]) });
+      expect(result.meta.limit).toBe(20);
+    });
+  });
+
+  // ── cursor-mode pagination ──────────────────────────────────────────────
+
+  describe('cursor-mode pagination', () => {
+    test('first page generates a valid nextCursor when hasMore', async () => {
+      const events = Array.from({ length: 6 }, (_, i) =>
+        makeEvent({ event_id: `e${i}`, observed_at: new Date(2026, 0, i + 1) })
+      );
+      const result = await listIndexerEvents({
+        pagination: { limit: 5 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.hasMore).toBe(true);
+      expect(typeof result.meta.nextCursor).toBe('string');
+      expect(result.meta.nextCursor.length).toBeGreaterThan(10);
+    });
+
+    test('nextCursor decodes to the correct sort anchor', async () => {
+      const events = Array.from({ length: 6 }, (_, i) =>
+        makeEvent({
+          event_id: `e${String(i).padStart(3, '0')}`,
+          observed_at: new Date(2026, 0, i + 1),
+        })
+      );
+      const result = await listIndexerEvents({
+        sorting: { sortBy: 'observed_at', order: 'asc' },
+        pagination: { limit: 5 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.nextCursor).toBeTruthy();
+      const decoded = decodeCursor(result.meta.nextCursor, 'observed_at');
+      expect(decoded.sortField).toBe('observed_at');
+      expect(decoded.id).toBe(result.data[4].event_id);
+    });
+
+    test('no nextCursor on the last page', async () => {
+      const events = Array.from({ length: 3 }, (_, i) => makeEvent({ event_id: `e${i}` }));
+      const result = await listIndexerEvents({
+        pagination: { limit: 10 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.hasMore).toBe(false);
+      expect(result.meta.nextCursor).toBeNull();
+    });
+
+    test('throws CursorError for a tampered cursor', async () => {
+      await expect(
+        listIndexerEvents({
+          pagination: { cursor: 'tampered.cursor.value' },
+          dbClient: makeFakeKnex([]),
+        })
+      ).rejects.toBeInstanceOf(CursorError);
+    });
+
+    test('cursor with ledger_sequence sort field works', async () => {
+      const events = Array.from({ length: 6 }, (_, i) =>
+        makeEvent({ event_id: `e${i}`, ledger_sequence: 100 + i })
+      );
+      const result = await listIndexerEvents({
+        sorting: { sortBy: 'ledger_sequence', order: 'asc' },
+        pagination: { limit: 5 },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.hasMore).toBe(true);
+      const decoded = decodeCursor(result.meta.nextCursor, 'ledger_sequence');
+      expect(decoded.sortField).toBe('ledger_sequence');
+    });
+
+    test('throws CursorError for sort-field mismatch', async () => {
+      // Encode cursor for observed_at but request ledger_sequence
+      const cursor = encodeCursor({ sortField: 'observed_at', sortValue: 'v', id: 'e1' });
+      await expect(
+        listIndexerEvents({
+          sorting: { sortBy: 'ledger_sequence' },
+          pagination: { cursor },
+          dbClient: makeFakeKnex([]),
+        })
+      ).rejects.toBeInstanceOf(CursorError);
+    });
+  });
+
+  // ── filters ────────────────────────────────────────────────────────────
+
+  describe('filters', () => {
+    test('invoiceId filter narrows result set', async () => {
+      const events = [
+        makeEvent({ event_id: 'e1', invoice_id: 'inv_A' }),
+        makeEvent({ event_id: 'e2', invoice_id: 'inv_B' }),
+        makeEvent({ event_id: 'e3', invoice_id: 'inv_A' }),
+      ];
+      const result = await listIndexerEvents({
+        filters: { invoiceId: 'inv_A' },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.total).toBe(2);
+    });
+
+    test('eventType filter narrows result set', async () => {
+      const events = [
+        makeEvent({ event_id: 'e1', event_type: 'escrow_created' }),
+        makeEvent({ event_id: 'e2', event_type: 'escrow_funded' }),
+      ];
+      const result = await listIndexerEvents({
+        filters: { eventType: 'escrow_created' },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.total).toBe(1);
+      expect(result.data[0].event_id).toBe('e1');
+    });
+
+    test('combined filters apply AND logic', async () => {
+      const CADDR = 'CDLZFC3SYJ27SBCC6BAKCY73WFXHBTE357R67CW567QX65ECUGN45RXI';
+      const events = [
+        makeEvent({ event_id: 'e1', invoice_id: 'inv_A', contract_id: CADDR }),
+        makeEvent({ event_id: 'e2', invoice_id: 'inv_A', contract_id: null }),
+        makeEvent({ event_id: 'e3', invoice_id: 'inv_B', contract_id: CADDR }),
+      ];
+      const result = await listIndexerEvents({
+        filters: { invoiceId: 'inv_A', contractId: CADDR },
+        dbClient: makeFakeKnex(events),
+      });
+
+      expect(result.meta.total).toBe(1);
+      expect(result.data[0].event_id).toBe('e1');
+    });
+  });
+
+  // ── sorting ────────────────────────────────────────────────────────────
+
+  describe('sorting', () => {
+    test('accepts ledger_sequence as sortBy without error', async () => {
+      const result = await listIndexerEvents({
+        sorting: { sortBy: 'ledger_sequence', order: 'asc' },
+        dbClient: makeFakeKnex([]),
+      });
+      expect(result.data).toEqual([]);
+    });
+
+    test('unknown sortBy falls back to observed_at gracefully', async () => {
+      const result = await listIndexerEvents({
+        sorting: { sortBy: 'not_a_real_field' },
+        dbClient: makeFakeKnex([makeEvent({ event_id: 'e1' })]),
+      });
+      expect(result.data).toHaveLength(1);
+    });
+
+    test('default sort field is observed_at', async () => {
+      const result = await listIndexerEvents({ dbClient: makeFakeKnex([]) });
+      // No error, meta is defined — default sort applied silently
+      expect(result.meta).toBeDefined();
+    });
+  });
+
+  // ── INDEXER_SORT_FIELDS constant ───────────────────────────────────────
+
+  test('INDEXER_SORT_FIELDS contains observed_at and ledger_sequence', () => {
+    expect(INDEXER_SORT_FIELDS).toContain('observed_at');
+    expect(INDEXER_SORT_FIELDS).toContain('ledger_sequence');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 2: cursorPagination — new sort fields
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('cursorPagination – indexer sort fields', () => {
+  let encodeCursor;
+  let decodeCursor;
+  let CursorError;
+  let ALLOWED_SORT_FIELDS;
+
+  beforeAll(() => {
+    ({ encodeCursor, decodeCursor, CursorError, ALLOWED_SORT_FIELDS } =
+      require('../src/utils/cursorPagination'));
+  });
+
+  test('ALLOWED_SORT_FIELDS includes observed_at', () => {
+    expect(ALLOWED_SORT_FIELDS).toContain('observed_at');
+  });
+
+  test('ALLOWED_SORT_FIELDS includes ledger_sequence', () => {
+    expect(ALLOWED_SORT_FIELDS).toContain('ledger_sequence');
+  });
+
+  test('encodeCursor succeeds for observed_at', () => {
+    const cursor = encodeCursor({
+      sortField: 'observed_at',
+      sortValue: '2026-01-01T00:00:00.000Z',
+      id: 'evt_123',
+    });
+    expect(typeof cursor).toBe('string');
+    expect(cursor).toContain('.');
+  });
+
+  test('encodeCursor succeeds for ledger_sequence', () => {
+    const cursor = encodeCursor({
+      sortField: 'ledger_sequence',
+      sortValue: 42000,
+      id: 'evt_456',
+    });
+    expect(typeof cursor).toBe('string');
+  });
+
+  test('decodeCursor round-trips observed_at cursor', () => {
+    const orig = { sortField: 'observed_at', sortValue: '2026-06-01T10:00:00Z', id: 'e001' };
+    const decoded = decodeCursor(encodeCursor(orig), 'observed_at');
+    expect(decoded.sortField).toBe('observed_at');
+    expect(decoded.sortValue).toBe(orig.sortValue);
+    expect(decoded.id).toBe('e001');
+  });
+
+  test('decodeCursor round-trips ledger_sequence cursor', () => {
+    const cursor = encodeCursor({ sortField: 'ledger_sequence', sortValue: 99999, id: 'e002' });
+    const decoded = decodeCursor(cursor, 'ledger_sequence');
+    expect(decoded.sortField).toBe('ledger_sequence');
+    expect(decoded.sortValue).toBe(99999);
+    expect(decoded.id).toBe('e002');
+  });
+
+  test('encodeCursor throws for an unknown sort field', () => {
+    expect(() =>
+      encodeCursor({ sortField: 'unknown_field', sortValue: 1, id: 'e001' })
+    ).toThrow();
+  });
+
+  test('decodeCursor throws CursorError for malformed cursor', () => {
+    expect(() => decodeCursor('not-a-valid-cursor', 'observed_at')).toThrow(CursorError);
+  });
+
+  test('decodeCursor throws CursorError for tampered signature', () => {
+    const valid = encodeCursor({ sortField: 'observed_at', sortValue: 'v', id: 'e1' });
+    const lastDot = valid.lastIndexOf('.');
+    const sig = valid.slice(lastDot + 1);
+    const tampered = valid.slice(0, lastDot + 1) +
+      sig.slice(0, -1) + (sig.slice(-1) === 'a' ? 'b' : 'a');
+    expect(() => decodeCursor(tampered, 'observed_at')).toThrow(CursorError);
+  });
+
+  test('decodeCursor throws CursorError when sortField mismatches', () => {
+    const cursor = encodeCursor({ sortField: 'observed_at', sortValue: 'v', id: 'e1' });
+    expect(() => decodeCursor(cursor, 'ledger_sequence')).toThrow(CursorError);
+  });
+
+  test('existing marketplace sort fields still accepted (backward compat)', () => {
+    for (const field of ['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at']) {
+      const cursor = encodeCursor({ sortField: field, sortValue: 1, id: 'e1' });
+      const decoded = decodeCursor(cursor, field);
+      expect(decoded.sortField).toBe(field);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 3: Route integration tests (GET /api/admin/indexer/events)
+// Uses supertest with a top-level jest.mock on the db so no real DB is hit.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Top-level mock for the db — must be hoisted before any require of app/service
+jest.mock('../src/db/knex', () => {
+  const q = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    count: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue({ total: 0, 'count(*)': 0 }),
+    then: jest.fn(function (resolve) {
+      return Promise.resolve([]).then(resolve);
+    }),
+  };
+  const mockDb = jest.fn(() => q);
+  mockDb._q = q;
+  return mockDb;
+});
+
+describe('GET /api/admin/indexer/events route', () => {
+  const request = require('supertest');
+  const jwt = require('jsonwebtoken');
+  const { createApp } = require('../src/app');
+  const db = require('../src/db/knex');
+  const { encodeCursor, CursorError } = require('../src/utils/cursorPagination');
+
+  const SECRET = process.env.JWT_SECRET;
+  const ISS = process.env.JWT_ISSUER || 'liquifact';
+  const AUD = process.env.JWT_AUDIENCE || 'liquifact-api';
+
+  function makeAdminToken(tenantId = 'tenant-test') {
+    return jwt.sign(
+      { sub: 'admin-user', tenantId, role: 'admin' },
+      SECRET,
+      { algorithm: 'HS256', issuer: ISS, audience: AUD },
+    );
+  }
+
+  let app;
+  let mockQ;
+  const adminToken = makeAdminToken();
+
+  beforeAll(() => {
+    app = createApp();
+    mockQ = db._q;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: count returns 0, data returns []
+    mockQ.first.mockResolvedValue({ total: 0, 'count(*)': 0 });
+    mockQ.then.mockImplementation(function (resolve) {
+      return Promise.resolve([]).then(resolve);
+    });
+  });
+
+  // ── auth guard ──────────────────────────────────────────────────────────
+
+  test('401 when no Authorization header', async () => {
+    const res = await request(app).get('/api/admin/indexer/events');
+    expect(res.status).toBe(401);
+  });
+
+  test('401 for invalid Bearer token', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('Authorization', 'Bearer not.a.valid.jwt');
+    expect(res.status).toBe(401);
+  });
+
+  // ── successful responses ────────────────────────────────────────────────
+
+  test('200 with empty data array when no events exist', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.total).toBe(0);
+    expect(res.body.meta.hasMore).toBe(false);
+    expect(res.body.meta.nextCursor).toBeNull();
+    expect(res.body.message).toBe('Indexer events retrieved successfully.');
+  });
+
+  test('200 with event rows returned from DB', async () => {
+    const rows = [makeEvent({ event_id: 'e1' }), makeEvent({ event_id: 'e2' })];
+    mockQ.first.mockResolvedValue({ total: 2, 'count(*)': 2 });
+    mockQ.then.mockImplementation(function (resolve) {
+      return Promise.resolve(rows).then(resolve);
+    });
+
+    const res = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  // ── query parameter validation → 400 ───────────────────────────────────
+
+  test('400 for limit > 100', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?limit=101')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/limit/i);
+  });
+
+  test('400 for limit = 0', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?limit=0')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+  });
+
+  test('400 for page < 1', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?page=0')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/page/i);
+  });
+
+  test('400 for invalid sortBy', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?sortBy=yield_bps')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/sortBy/i);
+  });
+
+  test('400 for invalid order', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?order=sideways')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/order/i);
+  });
+
+  test('400 for invalid invoiceId (contains space)', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?invoiceId=has%20spaces')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/invoiceId/i);
+  });
+
+  test('400 for invalid contractId format', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?contractId=BADADDR')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/contractId/i);
+  });
+
+  test('400 for empty cursor string', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?cursor=')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+  });
+
+  test('400 for malformed cursor (invalid signature)', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?cursor=tampered.invalid.sig')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/cursor/i);
+  });
+
+  // ── valid parameter acceptance ──────────────────────────────────────────
+
+  test('200 with limit=1 (minimum boundary)', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?limit=1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with limit=100 (maximum boundary)', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?limit=100')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with sortBy=observed_at', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?sortBy=observed_at')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with sortBy=ledger_sequence', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?sortBy=ledger_sequence')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with order=ASC (case-insensitive)', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?order=ASC')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with valid invoiceId filter', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?invoiceId=inv_123')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with valid eventType filter', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events?eventType=escrow_funded')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('200 with valid cursor from encodeCursor', async () => {
+    const cursor = encodeCursor({ sortField: 'observed_at', sortValue: 'v', id: 'e1' });
+    const res = await request(app)
+      .get(`/api/admin/indexer/events?cursor=${encodeURIComponent(cursor)}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+  });
+
+  test('page is ignored when cursor is supplied', async () => {
+    const cursor = encodeCursor({ sortField: 'observed_at', sortValue: 'v', id: 'e1' });
+    const res = await request(app)
+      .get(`/api/admin/indexer/events?cursor=${encodeURIComponent(cursor)}&page=99`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    // page=99 would be invalid in offset mode but is silently ignored with cursor
+    expect(res.status).toBe(200);
+  });
+
+  test('400 for eventType longer than 128 chars', async () => {
+    const tooLong = 'a'.repeat(129);
+    const res = await request(app)
+      .get(`/api/admin/indexer/events?eventType=${tooLong}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/eventType/i);
+  });
+
+  test('400 for invoiceId longer than 128 chars', async () => {
+    const tooLong = 'a'.repeat(129);
+    const res = await request(app)
+      .get(`/api/admin/indexer/events?invoiceId=${tooLong}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(400);
+  });
+
+  test('200 with no query params (all defaults)', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+    expect(res.body.meta).toBeDefined();
+    expect(res.body.meta.limit).toBe(20);
+  });
+
+  test('response shape includes data, meta, and message', async () => {
+    const res = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(typeof res.body.meta).toBe('object');
+    expect(typeof res.body.message).toBe('string');
+    expect(res.body.meta).toHaveProperty('total');
+    expect(res.body.meta).toHaveProperty('hasMore');
+    expect(res.body.meta).toHaveProperty('limit');
+    expect(res.body.meta).toHaveProperty('nextCursor');
+  });
+});


### PR DESCRIPTION
Closes #667 
- Add GET /api/admin/indexer/events with cursor + offset pagination
- Bounded page size (default 20, max 100), HMAC-signed opaque cursors
- Filters: invoiceId, eventType, contractId (stable across pages)
- Sort fields: observed_at (default), ledger_sequence
- CursorError maps to HTTP 400; admin-only via adminStack
- Extend ALLOWED_SORT_FIELDS in cursorPagination.js
- 57 tests covering cursor mode, offset mode, edge cases, auth, validation
