### PR TITLE
Feature/health 02 validation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -38,6 +38,7 @@ const {
   urlencodedBodyLimit,
 } = require('./middleware/bodySizeLimits');
 const { performHealthChecks, performReadinessChecks } = require('./services/health');
+const { validateHealthQuery, rejectBodyOnGet } = require('./schemas/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
@@ -153,7 +154,7 @@ function createApp() {
   // ── Health / Liveness / Readiness ──────────────────────────────────────
 
   // Liveness probe — no external dependencies
-  app.get('/health', (req, res) => {
+  app.get('/health', rejectBodyOnGet, validateHealthQuery, (req, res) => {
     res.json({
       status: 'ok',
       service: 'liquifact-api',
@@ -163,7 +164,7 @@ function createApp() {
   });
 
   // Liveness alias (Kubernetes convention)
-  app.get('/healthz', (req, res) => {
+  app.get('/healthz', rejectBodyOnGet, validateHealthQuery, (req, res) => {
     res.json({
       status: 'ok',
       service: 'liquifact-api',
@@ -173,7 +174,7 @@ function createApp() {
   });
 
   // Full health check (all dependencies)
-  app.get('/ready', async (req, res) => {
+  app.get('/ready', rejectBodyOnGet, validateHealthQuery, async (req, res) => {
     try {
       const { healthy, checks } = await performHealthChecks();
       const status = healthy ? 200 : 503;
@@ -195,7 +196,7 @@ function createApp() {
   });
 
   // Readiness probe (critical deps only: DB, Soroban RPC)
-  app.get('/readyz', async (req, res) => {
+  app.get('/readyz', rejectBodyOnGet, validateHealthQuery, async (req, res) => {
     try {
       const { healthy, checks } = await performReadinessChecks();
       const status = healthy ? 200 : 503;

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -28,6 +28,7 @@ const { computeEscrowDerivedFields } = require('../../services/escrowDerived');
 const AppError = require('../../errors/AppError');
 const { invoiceCreateSchema, invoiceUpdateSchema, parseValidationErrors } = require('../../schemas/invoice');
 const { validatePatchFields, detectLockedFieldChange } = require('../../middleware/patchInvoice');
+const { validateHealthQuery, rejectBodyOnGet } = require('../../schemas/health');
 
 // ── Sub-router mounts ────────────────────────────────────────────────────────
 router.use('/invest', investRoutes);
@@ -35,7 +36,7 @@ router.use('/sme', smeRouter);
 
 // ── Utility routes ───────────────────────────────────────────────────────────
 
-router.get('/health', (req, res) => {
+router.get('/health', rejectBodyOnGet, validateHealthQuery, (req, res) => {
   return res.json({
     status: 'ok',
     service: 'liquifact-api',

--- a/src/schemas/health.js
+++ b/src/schemas/health.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * @fileoverview Zod schemas for health endpoint query validation.
+ *
+ * Exposes:
+ *  - `healthQuerySchema` — strict query schema (rejects unknown keys)
+ *  - `validateHealthQuery` — Express middleware for query validation
+ *  - `rejectBodyOnGet` — Express middleware to reject request bodies on GET requests
+ *
+ * @module schemas/health
+ */
+
+const { z } = require('zod');
+
+/**
+ * Health query schema — accepts empty object (no query params allowed)
+ * but strictly rejects any unknown fields with a clear error message.
+ *
+ * @type {z.ZodObject<{}>}
+ */
+const healthQuerySchema = z.object({}).strict();
+
+/**
+ * Express middleware factory for validating health endpoint query parameters.
+ *
+ * Uses Zod to validate query parameters against `healthQuerySchema`.
+ * Returns a 400 RFC 7807 Problem Details response on validation failure.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @returns {void}
+ */
+function validateHealthQuery(req, res, next) {
+  const result = healthQuerySchema.safeParse(req.query);
+
+  if (!result.success) {
+    const fieldErrors = {};
+    for (const issue of result.error.issues) {
+      const path = issue.path.join('.');
+      if (!fieldErrors[path]) {
+        fieldErrors[path] = [];
+      }
+      fieldErrors[path].push(issue.message);
+    }
+
+    return res.status(400).json({
+      type: 'https://liquifact.io/problems/validation-error',
+      title: 'Validation Error',
+      status: 400,
+      detail: 'Query parameters contain invalid or unknown fields.',
+      instance: req.originalUrl,
+      code: 'VALIDATION_ERROR',
+      fieldErrors,
+    });
+  }
+
+  next();
+}
+
+/**
+ * Express middleware to reject request bodies on GET/HEAD requests.
+ *
+ * Health endpoints are read-only and should never accept request bodies.
+ * This middleware checks if a body was parsed and returns 400 if present.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @returns {void}
+ */
+function rejectBodyOnGet(req, res, next) {
+  // Only reject on GET/HEAD requests (health endpoints)
+  if ((req.method === 'GET' || req.method === 'HEAD') && req.body && Object.keys(req.body).length > 0) {
+    return res.status(400).json({
+      type: 'https://liquifact.io/problems/validation-error',
+      title: 'Validation Error',
+      status: 400,
+      detail: 'GET/HEAD requests must not include a request body.',
+      instance: req.originalUrl,
+      code: 'INVALID_BODY_ON_GET',
+      fieldErrors: {
+        body: ['Request body is not allowed on GET/HEAD requests'],
+      },
+    });
+  }
+
+  next();
+}
+
+module.exports = {
+  healthQuerySchema,
+  validateHealthQuery,
+  rejectBodyOnGet,
+};

--- a/tests/health.validation.test.js
+++ b/tests/health.validation.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/**
+ * Integration tests for health endpoint input validation.
+ *
+ * Covers:
+ * - Request body rejection on GET endpoints
+ * - Unknown query parameter rejection
+ * - RFC 7807 compliant error responses
+ */
+
+const request = require('supertest');
+const { createApp } = require('../src/app');
+
+describe('Health endpoint input validation', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  describe('Request body rejection on GET endpoints', () => {
+    const testEndpoints = ['/health', '/healthz', '/ready', '/readyz'];
+
+    testEndpoints.forEach((endpoint) => {
+      it(`rejects request body on GET ${endpoint} with 400`, async () => {
+        const res = await request(app)
+          .get(endpoint)
+          .send({ unexpected: 'body' })
+          .set('Content-Type', 'application/json');
+
+        expect(res.status).toBe(400);
+        expect(res.body.type).toBe('https://liquifact.io/problems/validation-error');
+        expect(res.body.title).toBe('Validation Error');
+        expect(res.body.status).toBe(400);
+        expect(res.body.detail).toBe('GET/HEAD requests must not include a request body.');
+        expect(res.body.fieldErrors).toBeDefined();
+        expect(res.body.fieldErrors.body).toContain('Request body is not allowed on GET/HEAD requests');
+      });
+    });
+  });
+
+  describe('Unknown query parameter rejection', () => {
+    const testEndpoints = ['/health', '/healthz', '/ready', '/readyz'];
+
+    testEndpoints.forEach((endpoint) => {
+      it(`rejects unknown query parameters on ${endpoint} with 400`, async () => {
+        const res = await request(app)
+          .get(`${endpoint}?unknown=param`);
+
+        expect(res.status).toBe(400);
+        expect(res.body.type).toBe('https://liquifact.io/problems/validation-error');
+        expect(res.body.title).toBe('Validation Error');
+        expect(res.body.status).toBe(400);
+        expect(res.body.detail).toBe('Query parameters contain invalid or unknown fields.');
+        expect(res.body.fieldErrors).toBeDefined();
+        // Zod strict() reports unknown keys at root level with empty path
+        expect(res.body.fieldErrors['']).toContain('Unrecognized key: "unknown"');
+      });
+
+      it(`rejects multiple unknown query parameters on ${endpoint}`, async () => {
+        const res = await request(app)
+          .get(`${endpoint}?param1=value1&param2=value2`);
+
+        expect(res.status).toBe(400);
+        // Both unknown params appear at root level, combined in one message
+        expect(res.body.fieldErrors['']).toContain('Unrecognized keys: "param1", "param2"');
+      });
+    });
+  });
+
+  describe('Valid requests still work', () => {
+    it('GET /health returns 200 with no query params', async () => {
+      const res = await request(app).get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ok');
+      expect(res.body.service).toBe('liquifact-api');
+    });
+
+    it('GET /healthz returns 200 with no query params', async () => {
+      const res = await request(app).get('/healthz');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ok');
+    });
+
+    it('GET /ready returns 200 or 503 (depends on deps)', async () => {
+      const res = await request(app).get('/ready');
+      expect([200, 503]).toContain(res.status);
+      expect(res.body).toHaveProperty('ready');
+      expect(res.body).toHaveProperty('service', 'liquifact-api');
+    });
+
+    it('GET /readyz returns 200 or 503', async () => {
+      const res = await request(app).get('/readyz');
+      expect([200, 503]).toContain(res.status);
+      expect(res.body).toHaveProperty('ready');
+      expect(res.body).toHaveProperty('service', 'liquifact-api');
+    });
+  });
+
+  describe('RFC 7807 error response structure', () => {
+    it('body rejection includes all required RFC 7807 fields', async () => {
+      const res = await request(app)
+        .get('/health')
+        .send({ test: 'body' })
+        .set('Content-Type', 'application/json');
+
+      expect(res.status).toBe(400);
+      expect(res.body.type).toMatch(/^https?:\/\//);
+      expect(res.body.title).toBe('Validation Error');
+      expect(res.body.status).toBe(400);
+      expect(res.body.detail).toBeDefined();
+      expect(res.body.instance).toBeDefined();
+      expect(res.body.fieldErrors).toBeDefined();
+    });
+
+    it('query param rejection includes all required RFC 7807 fields', async () => {
+      const res = await request(app).get('/health?invalid=param');
+
+      expect(res.status).toBe(400);
+      expect(res.body.type).toMatch(/^https?:\/\//);
+      expect(res.body.title).toBe('Validation Error');
+      expect(res.body.status).toBe(400);
+      expect(res.body.detail).toBeDefined();
+      expect(res.body.instance).toBeDefined();
+      expect(res.body.fieldErrors).toBeDefined();
+    });
+
+    it('fieldErrors uses field path as key with array of messages', async () => {
+      const res = await request(app).get('/health?foo=bar&baz=qux');
+
+      expect(res.body.fieldErrors).toBeDefined();
+      expect(Array.isArray(res.body.fieldErrors[''])).toBe(true);
+      // Zod combines multiple unknown keys into one message
+      expect(res.body.fieldErrors['']).toContain('Unrecognized keys: "foo", "baz"');
+    });
+  });
+
+  describe('HEAD requests also reject bodies', () => {
+    it.skip('HEAD requests with body are rejected by middleware', () => {
+      // HEAD requests with body are not supported by supertest/superagent
+      // The middleware handles it but we can't test via supertest
+    });
+  });
+});

--- a/tests/integration/v1.escrow.indexer.test.js
+++ b/tests/integration/v1.escrow.indexer.test.js
@@ -1,0 +1,345 @@
+'use strict';
+
+/**
+ * Integration tests for the v1 escrow indexer endpoint.
+ * 
+ * Covers success, not-found, validation-failure, and idempotent-repeat paths.
+ * Uses an in-memory mock database for fast, isolated tests.
+ */
+
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+// Mock the database with an in-memory store (similar to tests/escrow.read.test.js)
+jest.mock('../../src/db/knex', () => {
+  const rows = new Map();
+  const fakeDb = jest.fn((table) => ({
+    _table: table,
+    _whereId: null,
+    where(field, value) {
+      if (typeof field === 'string') {
+        this._whereId = String(value);
+      }
+      return this;
+    },
+    async first() {
+      if (!this._whereId) return null;
+      return rows.get(this._whereId) || null;
+    },
+    async del() {
+      rows.clear();
+      return 0;
+    },
+    async destroy() {
+      rows.clear();
+    },
+    async insert(payload) {
+      const entries = Array.isArray(payload) ? payload : [payload];
+      entries.forEach((entry) => {
+        if (entry && entry.invoice_id) {
+          rows.set(entry.invoice_id, entry);
+        }
+      });
+      return entries.length;
+    },
+  }));
+  fakeDb.destroy = async () => {
+    rows.clear();
+  };
+  return fakeDb;
+}, { virtual: true });
+
+const db = require('../../src/db/knex');
+const v1Router = require('../../src/routes/v1/index');
+const { errorHandler } = require('../../src/middleware/errorHandler');
+const { problemJsonHandler } = require('../../src/middleware/problemJson');
+
+// Mock the escrowMap to return a valid address for our test invoice
+jest.mock('../../src/config/escrowMap', () => ({
+  resolveEscrowAddress: jest.fn((id) => {
+    if (id === 'unknown-inv' || id === 'not-mapped') return null;
+    if (id === 'inv_test_123') return 'C_ESCROW_FOR_INV_TEST_123';
+    return `C_ESCROW_FOR_${id.toUpperCase()}`;
+  }),
+}));
+
+// Mock soroban to test fallback
+jest.mock('../../src/services/soroban', () => ({
+  callSorobanContract: jest.fn(async (operation) => {
+    return operation();
+  }),
+}));
+
+const TEST_JWT_SECRET = process.env.JWT_SECRET || 'test-secret-at-least-32-characters-long-string-for-jest';
+
+const VALID_INVOICE_ID = 'inv_test_123';
+const ESCROW_ADDRESS = 'C_ESCROW_FOR_INV_TEST_123';
+
+function buildTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/v1', v1Router);
+  app.use(problemJsonHandler);
+  app.use(errorHandler);
+  return app;
+}
+
+function createAuthToken(payload = { sub: 'test-user', role: 'user' }) {
+  return jwt.sign(payload, TEST_JWT_SECRET, { expiresIn: '1h', algorithm: 'HS256' });
+}
+
+function getAuthHeader(payload) {
+  return { Authorization: `Bearer ${createAuthToken(payload)}` };
+}
+
+// Helper to seed a projection row
+async function seedProjection(invoiceId, overrides = {}) {
+  await db('escrow_event_projection').insert({
+    invoice_id: invoiceId,
+    latest_event_id: 'evt_1',
+    latest_event_type: 'funded',
+    latest_ledger_sequence: 12345,
+    latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 5000 }),
+    latest_observed_at: new Date().toISOString(),
+    latest_paging_token: '12345-1',
+    ...overrides,
+  });
+}
+
+describe('GET /v1/escrow/:invoiceId — indexer endpoint', () => {
+  let app;
+
+  beforeAll(() => {
+    app = buildTestApp();
+  });
+
+  beforeEach(async () => {
+    await db('escrow_event_projection').del();
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  describe('Success path', () => {
+    it('returns 200 with escrow data when projection exists', async () => {
+      await seedProjection(VALID_INVOICE_ID);
+
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.invoiceId).toBe(VALID_INVOICE_ID);
+      expect(res.body.data.escrowAddress).toBe(ESCROW_ADDRESS);
+      expect(res.body.data.status).toBe('funded');
+      expect(res.body.data.fundedAmount).toBe(5000);
+      expect(res.body.data.latest_ledger_sequence).toBe(12345);
+      expect(res.body.data.fromProjection).toBe(true);
+      expect(res.body.data.daysToMaturity).toBeDefined();
+      expect(res.body.message).toContain('event projection');
+      expect(res.headers['x-escrow-address']).toBe(ESCROW_ADDRESS);
+    });
+
+    it('includes derived fields in response', async () => {
+      await seedProjection(VALID_INVOICE_ID, {
+        latest_event_body: JSON.stringify({
+          status: 'funded',
+          fundedAmount: 7500,
+          maturityDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+        latest_ledger_sequence: 20000,
+      });
+
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.fundedPercent).toBeDefined();
+      expect(res.body.data.daysToMaturity).toBeDefined();
+      expect(res.body.data.apyPercent).toBeDefined();
+    });
+  });
+
+  describe('Not-found path', () => {
+    it('returns 404 when no escrow mapping exists for invoiceId', async () => {
+      const res = await request(app)
+        .get('/v1/escrow/unknown-inv')
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(404);
+      // The escrowMap returns a plain error object, not RFC 7807
+      expect(res.body.error).toBeDefined();
+      expect(res.body.error).toContain("No escrow contract mapping found");
+    });
+
+    it('returns 404 when invoiceId has no projection and no on-chain data', async () => {
+      const res = await request(app)
+        .get('/v1/escrow/not-mapped')
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  describe('Validation-failure path', () => {
+    it('returns 400 for invoiceId starting with invalid character', async () => {
+      const res = await request(app)
+        .get('/v1/escrow/-invalid-start')
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(400);
+      // Returns RFC 7807 format
+      expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(res.body.type).toMatch(/bad-request/);
+      expect(res.body.title).toContain('invoiceId contains invalid characters');
+      expect(res.body.status).toBe(400);
+      expect(res.body.detail).toBeDefined();
+    });
+
+    it('returns 401 when no authorization header provided', async () => {
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`);
+
+      expect(res.status).toBe(401);
+      expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(res.body.type).toMatch(/unauthorized/);
+      expect(res.body.title).toBe('Unauthorized');
+      expect(res.body.status).toBe(401);
+      expect(res.body.detail).toContain('Authentication token is required');
+    });
+
+    it('returns 401 when authorization header is malformed', async () => {
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set('Authorization', 'InvalidToken');
+
+      expect(res.status).toBe(401);
+      expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(res.body.type).toMatch(/unauthorized/);
+      expect(res.body.title).toBe('Unauthorized');
+    });
+
+    it('returns 401 when token is expired', async () => {
+      const expiredToken = jwt.sign(
+        { sub: 'test-user' },
+        TEST_JWT_SECRET,
+        { expiresIn: '-1h', algorithm: 'HS256' }
+      );
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set('Authorization', `Bearer ${expiredToken}`);
+
+      expect(res.status).toBe(401);
+      expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(res.body.type).toMatch(/token-expired/);
+      expect(res.body.title).toBe('Invalid Token');
+      expect(res.body.status).toBe(401);
+      expect(res.body.detail).toContain('Token has expired');
+    });
+  });
+
+  describe('Idempotent-repeat path (cache)', () => {
+    it('returns cached data on second request (idempotent)', async () => {
+      await seedProjection(VALID_INVOICE_ID);
+
+      // First request
+      const res1 = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set(getAuthHeader());
+
+      expect(res1.status).toBe(200);
+      expect(res1.body.data.fundedAmount).toBe(5000);
+
+      // Second request should hit cache
+      const res2 = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set(getAuthHeader());
+
+      expect(res2.status).toBe(200);
+      expect(res2.body.data.fundedAmount).toBe(5000);
+      expect(res2.body.data).toEqual(res1.body.data);
+    });
+
+    it('returns same response shape on repeated calls', async () => {
+      await seedProjection(VALID_INVOICE_ID);
+
+      const responses = await Promise.all([
+        request(app).get(`/v1/escrow/${VALID_INVOICE_ID}`).set(getAuthHeader()),
+        request(app).get(`/v1/escrow/${VALID_INVOICE_ID}`).set(getAuthHeader()),
+        request(app).get(`/v1/escrow/${VALID_INVOICE_ID}`).set(getAuthHeader()),
+      ]);
+
+      responses.forEach((res) => {
+        expect(res.status).toBe(200);
+        expect(res.body.data.invoiceId).toBe(VALID_INVOICE_ID);
+        expect(res.body.data.escrowAddress).toBe(ESCROW_ADDRESS);
+        expect(res.body.message).toBeDefined();
+      });
+    });
+  });
+
+  describe('Response shape assertions', () => {
+    beforeEach(async () => {
+      await seedProjection(VALID_INVOICE_ID);
+    });
+
+    it('returns RFC 7807 compliant error shape on validation failure', async () => {
+      const res = await request(app)
+        .get('/v1/escrow/-invalid-start')
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(res.body.type).toMatch(/bad-request/);
+      expect(res.body.title).toBeDefined();
+      expect(res.body.status).toBe(400);
+      expect(res.body.detail).toBeDefined();
+      expect(res.body.instance).toBeDefined();
+    });
+
+    it('returns error shape on not-found (from escrowMap)', async () => {
+      const res = await request(app)
+        .get('/v1/escrow/unknown-inv')
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(404);
+      // escrowMap returns plain error object
+      expect(res.body.error).toBeDefined();
+      expect(typeof res.body.error).toBe('string');
+    });
+
+    it('returns RFC 7807 compliant error shape on unauthorized', async () => {
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`);
+
+      expect(res.status).toBe(401);
+      expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(res.body.type).toMatch(/unauthorized/);
+      expect(res.body.title).toBe('Unauthorized');
+      expect(res.body.status).toBe(401);
+      expect(res.body.detail).toBeDefined();
+      expect(res.body.instance).toBeDefined();
+    });
+
+    it('success response includes required fields', async () => {
+      const res = await request(app)
+        .get(`/v1/escrow/${VALID_INVOICE_ID}`)
+        .set(getAuthHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.message).toBeDefined();
+      expect(typeof res.body.data.invoiceId).toBe('string');
+      expect(typeof res.body.data.escrowAddress).toBe('string');
+      expect(typeof res.body.data.status).toBe('string');
+      expect(typeof res.body.data.fundedAmount).toBe('number');
+      expect(typeof res.body.data.fromProjection).toBe('boolean');
+      expect(res.headers['x-escrow-address']).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Adds strict input validation to all health endpoints (`/health`, `/healthz`, `/ready`, `/readyz`, `/v1/health`) rejecting request bodies on GET/HEAD with 400 `INVALID_BODY_ON_GET` and unknown query parameters with 400 `VALIDATION_ERROR`. Error responses follow RFC 7807 `application/problem+json`. Includes comprehensive tests covering body rejection, unknown query params, and valid requests. 

Closes #678