### PR TITLE
test(health): add focused health and readiness endpoint coverage

### DIFF
--- a/tests/health.endpoint.test.js
+++ b/tests/health.endpoint.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const request = require('supertest');
+
+jest.mock('../src/services/health', () => ({
+  performHealthChecks: jest.fn(),
+  performReadinessChecks: jest.fn(),
+}));
+
+const { createApp } = require('../src/app');
+const { performHealthChecks, performReadinessChecks } = require('../src/services/health');
+
+describe('Health endpoint coverage', () => {
+  let app;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    performHealthChecks.mockReset();
+    performReadinessChecks.mockReset();
+
+    performHealthChecks.mockResolvedValue({
+      healthy: true,
+      checks: {
+        database: { status: 'healthy' },
+        soroban: { status: 'healthy' },
+      },
+    });
+
+    performReadinessChecks.mockResolvedValue({
+      healthy: true,
+      checks: {
+        database: { status: 'healthy' },
+        soroban: { status: 'healthy' },
+      },
+    });
+  });
+
+  it('GET /health returns 200 with liveness payload', async () => {
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'ok',
+      service: 'liquifact-api',
+      version: expect.any(String),
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('GET /healthz returns 200 with the same liveness payload', async () => {
+    const res = await request(app).get('/healthz');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'ok',
+      service: 'liquifact-api',
+      version: expect.any(String),
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('GET /ready returns 200 when health checks are healthy', async () => {
+    const res = await request(app).get('/ready');
+
+    expect(performHealthChecks).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ready: true,
+      service: 'liquifact-api',
+      checks: {
+        database: { status: 'healthy' },
+        soroban: { status: 'healthy' },
+      },
+    });
+  });
+
+  it('GET /ready returns 503 when health checks are unhealthy', async () => {
+    performHealthChecks.mockResolvedValueOnce({
+      healthy: false,
+      checks: {
+        database: { status: 'unhealthy', error: 'Database unreachable' },
+        soroban: { status: 'healthy' },
+      },
+    });
+
+    const res = await request(app).get('/ready');
+
+    expect(performHealthChecks).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      ready: false,
+      service: 'liquifact-api',
+      checks: {
+        database: { status: 'unhealthy', error: 'Database unreachable' },
+        soroban: { status: 'healthy' },
+      },
+    });
+  });
+
+  it('GET /readyz returns 200 when readiness checks are healthy', async () => {
+    const res = await request(app).get('/readyz');
+
+    expect(performReadinessChecks).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ready: true,
+      service: 'liquifact-api',
+      checks: {
+        database: { status: 'healthy' },
+        soroban: { status: 'healthy' },
+      },
+    });
+  });
+
+  it('GET /readyz returns 503 when readiness checks are unhealthy', async () => {
+    performReadinessChecks.mockResolvedValueOnce({
+      healthy: false,
+      checks: {
+        database: { status: 'unhealthy', error: 'Database unreachable' },
+        soroban: { status: 'healthy' },
+      },
+    });
+
+    const res = await request(app).get('/readyz');
+
+    expect(performReadinessChecks).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      ready: false,
+      service: 'liquifact-api',
+      checks: {
+        database: { status: 'unhealthy', error: 'Database unreachable' },
+        soroban: { status: 'healthy' },
+      },
+    });
+  });
+});


### PR DESCRIPTION
# closes #679

## Summary

This PR adds focused test coverage for the API liveness and readiness endpoints in `src/app.js`.

## What changed

- Added `tests/health.endpoint.test.js`
- Verified `GET /health` returns a 200 liveness response with the expected JSON shape
- Verified `GET /healthz` returns a 200 liveness response with the same expected shape
- Verified `GET /ready` returns 200 when dependency health checks are healthy
- Verified `GET /ready` returns 503 when dependency health checks are unhealthy
- Verified `GET /readyz` returns 200 when readiness checks are healthy
- Verified `GET /readyz` returns 503 when readiness checks are unhealthy
- Used mocked `performHealthChecks` and `performReadinessChecks` to ensure deterministic behavior

## Why this change

The existing test suite covers readiness probe internals and storage readiness, but there was a gap for direct endpoint behavior and response shape validation for `GET /health`, `GET /healthz`, `GET /ready`, and `GET /readyz`.

## Testing

Executed:

- `npx jest tests/health.endpoint.test.js --runInBand --silent`
- `npx jest tests/health.endpoint.test.js tests/health.readiness.test.js --runInBand --silent`

Results:

- `2` test suites passed
- `28` tests passed

## Notes

- The branch is `test/health-01-endpoint`
- The new test file is committed and pushed to `origin/test/health-01-endpoint`
- This PR is intended to address improved health endpoint coverage and reliability for issue #679
