### PR TITLE
refactor(health): extract shared validation helper

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -38,6 +38,7 @@ const {
   urlencodedBodyLimit,
 } = require('./middleware/bodySizeLimits');
 const { performHealthChecks, performReadinessChecks } = require('./services/health');
+const { createHealthHandler } = require('./utils/healthHandler');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
@@ -173,48 +174,10 @@ function createApp() {
   });
 
   // Full health check (all dependencies)
-  app.get('/ready', async (req, res) => {
-    try {
-      const { healthy, checks } = await performHealthChecks();
-      const status = healthy ? 200 : 503;
-
-      res.status(status).json({
-        ready: healthy,
-        service: 'liquifact-api',
-        timestamp: new Date().toISOString(),
-        checks,
-      });
-    } catch (error) {
-      res.status(503).json({
-        ready: false,
-        service: 'liquifact-api',
-        timestamp: new Date().toISOString(),
-        error: error.message,
-      });
-    }
-  });
+  app.get('/ready', createHealthHandler(performHealthChecks));
 
   // Readiness probe (critical deps only: DB, Soroban RPC)
-  app.get('/readyz', async (req, res) => {
-    try {
-      const { healthy, checks } = await performReadinessChecks();
-      const status = healthy ? 200 : 503;
-
-      res.status(status).json({
-        ready: healthy,
-        service: 'liquifact-api',
-        timestamp: new Date().toISOString(),
-        checks,
-      });
-    } catch (error) {
-      res.status(503).json({
-        ready: false,
-        service: 'liquifact-api',
-        timestamp: new Date().toISOString(),
-        error: error.message,
-      });
-    }
-  });
+  app.get('/readyz', createHealthHandler(performReadinessChecks));
 
   // API info
   app.get('/api', (req, res) => {

--- a/src/utils/healthHandler.js
+++ b/src/utils/healthHandler.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const SERVICE_NAME = 'liquifact-api';
+
+/**
+ * Creates an Express handler for a readiness-style health check.
+ *
+ * Keeping the result validation and error mapping here ensures every health
+ * handler returns the same response shape and status codes.
+ *
+ * @param {() => Promise<{healthy: boolean, checks: object}>} checkHealth
+ *   Health-check function invoked for each request.
+ * @returns {import('express').RequestHandler} Express request handler.
+ */
+function createHealthHandler(checkHealth) {
+  return async function healthHandler(req, res) {
+    try {
+      const { healthy, checks } = await checkHealth();
+      const status = healthy ? 200 : 503;
+
+      return res.status(status).json({
+        ready: healthy,
+        service: SERVICE_NAME,
+        timestamp: new Date().toISOString(),
+        checks,
+      });
+    } catch (error) {
+      return res.status(503).json({
+        ready: false,
+        service: SERVICE_NAME,
+        timestamp: new Date().toISOString(),
+        error: error.message,
+      });
+    }
+  };
+}
+
+module.exports = { createHealthHandler };

--- a/src/utils/healthHandler.test.js
+++ b/src/utils/healthHandler.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { createHealthHandler } = require('./healthHandler');
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
+
+describe('createHealthHandler', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-24T10:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the unchanged success response for a healthy check', async () => {
+    const checks = { database: { status: 'healthy' } };
+    const checkHealth = jest.fn().mockResolvedValue({ healthy: true, checks });
+    const res = createResponse();
+
+    await createHealthHandler(checkHealth)({}, res);
+
+    expect(checkHealth).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      ready: true,
+      service: 'liquifact-api',
+      timestamp: '2026-07-24T10:00:00.000Z',
+      checks,
+    });
+  });
+
+  it('preserves the 503 response and checks for an unhealthy result', async () => {
+    const checks = { database: { status: 'unhealthy' } };
+    const res = createResponse();
+
+    await createHealthHandler(jest.fn().mockResolvedValue({ healthy: false, checks }))({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      ready: false,
+      service: 'liquifact-api',
+      timestamp: '2026-07-24T10:00:00.000Z',
+      checks,
+    });
+  });
+
+  it('preserves the 503 error response when the health check rejects', async () => {
+    const res = createResponse();
+
+    await createHealthHandler(jest.fn().mockRejectedValue(new Error('probe failed')))({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      ready: false,
+      service: 'liquifact-api',
+      timestamp: '2026-07-24T10:00:00.000Z',
+      error: 'probe failed',
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- extract the repeated readiness-handler result validation, response shaping, and error mapping into `createHealthHandler`
- use the shared helper for both `/ready` and `/readyz`
- add focused unit coverage for healthy, unhealthy, and rejected health checks

## Why

The two readiness handlers duplicated the same validation preamble and 200/503 response mapping. Centralizing it keeps their behavior aligned without adding dependencies.

Closes #681.

## Impact

No API behavior changes. Healthy checks still return 200; unhealthy results and rejected checks still return 503 with the same response fields.

## Validation

Passed:

```text
node --check src/utils/healthHandler.js
node --check src/utils/healthHandler.test.js
node --check src/app.js
git diff --check
manual health handler assertions passed
```

Environment-blocked:

```text
npm test / npm run lint / npm run build
```

The checkout initially had no dependencies installed. Two `npm ci` attempts failed before creating `node_modules` because the npm registry repeatedly returned `EHOSTUNREACH`/`ECONNRESET` and eventually exited with code `-4077`.