### PR TITLE
test(cors): add allowlist trailing-slash, case-variant, null-origin, and subdomain bypass tests (#631)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,12 @@
   "jest": {
     "testEnvironment": "node",
     "transformIgnorePatterns": [],
-    "testPathIgnorePatterns": [],
+    "testPathIgnorePatterns": [
+      "<rootDir>/dist/"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/"
+    ],
     "moduleNameMapper": {
       "^node:test$": "<rootDir>/tests/mocks/node_test_shim.js",
       "^node:assert/strict$": "<rootDir>/tests/mocks/node_assert_shim.js"

--- a/src/config/cors.test.js
+++ b/src/config/cors.test.js
@@ -951,4 +951,96 @@ describe('CORS configuration module', () => {
       });
     });
   });
+
+  // ─── Express middleware integration (driving cors(createCorsOptions())) ──
+
+  describe('express CORS middleware integration', () => {
+    function setupApp(corsOrigins) {
+      const express = require('express');
+      const cors = require('cors');
+      const { createCorsOptions } = require('./cors');
+
+      const app = express();
+      app.use(
+        cors(
+          createCorsOptions({
+            NODE_ENV: 'production',
+            CORS_ORIGINS: corsOrigins,
+          })
+        )
+      );
+      app.get('/test', (req, res) => res.json({ ok: true }));
+      app.use((err, req, res, _next) => {
+        if (err && err.isCorsOriginRejected) {
+          return res.status(403).json({ error: { message: err.message } });
+        }
+        return res.status(500).json({ error: { message: err.message } });
+      });
+      return app;
+    }
+
+    it('allows exact allowlisted origin', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'https://app.example.com');
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('allows trailing-slash variant of allowlisted origin', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'https://app.example.com/');
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('allows upper-case host variant of allowlisted origin', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'HTTPS://APP.EXAMPLE.COM');
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('rejects literal "null" origin with 403', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'null');
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
+    });
+
+    it('rejects disallowed origin with 403', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'https://evil.com');
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('rejects trailing-slash variant of disallowed origin with 403', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'https://evil.com/');
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('rejects upper-case variant of disallowed origin with 403', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'HTTPS://EVIL.COM');
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('rejects subdomain bypass attempt with 403', async () => {
+      const request = require('supertest');
+      const app = setupApp('https://app.example.com');
+      const res = await request(app).get('/test').set('Origin', 'https://app.example.com.evil.com');
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('handles CORS_ORIGINS configured with trailing slash or uppercase characters', async () => {
+      const request = require('supertest');
+      const app = setupApp('HTTPS://APP.EXAMPLE.COM/');
+      const res = await request(app).get('/test').set('Origin', 'https://app.example.com');
+      expect(res.statusCode).toBe(200);
+    });
+  });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -154,7 +154,7 @@ describe('Server Core Integration Tests', () => {
         .options('/health')
         .set('Origin', allowedOrigin)
         .set('Access-Control-Request-Method', 'GET');
-      
+
       expect(res.statusCode).toBe(204);
       expect(res.headers['access-control-allow-origin']).toBe(allowedOrigin);
     });
@@ -163,18 +163,105 @@ describe('Server Core Integration Tests', () => {
       const res = await request(app)
         .get('/health')
         .set('Origin', allowedOrigin);
-      
+
       expect(res.statusCode).toBe(200);
       expect(res.headers['access-control-allow-origin']).toBe(allowedOrigin);
+    });
+
+    it('should allow requests from a trailing-slash variant of an allowed origin', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'http://localhost:3000/');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe('http://localhost:3000/');
+    });
+
+    it('should allow requests from an upper-case host variant of an allowed origin', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'HTTP://LOCALHOST:3000');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe('HTTP://LOCALHOST:3000');
+    });
+
+    it('should allow requests from a combined upper-case and trailing-slash variant of an allowed origin', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'HTTP://LOCALHOST:3000/');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe('HTTP://LOCALHOST:3000/');
+    });
+
+    it('should reject requests with null origin (literal "null") with 403', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'null');
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
+    });
+
+    it('should reject preflight (OPTIONS) requests with null origin (literal "null") with 403', async () => {
+      const res = await request(app)
+        .options('/health')
+        .set('Origin', 'null')
+        .set('Access-Control-Request-Method', 'GET');
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
     });
 
     it('should reject requests from disallowed origins with 403', async () => {
       const res = await request(app)
         .get('/health')
         .set('Origin', disallowedOrigin);
-      
+
       expect(res.statusCode).toBe(403);
       expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
+    });
+
+    it('should reject requests from upper-case variant of disallowed origins with 403', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'HTTP://MALICIOUS-SITE.COM');
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
+    });
+
+    it('should reject requests from trailing-slash variant of disallowed origins with 403', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'http://malicious-site.com/');
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
+    });
+
+    it('should reject subdomain bypass attempts with 403', async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'http://localhost:3000.attacker.com');
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.message).toBe('CORS policy: origin is not allowed.');
+
+      const res2 = await request(app)
+        .get('/health')
+        .set('Origin', 'http://attacker.localhost:3000');
+
+      expect(res2.statusCode).toBe(403);
+      expect(res2.body.error.message).toBe('CORS policy: origin is not allowed.');
+    });
+
+    it('should allow requests without an Origin header (non-browser / server-to-server)', async () => {
+      const res = await request(app).get('/health');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
     });
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "sourceMap": true
   },


### PR DESCRIPTION
## Description
This PR addresses issue **#631 (Cover CORS allowlist edge cases)** by adding comprehensive unit and Express middleware integration tests for the CORS allowlist validation logic.

The tests drive the actual `cors(createCorsOptions())` Express middleware (using `supertest`), validating exact origins, case-variant hosts/schemes, trailing-slash variants, null-origin rejections, and subdomain bypass prevention.

---

## Changes Made

- **`src/config/cors.test.js`**:
  - Added `express CORS middleware integration` test suite driving the live `cors(createCorsOptions())` middleware.
  - Added assertions for exact allowlisted origins, trailing-slash variants, upper-case scheme/host variants, literal `"null"` origin rejection (sandboxed iframes), disallowed origin rejection, trailing-slash & case-variant disallowed origin rejection, and subdomain bypass prevention (`app.example.com.evil.com`).
  - Added test coverage verifying that origins configured with trailing slashes or upper-case characters in `CORS_ORIGINS` are correctly normalized.
- **`tests/server.test.js`**:
  - Expanded `CORS Policy` integration tests driving the primary Express app instance via `supertest`.
- **`package.json` & `tsconfig.build.json`**:
  - Added `modulePathIgnorePatterns` for `dist/` to avoid Jest module resolution conflicts.
  - Adjusted `rootDir` in `tsconfig.build.json` for clean builds.

---

## Edge Cases Covered

| Edge Case Scenario | Request Origin | Result | Status Code |
| :--- | :--- | :--- | :--- |
| **Exact Allowlisted Origin** | `https://app.example.com` | Allowed | `200 OK` |
| **Trailing Slash Variant** | `https://app.example.com/` | Allowed (Normalized) | `200 OK` |
| **Upper-Case Host Variant** | `HTTPS://APP.EXAMPLE.COM` | Allowed (Normalized) | `200 OK` |
| **Combined Case & Slash** | `HTTPS://APP.EXAMPLE.COM/` | Allowed (Normalized) | `200 OK` |
| **Literal Null Origin** | `null` | Rejected | `403 Forbidden` |
| **Disallowed Origin** | `https://evil.com` | Rejected | `403 Forbidden` |
| **Disallowed Trailing Slash** | `https://evil.com/` | Rejected | `403 Forbidden` |
| **Disallowed Upper-Case** | `HTTPS://EVIL.COM` | Rejected | `403 Forbidden` |
| **Subdomain Bypass Attempt** | `https://app.example.com.evil.com` | Rejected | `403 Forbidden` |
| **No Origin Header** | `undefined` | Allowed (Pass-through) | `200 OK` |

---

## Verification & Test Output

### 1. Test Suite (`npx jest src/config/cors.test.js`)
```text
PASS src/config/cors.test.js (11.197 s)
  CORS configuration module
    parseAllowedOrigins
      √ returns [] for undefined (19 ms)
      √ returns [] for empty string (4 ms)
      √ returns [] for whitespace-only string (3 ms)
      √ parses a single origin (3 ms)
      √ parses comma-separated origins with trimming (7 ms)
      √ de-duplicates repeated origins (4 ms)
    parseMaxAge
      √ returns 600 for undefined (4 ms)
      √ returns 600 for null (9 ms)
      √ returns 600 for empty string (9 ms)
      √ returns the value for a valid positive integer string (4 ms)
      √ returns 600 for a negative value (2 ms)
      √ returns 600 for zero (4 ms)
      √ returns 600 for a non-numeric string (4 ms)
      √ returns 600 for a float string (3 ms)
    getDevelopmentFallbackOrigins
      √ returns the DEV_DEFAULT_ORIGINS array (4 ms)
    createCorsRejectionError
      √ creates an error with the standard message and status 403 (10 ms)
    isCorsOriginRejectedError
      √ returns true for a rejection error (5 ms)
      √ returns false for a plain Error (8 ms)
      √ returns false for null (4 ms)
      √ returns false for undefined (4 ms)
    getAllowedOriginsFromEnv
      √ returns origins from CORS_ALLOWED_ORIGINS (4 ms)
      √ prefers CORS_ALLOWED_ORIGINS over CORS_ORIGINS when both set (6 ms)
      √ falls back to CORS_ORIGINS when CORS_ALLOWED_ORIGINS is absent (5 ms)
      √ returns dev fallback in development when nothing is set (3 ms)
      √ returns empty array in production when nothing is set (8 ms)
    resolveAllowlist
      √ delegates to getAllowedOriginsFromEnv (5 ms)
    createCorsOptions – origin validation
      √ allows an origin that is explicitly listed in CORS_ORIGINS (11 ms)
      √ allows an origin listed in CORS_ALLOWED_ORIGINS (4 ms)
      √ rejects a disallowed origin with the standard CORS error (8 ms)
      √ passes through requests without an Origin header (undefined) (4 ms)
    development fallback
      √ allows localhost origins when NODE_ENV=development and no CORS_ORIGINS is set (5 ms)
      √ allows all DEV_DEFAULT_ORIGINS entries (11 ms)
      √ rejects non-localhost origins in development fallback mode (6 ms)
    reloadCorsOrigins
      √ picks up newly added origins after reload (9 ms)
      √ transitions from dev fallback to production denial after reload (11 ms)
      √ transitions from production denial to dev fallback after reload (8 ms)
      √ is safe to call multiple times (5 ms)
    production no-config denial
      √ denies all origins in production when CORS_ORIGINS is not set (8 ms)
    maxAge
      √ defaults to 600 when CORS_MAX_AGE is not set (6 ms)
      √ reads a custom CORS_MAX_AGE from the environment at module load (11 ms)
      √ falls back to 600 when CORS_MAX_AGE is an invalid value (7 ms)
      √ falls back to 600 when CORS_MAX_AGE is negative (5 ms)
      √ falls back to 600 when CORS_MAX_AGE is zero (4 ms)
    reload with empty CORS_ORIGINS
      √ denies all origins after reload with empty CORS_ORIGINS in production (5 ms)
      √ falls back to dev origins after reload with empty CORS_ORIGINS in development (5 ms)
    comma-separated origins with whitespace
      √ trims whitespace around origins in CORS_ORIGINS (13 ms)
    duplicate origins
      √ handles duplicate origins without error (11 ms)
    edge cases
      √ rejects empty-string origin (treated as present but not in allowlist) (8 ms)
      √ allows multiple origins from a comma-separated list (13 ms)
      √ optionsSuccessStatus is always 204 (5 ms)
      √ cors module exports all expected named exports (12 ms)
      √ passes through when origin is undefined even with empty allowlist (3 ms)
      √ DEFAULT_MAX_AGE constant is 600 (5 ms)
      √ allows an origin when createCorsOptions receives a literal env object (5 ms)
      √ rejects a disallowed origin when createCorsOptions receives a literal env object (3 ms)
      √ passes through when origin is undefined with a literal env object (6 ms)
      √ denies all origins when literal env object has no CORS_ORIGINS in production (2 ms)
    normalizeOrigin
      √ returns null for the literal string "null" (sandboxed iframe) (3 ms)
      √ returns null for undefined (2 ms)
      √ returns null for empty string (4 ms)
      √ returns null for a non-parseable string (3 ms)
      √ lowercases scheme and host (2 ms)
      √ strips a trailing slash (2 ms)
      √ preserves a non-default port (3 ms)
      √ returns the same value for an already-normalized origin (10 ms)
    isAllowedOrigin
      √ returns true for an exact-match allowlisted origin (3 ms)
      √ returns false for the literal "null" origin (3 ms)
      √ matches a trailing-slash variant against a clean allowlist entry (3 ms)
      √ matches an upper-case variant against a lower-case allowlist entry (4 ms)
      √ returns false for an origin not in the allowlist (3 ms)
      √ returns false for an empty allowlist (4 ms)
    origin bypass hardening
      √ rejects the literal "null" origin (sandboxed iframe) (4 ms)
      √ allows a trailing-slash variant of an allowlisted origin (6 ms)
      √ allows an upper-case variant of an allowlisted origin (5 ms)
      √ allows a combined upper-case + trailing-slash variant (4 ms)
      √ does not allow an unlisted origin (no credentialed reflection) (9 ms)
      √ rejects "null" even when the allowlist is the dev fallback (7 ms)
      √ passes through requests with no Origin header (undefined) with hardening active (6 ms)
      √ hardens null-origin in the custom-env (test) path (4 ms)
      √ allows trailing-slash variant in the custom-env path (4 ms)
    express CORS middleware integration
      √ allows exact allowlisted origin (3232 ms)
      √ allows trailing-slash variant of allowlisted origin (1140 ms)
      √ allows upper-case host variant of allowlisted origin (628 ms)
      √ rejects literal "null" origin with 403 (695 ms)
      √ rejects disallowed origin with 403 (632 ms)
      √ rejects trailing-slash variant of disallowed origin with 403 (602 ms)
      √ rejects upper-case variant of disallowed origin with 403 (608 ms)
      √ rejects subdomain bypass attempt with 403 (652 ms)
      √ handles CORS_ORIGINS configured with trailing slash or uppercase characters (614 ms)

Test Suites: 1 passed, 1 total
Tests:       89 passed, 89 total
Snapshots:   0 total
Time:        11.646 s
