### PR TITLE
feat(invoice-state): persist transitions to the database with tenant scoping

### DIFF
--- a/docs/invoice-lifecycle-api.md
+++ b/docs/invoice-lifecycle-api.md
@@ -1,6 +1,226 @@
-# Invoice Lifecycle & Gating Specification
+# Invoice Lifecycle State Machine API
+
+## Overview
+
+The Invoice Lifecycle API implements a tenant-scoped state machine for managing invoice transitions through the LiquiFact platform. The state machine enforces strict transition rules and maintains a complete, append-only audit trail of every state change.
+
+**Persistence:** Invoice state is stored in the tenant-scoped `invoices` table via Knex. Every transition handler resolves the invoice with `invoiceService.resolveInvoiceForTenant(invoiceId, tenantId)` and, after a successful `executeTransition()` call from the state machine (`src/services/invoiceStateMachine.js`), persists the resulting `status` via `invoiceService.updateInvoice()`. **Status is never accepted from the client request body** — the only client-controlled input is `targetState` (or an implicit target on the convenience endpoints), which must pass state-machine validation before anything is written.
+
+**Tenant isolation:** Every route in this router mounts the `extractTenant` middleware. Tenant context is resolved from the `x-tenant-id` header or a `tenantId` claim on the authenticated JWT. Requests without a resolvable tenant are rejected with `400`. Invoices belonging to another tenant are indistinguishable from invoices that don't exist — both return `404 INVOICE_NOT_FOUND`.
+
+**Response envelope:** Success and error responses use the standardized envelope from `src/utils/responseHelper.js` (`data`, `meta`, `error` fields), with a human-readable `message` field attached at the top level.
+
+## State Machine
+
+Implemented in [`src/services/invoiceStateMachine.js`](../src/services/invoiceStateMachine.js).
+
+### States
+
+- **pending**: Initial state when an invoice is created
+- **approved**: Invoice has been verified and approved
+- **linked_escrow**: Invoice is linked to an escrow contract (terminal state)
+- **rejected**: Invoice was rejected during verification (terminal state)
+- **cancelled**: Invoice was cancelled (terminal state)
+
+### Valid Transitions
+
+```
+pending → approved
+pending → rejected
+pending → cancelled
+
+approved → linked_escrow
+approved → cancelled
+
+linked_escrow → (none — terminal)
+rejected → (none — terminal)
+cancelled → (none — terminal)
+```
+
+### Transition Rules
+
+1. **No silent jumps** — e.g. `pending → linked_escrow` is rejected with `INVALID_TRANSITION`.
+2. **Terminal states** — once an invoice reaches `linked_escrow`, `rejected`, or `cancelled`, no further transitions are allowed (`TERMINAL_STATE`).
+3. **Reason required for terminal targets** — transitions into `rejected` or `cancelled` require a non-empty reason (after control-character stripping and trimming), capped at 1024 characters.
+4. **Audit trail** — every successful transition creates an immutable `STATE_TRANSITION` audit log entry (actor, before/after state, reason, IP, user agent).
+5. **Tenant scoping** — the invoice is always re-resolved for the caller's tenant before any transition is attempted.
+
+## API Endpoints
+
+All endpoints are mounted under `/api/invoices` (see [`src/routes/invoiceStateRoutes.js`](../src/routes/invoiceStateRoutes.js)) and require an `x-tenant-id` header (or a JWT `tenantId` claim).
+
+### 1. Get Invoice State
+
+**`GET /api/invoices/:id/state`**
+
+Returns the current state and allowed transitions for an invoice.
+
+```json
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "currentState": "pending",
+    "allowedTransitions": ["approved", "rejected", "cancelled"],
+    "isTerminal": false
+  },
+  "meta": { "timestamp": "2026-07-24T10:30:00.000Z", "version": "0.1.0" },
+  "error": null,
+  "message": "Invoice state retrieved successfully"
+}
+```
+
+### 2. Execute State Transition
+
+**`POST /api/invoices/:id/transition`**
+
+Generic transition endpoint driven entirely by the state machine.
+
+Request body:
+```json
+{ "targetState": "approved", "reason": "Invoice verified and approved by finance team" }
+```
+
+Success response:
+```json
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "previousState": "pending",
+    "currentState": "approved",
+    "transitionedAt": "2026-07-24T10:30:00.000Z",
+    "transitionedBy": "user-123",
+    "reason": "Invoice verified and approved by finance team",
+    "auditLogId": "AUDIT-1714132200000-abc123def"
+  },
+  "message": "Invoice transitioned from pending to approved"
+}
+```
+
+Invalid-transition error response:
+```json
+{
+  "data": null,
+  "error": {
+    "message": "Invalid state transition from pending to linked_escrow. Allowed transitions: approved, rejected, cancelled",
+    "code": "INVALID_TRANSITION",
+    "details": { "allowedTransitions": ["approved", "rejected", "cancelled"] }
+  }
+}
+```
+
+### 3. Approve Invoice
+
+**`POST /api/invoices/:id/approve`** — convenience wrapper for `pending → approved`.
+
+Request body: `{ "reason": "All verification checks passed" }` (optional; defaults to `"Invoice approved"`).
+
+### 4. Link Invoice to Escrow
+
+**`POST /api/invoices/:id/link-escrow`** — convenience wrapper for `approved → linked_escrow`.
+
+This is a **capital-movement endpoint** and is gated by `requireKycForFunding` followed by `auditKycAccess` (see [`src/middleware/kycGating.js`](../src/middleware/kycGating.js)): the caller's authenticated SME must hold a `verified` or `exempted` KYC status, or the request is rejected with `403 KYC_GATE_FAILED` before the invoice is even looked up. A successful access is logged via `auditKycAccess` for compliance review.
+
+Request body: `{ "escrowId": "escrow-123", "reason": "Escrow contract created on Stellar" }` (`escrowId` is optional; when provided it is persisted into the invoice's `metadata.escrowId`).
+
+Business rule beyond the core state machine: `canLinkToEscrow()` additionally requires the invoice to currently be `approved` — attempting to link a `pending` or already-`linked_escrow` invoice returns `400 CANNOT_LINK_TO_ESCROW`.
+
+### 5. Reject Invoice
+
+**`POST /api/invoices/:id/reject`** — convenience wrapper for `* → rejected`.
+
+Request body: `{ "reason": "Invalid documentation provided" }`. `reason` is **required** — a missing or blank reason returns `400 MISSING_TRANSITION_REASON` before the state machine is even consulted.
+
+### 6. Get Transition History
+
+**`GET /api/invoices/:id/history`**
+
+Returns the full, tenant-scoped audit trail for an invoice, most recent first.
+
+```json
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "currentState": "linked_escrow",
+    "transitions": [
+      {
+        "id": "AUDIT-1714134000000-def456",
+        "timestamp": "2026-07-24T11:00:00.000Z",
+        "actor": "user-123",
+        "fromState": "approved",
+        "toState": "linked_escrow",
+        "reason": "Escrow contract created on Stellar",
+        "ipAddress": "192.168.1.100"
+      }
+    ],
+    "totalTransitions": 1
+  },
+  "message": "Invoice transition history retrieved successfully"
+}
+```
+
+## Error Codes
+
+| Code | Description | HTTP Status |
+|------|-------------|-------------|
+| `INVOICE_NOT_FOUND` | Invoice does not exist, is soft-deleted, or belongs to another tenant | 404 |
+| `MISSING_TARGET_STATE` | `targetState` not provided on `/transition` | 400 |
+| `MISSING_TRANSITION_REASON` | Reason required (terminal target, or `/reject`) but absent/blank | 400 |
+| `TRANSITION_REASON_TOO_LONG` | Reason exceeds 1024 characters | 400 |
+| `ALREADY_IN_TARGET_STATE` | Invoice is already in the requested state | 400 |
+| `TERMINAL_STATE` | Invoice's current state does not permit further transitions | 400 |
+| `INVALID_TRANSITION` | Requested transition is not in the allowed-transition table | 400 |
+| `CANNOT_LINK_TO_ESCROW` | Invoice is not in `approved` state | 400 |
+| `KYC_GATE_FAILED` | SME's KYC status does not permit the capital-moving `link-escrow` operation | 403 |
+| `MISSING_SME_ID` | Authenticated principal has no `smeId` claim (required for the KYC gate) | 400 |
+
+## Audit Trail
+
+Every successful transition creates an immutable entry via `createAuditLog()` (`src/services/auditLog.js`), persisted to the append-only `audit_log_events` table:
+
+```json
+{
+  "id": "AUDIT-1714132200000-abc123",
+  "timestamp": "2026-07-24T10:30:00.000Z",
+  "actor": "user-123",
+  "action": "STATE_TRANSITION",
+  "resourceType": "invoice",
+  "resourceId": "inv-001",
+  "changes": { "before": { "state": "pending" }, "after": { "state": "approved" } },
+  "statusCode": 200,
+  "ipAddress": "192.168.1.100",
+  "userAgent": "Mozilla/5.0...",
+  "metadata": {
+    "reason": "Invoice verified",
+    "transitionType": "pending_to_approved",
+    "method": "POST",
+    "path": "/api/invoices/inv-001/approve"
+  }
+}
+```
 
 ## Capital Moving States Gating
-The following states involve the reallocation of funds and require KYC verification:
-* funded
-* settled
+
+Beyond the `pending`/`approved`/`linked_escrow`/`rejected`/`cancelled` lifecycle covered by this router, `CAPITAL_MOVING_STATES` (`src/services/invoiceStateMachine.js`) identifies funding-progress statuses that involve the reallocation of funds and therefore require KYC verification wherever they are reached:
+
+* `funded`
+* `settled`
+
+`kycGatingMiddleware` (`src/middleware/kycGating.js`) blocks any request whose target state is in this set unless the caller is KYC-verified. This is used by the investor funding flow (`src/routes/invest.js`); it is distinct from the `requireKycForFunding` gate on `POST /api/invoices/:id/link-escrow` described above.
+
+## Security Considerations
+
+- **Tenant scoping**: all reads/writes are scoped by `invoice_id` **and** `tenant_id`; cross-tenant IDs return `404` rather than `403`, so tenant existence is never leaked.
+- **Status is never client-overridable**: the request body's only meaningful input is `targetState` (or is implicit on the convenience endpoints); the persisted `status` always comes from the state machine's `executeTransition()` result.
+- **KYC gate on capital movement**: `POST /:id/link-escrow` requires `requireKycForFunding` to pass before the invoice is resolved or any transition is attempted.
+- **Actor resolution**: the acting principal is taken from `req.user.id`/`req.user.sub` (JWT), falling back to the request IP only when no authenticated user is present.
+- **Reason sanitization**: control characters are stripped and the string is trimmed before being persisted to the audit log, mitigating log-injection via the `reason` field.
+
+## Testing
+
+```bash
+npm test tests/invoice.state.test.js
+npm run test:coverage -- tests/invoice.state.test.js
+npm run lint:new
+```
+
+`tests/invoice.state.test.js` exercises the full transition matrix (valid and invalid pairs), terminal-state rejection, reason validation/sanitization, audit-log emission, and the route layer (tenant isolation, cross-tenant 404s, KYC-gated `link-escrow`, and unexpected-error propagation).

--- a/src/middleware/kycGating.js
+++ b/src/middleware/kycGating.js
@@ -1,5 +1,6 @@
 const { CAPITAL_MOVING_STATES } = require('../services/invoiceStateMachine');
 const kycService = require('../services/kycService');
+const logger = require('../logger');
 
 /**
  * Blocks invoice state transitions that move capital unless the user has KYC.
@@ -61,6 +62,32 @@ async function requireKycForFunding(req, res, next) {
     }
 }
 
+/**
+ * Logs successful access to a KYC-gated endpoint for audit trails.
+ * Intended to run immediately after `requireKycForFunding` on gated routes.
+ *
+ * @param {import('express').Request} req - Express request.
+ * @param {import('express').Response} res - Express response.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @returns {void}
+ */
+function auditKycAccess(req, res, next) {
+    const smeId = req.user && req.user.smeId;
+
+    logger.info(
+        {
+            userId: req.user && (req.user.id || req.user.sub),
+            smeId,
+            endpoint: req.originalUrl,
+            method: req.method,
+        },
+        'KYC-gated endpoint accessed',
+    );
+
+    next();
+}
+
 kycGatingMiddleware.requireKycForFunding = requireKycForFunding;
+kycGatingMiddleware.auditKycAccess = auditKycAccess;
 
 module.exports = kycGatingMiddleware;

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -1,15 +1,342 @@
+/**
+ * Invoice State Transition Routes
+ * Handles invoice lifecycle state transitions with audit logging.
+ *
+ * Invoices are resolved and persisted through invoiceService (Knex), scoped
+ * to the authenticated tenant from extractTenant middleware. Status is never
+ * taken from the client — it is always derived from the state machine result
+ * of a validated transition.
+ *
+ * The capital-movement link-escrow route is protected by the KYC gate.
+ *
+ * @module routes/invoiceStateRoutes
+ */
+
+'use strict';
+
 const express = require('express');
 const router = express.Router();
-const { CAPITAL_MOVING_STATES } = require('../services/invoiceStateMachine');
+const {
+  INVOICE_STATES,
+  getAllowedTransitions,
+  getTransitionHistory,
+  canLinkToEscrow,
+} = require('../services/invoiceStateMachine');
+const invoiceService = require('../services/invoiceService');
+const { getAuditLogs } = require('../services/auditLog');
+const { requireKycForFunding, auditKycAccess } = require('../middleware/kycGating');
+const { extractTenant } = require('../middleware/tenant');
+const responseHelper = require('../utils/responseHelper');
 
-router.post('/transition', (req, res) => {
-    const { targetState } = req.body;
-    
-    if (CAPITAL_MOVING_STATES.has(targetState)) {
-        return res.status(200).json({ requiresKYC: true, state: targetState });
+router.use(extractTenant);
+
+/**
+ * Resolves the acting principal identifier from the authenticated request.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {string} Actor identifier.
+ */
+function getActorFromRequest(req) {
+  if (req.user && req.user.id) {
+    return req.user.id;
+  }
+  if (req.user && req.user.sub) {
+    return req.user.sub;
+  }
+  return req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+}
+
+/**
+ * Sends a standardized 404 when an invoice is unknown or belongs to another tenant.
+ *
+ * @param {import('express').Response} res - Express response object.
+ * @returns {import('express').Response} The 404 response.
+ */
+function sendInvoiceNotFound(res) {
+  return res.status(404).json(responseHelper.error('Invoice not found', 'INVOICE_NOT_FOUND'));
+}
+
+/**
+ * Sends a standardized error envelope for state-machine validation failures.
+ *
+ * @param {import('express').Response} res - Express response object.
+ * @param {Error & {code?: string, allowedTransitions?: string[], statusCode?: number}} error - The thrown error.
+ * @returns {import('express').Response} The error response.
+ */
+function sendTransitionError(res, error) {
+  const status = error.statusCode || 400;
+  const details = error.allowedTransitions ? { allowedTransitions: error.allowedTransitions } : null;
+
+  return res.status(status).json(responseHelper.error(error.message, error.code, details));
+}
+
+/**
+ * GET /api/invoices/:id/state
+ * Returns the current state and allowed transitions for an invoice.
+ */
+router.get('/:id/state', async (req, res, next) => {
+  const { id } = req.params;
+
+  try {
+    const invoice = await invoiceService.resolveInvoiceForTenant(id, req.tenantId);
+
+    if (!invoice) {
+      return sendInvoiceNotFound(res);
     }
-    
-    return res.status(200).json({ requiresKYC: false, state: targetState });
+
+    const currentState = invoice.status;
+    const allowedTransitions = getAllowedTransitions(currentState);
+
+    return res.json({
+      ...responseHelper.success({
+        invoiceId: id,
+        currentState,
+        allowedTransitions,
+        isTerminal: allowedTransitions.length === 0,
+      }),
+      message: 'Invoice state retrieved successfully',
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+/**
+ * POST /api/invoices/:id/transition
+ * Executes a state transition and persists the resulting state.
+ *
+ * Request body: { "targetState": "approved", "reason": "..." }
+ */
+router.post('/:id/transition', async (req, res, next) => {
+  const { id } = req.params;
+  const { targetState, reason } = req.body || {};
+
+  try {
+    if (!targetState) {
+      return res.status(400).json(
+        responseHelper.error('Target state is required', 'MISSING_TARGET_STATE'),
+      );
+    }
+
+    const actor = getActorFromRequest(req);
+    const ipAddress = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    const userAgent = req.get('user-agent') || 'unknown';
+
+    const result = await invoiceService.transitionInvoice(id, targetState, req.tenantId, {
+      actor,
+      reason,
+      ipAddress,
+      userAgent,
+      metadata: {
+        method: req.method,
+        path: req.path,
+      },
+    });
+
+    return res.status(200).json({
+      ...responseHelper.success({
+        invoiceId: id,
+        previousState: result.previousState,
+        currentState: result.newState,
+        transitionedAt: result.transitionedAt,
+        transitionedBy: result.transitionedBy,
+        reason,
+        auditLogId: result.auditLog.id,
+      }),
+      message: `Invoice transitioned from ${result.previousState} to ${result.newState}`,
+    });
+  } catch (error) {
+    if (error.code) {
+      return sendTransitionError(res, error);
+    }
+    return next(error);
+  }
+});
+
+/**
+ * POST /api/invoices/:id/approve
+ * Convenience endpoint to approve a pending invoice.
+ */
+router.post('/:id/approve', async (req, res, next) => {
+  const { id } = req.params;
+  const { reason } = req.body || {};
+
+  try {
+    const actor = getActorFromRequest(req);
+    const ipAddress = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    const userAgent = req.get('user-agent') || 'unknown';
+
+    const result = await invoiceService.transitionInvoice(id, INVOICE_STATES.APPROVED, req.tenantId, {
+      actor,
+      reason: reason || 'Invoice approved',
+      ipAddress,
+      userAgent,
+      metadata: {
+        method: req.method,
+        path: req.path,
+        action: 'approve',
+      },
+    });
+
+    return res.status(200).json({
+      ...responseHelper.success({
+        invoiceId: id,
+        previousState: result.previousState,
+        currentState: result.newState,
+        transitionedAt: result.transitionedAt,
+        transitionedBy: result.transitionedBy,
+        auditLogId: result.auditLog.id,
+      }),
+      message: 'Invoice approved successfully',
+    });
+  } catch (error) {
+    if (error.code) {
+      return sendTransitionError(res, error);
+    }
+    return next(error);
+  }
+});
+
+/**
+ * POST /api/invoices/:id/link-escrow
+ * Links an approved invoice to escrow. This is a capital-movement endpoint
+ * gated on the caller's SME holding a verified/exempted KYC status.
+ */
+router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req, res, next) => {
+  const { id } = req.params;
+  const { escrowId, reason } = req.body || {};
+
+  try {
+    const invoice = await invoiceService.resolveInvoiceForTenant(id, req.tenantId);
+
+    if (!invoice) {
+      return sendInvoiceNotFound(res);
+    }
+
+    const linkValidation = canLinkToEscrow(invoice);
+    if (!linkValidation.canLink) {
+      return res.status(400).json(
+        responseHelper.error(linkValidation.reason, 'CANNOT_LINK_TO_ESCROW'),
+      );
+    }
+
+    const actor = getActorFromRequest(req);
+    const ipAddress = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    const userAgent = req.get('user-agent') || 'unknown';
+
+    const result = await invoiceService.transitionInvoice(id, INVOICE_STATES.LINKED_ESCROW, req.tenantId, {
+      actor,
+      reason: reason || 'Invoice linked to escrow',
+      ipAddress,
+      userAgent,
+      escrowId: escrowId || null,
+      metadata: {
+        method: req.method,
+        path: req.path,
+        action: 'link-escrow',
+        escrowId: escrowId || 'pending',
+      },
+    });
+
+    return res.status(200).json({
+      ...responseHelper.success({
+        invoiceId: id,
+        previousState: result.previousState,
+        currentState: result.newState,
+        escrowId: escrowId || null,
+        transitionedAt: result.transitionedAt,
+        transitionedBy: result.transitionedBy,
+        auditLogId: result.auditLog.id,
+      }),
+      message: 'Invoice linked to escrow successfully',
+    });
+  } catch (error) {
+    if (error.code) {
+      return sendTransitionError(res, error);
+    }
+    return next(error);
+  }
+});
+
+/**
+ * POST /api/invoices/:id/reject
+ * Convenience endpoint to reject an invoice. Requires a non-empty reason.
+ */
+router.post('/:id/reject', async (req, res, next) => {
+  const { id } = req.params;
+  const { reason } = req.body || {};
+
+  try {
+    if (!reason || typeof reason !== 'string' || reason.trim().length === 0) {
+      return res.status(400).json(
+        responseHelper.error('Reason is required for rejection', 'MISSING_TRANSITION_REASON'),
+      );
+    }
+
+    const actor = getActorFromRequest(req);
+    const ipAddress = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    const userAgent = req.get('user-agent') || 'unknown';
+
+    const result = await invoiceService.transitionInvoice(id, INVOICE_STATES.REJECTED, req.tenantId, {
+      actor,
+      reason,
+      ipAddress,
+      userAgent,
+      metadata: {
+        method: req.method,
+        path: req.path,
+        action: 'reject',
+      },
+    });
+
+    return res.status(200).json({
+      ...responseHelper.success({
+        invoiceId: id,
+        previousState: result.previousState,
+        currentState: result.newState,
+        reason,
+        transitionedAt: result.transitionedAt,
+        transitionedBy: result.transitionedBy,
+        auditLogId: result.auditLog.id,
+      }),
+      message: 'Invoice rejected successfully',
+    });
+  } catch (error) {
+    if (error.code) {
+      return sendTransitionError(res, error);
+    }
+    return next(error);
+  }
+});
+
+/**
+ * GET /api/invoices/:id/history
+ * Returns the state-transition history for an invoice.
+ */
+router.get('/:id/history', async (req, res, next) => {
+  const { id } = req.params;
+
+  try {
+    const invoice = await invoiceService.resolveInvoiceForTenant(id, req.tenantId);
+
+    if (!invoice) {
+      return sendInvoiceNotFound(res);
+    }
+
+    const history = await getTransitionHistory(id, getAuditLogs);
+
+    return res.json({
+      ...responseHelper.success({
+        invoiceId: id,
+        currentState: invoice.status,
+        transitions: history,
+        totalTransitions: history.length,
+      }),
+      message: 'Invoice transition history retrieved successfully',
+    });
+  } catch (error) {
+    return next(error);
+  }
 });
 
 module.exports = router;

--- a/src/services/invoiceService.js
+++ b/src/services/invoiceService.js
@@ -30,6 +30,7 @@ const { applyQueryOptions } = require('../utils/queryBuilder');
 const logger = require('../logger');
 const AppError = require('../errors/AppError');
 const { LOCKED_STATUSES } = require('../middleware/patchInvoice');
+const { executeTransition } = require('./invoiceStateMachine');
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -92,43 +93,6 @@ function nowValue() {
   return db && db.fn && typeof db.fn.now === 'function'
     ? db.fn.now()
     : new Date().toISOString();
-}
-
-/**
- * Stub state-machine transition executor.
- *
- * TODO: Replace with the full invoice state-machine implementation.
- * Currently validates that the transition is structurally well-formed and
- * returns a simple result object.  All real validation and audit-log
- * persistence must be wired in here when the state machine is ready.
- *
- * @param {object} ctx - Transition context.
- * @param {string} ctx.invoiceId
- * @param {string} ctx.currentState
- * @param {string} ctx.targetState
- * @param {string} ctx.actor
- * @param {string} [ctx.reason]
- * @param {string} [ctx.ipAddress]
- * @param {string} [ctx.userAgent]
- * @param {object} [ctx.metadata]
- * @returns {Promise<{previousState: string, newState: string}>}
- */
-async function executeTransition(ctx) {
-  // Minimal stub — the real state machine belongs in its own module.
-  // For now this just returns the target state so the rest of the
-  // transitionInvoice pipeline (status update, audit logging) works.
-  const { currentState, targetState } = ctx;
-
-  if (!currentState || !targetState) {
-    const err = new Error('Invalid state transition context');
-    err.code = 'INVALID_TRANSITION';
-    throw err;
-  }
-
-  return {
-    previousState: currentState,
-    newState: targetState,
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/invoiceStateMachine.js
+++ b/src/services/invoiceStateMachine.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { createAuditLog } = require('./auditLog');
+const logger = require('../logger');
+
 /**
  * Canonical invoice status vocabulary shared by invoice-list and marketplace
  * query validators.
@@ -75,10 +78,325 @@ const TERMINAL_STATES = Object.freeze([
  */
 const CAPITAL_MOVING_STATES = new Set(['funded', 'settled']);
 
+/**
+ * Valid state transitions for the approval/escrow lifecycle.
+ * Maps each lifecycle state to the set of states it may transition to.
+ * @type {Readonly<Record<string, string[]>>}
+ */
+const VALID_TRANSITIONS = Object.freeze({
+  [INVOICE_STATES.PENDING]: [INVOICE_STATES.APPROVED, INVOICE_STATES.REJECTED, INVOICE_STATES.CANCELLED],
+  [INVOICE_STATES.APPROVED]: [INVOICE_STATES.LINKED_ESCROW, INVOICE_STATES.CANCELLED],
+  [INVOICE_STATES.LINKED_ESCROW]: [],
+  [INVOICE_STATES.REJECTED]: [],
+  [INVOICE_STATES.CANCELLED]: [],
+});
+
+/**
+ * Target states that require a non-empty reason to transition into.
+ * @type {readonly string[]}
+ */
+const TERMINAL_REASON_REQUIRED_STATES = Object.freeze([
+  INVOICE_STATES.REJECTED,
+  INVOICE_STATES.CANCELLED,
+]);
+
+/**
+ * Maximum permitted length (in characters) for a transition reason.
+ * @type {number}
+ */
+const MAX_TRANSITION_REASON_LENGTH = 1024;
+
+/**
+ * Strips control characters from a transition reason and trims whitespace.
+ *
+ * @param {*} reason - Raw reason input.
+ * @returns {string|null} Sanitized reason, or null when absent/empty.
+ */
+function normalizeTransitionReason(reason) {
+  if (reason === null || reason === undefined) {
+    return null;
+  }
+
+  const value = typeof reason === 'string' ? reason : String(reason);
+  const sanitized = value.replace(/[\u0000-\u001F\u007F]+/g, ' ').trim();
+  return sanitized.length === 0 ? null : sanitized;
+}
+
+/**
+ * Checks whether a string is a recognized invoice status.
+ *
+ * @param {string} state - Status value to check.
+ * @returns {boolean} `true` when the value is in {@link ALL_INVOICE_STATUSES}.
+ */
+function isValidState(state) {
+  return ALL_INVOICE_STATUSES.includes(state);
+}
+
+/**
+ * Checks whether a transition from one lifecycle state to another is allowed.
+ *
+ * @param {string} fromState - Current state.
+ * @param {string} toState - Desired state.
+ * @returns {boolean} `true` when the transition is permitted.
+ */
+function isTransitionAllowed(fromState, toState) {
+  if (!isValidState(fromState) || !isValidState(toState)) {
+    return false;
+  }
+
+  const allowedTransitions = VALID_TRANSITIONS[fromState] || [];
+  return allowedTransitions.includes(toState);
+}
+
+/**
+ * Checks whether a state is terminal (no further transitions allowed).
+ *
+ * @param {string} state - State to check.
+ * @returns {boolean} `true` when terminal.
+ */
+function isTerminalState(state) {
+  return TERMINAL_STATES.includes(state);
+}
+
+/**
+ * Gets all allowed transitions from a given state.
+ *
+ * @param {string} fromState - Current state.
+ * @returns {string[]} Array of allowed next states.
+ */
+function getAllowedTransitions(fromState) {
+  if (!isValidState(fromState)) {
+    return [];
+  }
+  return VALID_TRANSITIONS[fromState] || [];
+}
+
+/**
+ * Validates a proposed state transition without executing it.
+ *
+ * @param {object} options - Validation options.
+ * @param {string} options.invoiceId - Invoice identifier.
+ * @param {string} options.currentState - Current invoice state.
+ * @param {string} options.targetState - Desired target state.
+ * @param {string} options.actor - User performing the transition.
+ * @param {string} [options.reason] - Reason for the transition. Required for terminal targets.
+ * @returns {{isValid: boolean, error?: string, code?: string, allowedTransitions?: string[]}} Validation result.
+ */
+function validateTransition({ invoiceId, currentState, targetState, actor, reason: rawReason }) {
+  if (!invoiceId) {
+    return { isValid: false, error: 'Invoice ID is required', code: 'MISSING_INVOICE_ID' };
+  }
+
+  if (!currentState) {
+    return { isValid: false, error: 'Current state is required', code: 'MISSING_CURRENT_STATE' };
+  }
+
+  if (!targetState) {
+    return { isValid: false, error: 'Target state is required', code: 'MISSING_TARGET_STATE' };
+  }
+
+  if (!actor) {
+    return { isValid: false, error: 'Actor is required', code: 'MISSING_ACTOR' };
+  }
+
+  if (!isValidState(currentState)) {
+    return {
+      isValid: false,
+      error: `Invalid current state: ${currentState}`,
+      code: 'INVALID_CURRENT_STATE',
+    };
+  }
+
+  if (!isValidState(targetState)) {
+    return {
+      isValid: false,
+      error: `Invalid target state: ${targetState}`,
+      code: 'INVALID_TARGET_STATE',
+    };
+  }
+
+  if (currentState === targetState) {
+    return {
+      isValid: false,
+      error: `Invoice is already in state: ${targetState}`,
+      code: 'ALREADY_IN_TARGET_STATE',
+    };
+  }
+
+  const reason = normalizeTransitionReason(rawReason);
+
+  if (isTerminalState(currentState)) {
+    return {
+      isValid: false,
+      error: `Cannot transition from terminal state: ${currentState}`,
+      code: 'TERMINAL_STATE',
+    };
+  }
+
+  if (TERMINAL_REASON_REQUIRED_STATES.includes(targetState)) {
+    if (!reason) {
+      return {
+        isValid: false,
+        error: `Reason is required for terminal transition to ${targetState}`,
+        code: 'MISSING_TRANSITION_REASON',
+      };
+    }
+
+    if (reason.length > MAX_TRANSITION_REASON_LENGTH) {
+      return {
+        isValid: false,
+        error: `Transition reason must be ${MAX_TRANSITION_REASON_LENGTH} characters or fewer`,
+        code: 'TRANSITION_REASON_TOO_LONG',
+      };
+    }
+  }
+
+  if (!isTransitionAllowed(currentState, targetState)) {
+    const allowed = getAllowedTransitions(currentState);
+    return {
+      isValid: false,
+      error: `Invalid state transition from ${currentState} to ${targetState}. Allowed transitions: ${allowed.join(', ') || 'none'}`,
+      code: 'INVALID_TRANSITION',
+      allowedTransitions: allowed,
+    };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validates and executes a state transition, persisting an audit log entry.
+ *
+ * @param {object} options - Transition options.
+ * @param {string} options.invoiceId - Invoice identifier.
+ * @param {string} options.currentState - Current invoice state.
+ * @param {string} options.targetState - Desired target state.
+ * @param {string} options.actor - User performing the transition.
+ * @param {string} [options.reason] - Reason for the transition.
+ * @param {string} [options.ipAddress] - IP address of the requester.
+ * @param {string} [options.userAgent] - User agent of the requester.
+ * @param {object} [options.metadata] - Additional audit metadata.
+ * @returns {Promise<{success: boolean, previousState: string, newState: string, auditLog: object, transitionedAt: string, transitionedBy: string}>} Transition result.
+ * @throws {Error} With `.code` (and `.allowedTransitions` when applicable) when validation fails.
+ */
+async function executeTransition({
+  invoiceId,
+  currentState,
+  targetState,
+  actor,
+  reason = null,
+  ipAddress = 'unknown',
+  userAgent = 'unknown',
+  metadata = {},
+}) {
+  const validation = validateTransition({ invoiceId, currentState, targetState, actor, reason });
+
+  if (!validation.isValid) {
+    const error = new Error(validation.error);
+    error.code = validation.code;
+    error.allowedTransitions = validation.allowedTransitions;
+    throw error;
+  }
+
+  const normalizedReason = normalizeTransitionReason(reason);
+
+  const auditLog = await createAuditLog({
+    actor,
+    action: 'STATE_TRANSITION',
+    resourceType: 'invoice',
+    resourceId: invoiceId,
+    before: { state: currentState },
+    after: { state: targetState },
+    statusCode: 200,
+    ipAddress,
+    userAgent,
+    metadata: {
+      ...metadata,
+      ...(normalizedReason ? { reason: normalizedReason } : {}),
+      transitionType: `${currentState}_to_${targetState}`,
+      timestamp: new Date().toISOString(),
+    },
+  });
+
+  logger.info({
+    invoiceId,
+    actor,
+    transition: `${currentState} -> ${targetState}`,
+    reason: normalizedReason,
+    auditLogId: auditLog.id,
+  }, 'Invoice state transition executed');
+
+  return {
+    success: true,
+    previousState: currentState,
+    newState: targetState,
+    auditLog,
+    transitionedAt: auditLog.timestamp,
+    transitionedBy: actor,
+  };
+}
+
+/**
+ * Retrieves the state-transition history for an invoice, most recent first.
+ *
+ * @param {string} invoiceId - Invoice identifier.
+ * @param {Function} getAuditLogsFn - Function used to retrieve audit logs (injected for testability).
+ * @returns {Promise<Array<object>>} Array of transition records.
+ */
+async function getTransitionHistory(invoiceId, getAuditLogsFn) {
+  const logs = await getAuditLogsFn({
+    resourceId: invoiceId,
+    resourceType: 'invoice',
+    action: 'STATE_TRANSITION',
+    limit: 1000,
+  });
+
+  return logs.map((log) => ({
+    id: log.id,
+    timestamp: log.timestamp,
+    actor: log.actor,
+    fromState: log.changes.before?.state,
+    toState: log.changes.after?.state,
+    reason: log.metadata?.reason,
+    ipAddress: log.ipAddress,
+  }));
+}
+
+/**
+ * Validates additional business rules for linking an invoice to escrow,
+ * beyond the core state-machine transition rules.
+ *
+ * @param {object} invoice - Invoice object.
+ * @returns {{canLink: boolean, reason?: string}} Validation result.
+ */
+function canLinkToEscrow(invoice) {
+  if (!invoice) {
+    return { canLink: false, reason: 'Invoice not found' };
+  }
+
+  if (invoice.status !== INVOICE_STATES.APPROVED) {
+    return {
+      canLink: false,
+      reason: `Invoice must be in approved state. Current state: ${invoice.status}`,
+    };
+  }
+
+  return { canLink: true };
+}
+
 module.exports = {
   INVOICE_STATES,
   ALL_INVOICE_STATUSES,
   INVESTABLE_STATUSES,
   TERMINAL_STATES,
   CAPITAL_MOVING_STATES,
+  VALID_TRANSITIONS,
+  isValidState,
+  isTransitionAllowed,
+  isTerminalState,
+  getAllowedTransitions,
+  validateTransition,
+  executeTransition,
+  getTransitionHistory,
+  canLinkToEscrow,
 };

--- a/tests/invoice.state.test.js
+++ b/tests/invoice.state.test.js
@@ -210,6 +210,11 @@ describe('Transition Rules — individual assertions', () => {
     expect(isTransitionAllowed('pending', 'linked_escrow')).toBe(false);
   });
 
+  it('should NOT allow transitions involving an unrecognized state', () => {
+    expect(isTransitionAllowed('invalid', 'pending')).toBe(false);
+    expect(isTransitionAllowed('pending', 'invalid')).toBe(false);
+  });
+
   it('should NOT allow approved → rejected', () => {
     expect(isTransitionAllowed('approved', 'rejected')).toBe(false);
   });
@@ -853,6 +858,16 @@ describe('Invoice State API Routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
     });
+
+    it('should handle unexpected errors when reading state', async () => {
+      jest.spyOn(invoiceService, 'getInvoiceById').mockRejectedValue(new Error('DB unavailable'));
+
+      const res = await request(app)
+        .get('/api/invoices/inv-001/state')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(500);
+    });
   });
 
   describe('POST /api/invoices/:id/transition', () => {
@@ -1005,6 +1020,44 @@ describe('Invoice State API Routes', () => {
       expect(res.status).toBe(400);
       expect(res.body.error.code).toBe('CANNOT_LINK_TO_ESCROW');
     });
+
+    it('should return 404 for non-existent invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-999/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ escrowId: 'escrow-000' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+
+    it('should return 404 for cross-tenant link-escrow attempt', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-002/link-escrow')
+        .set('x-tenant-id', TENANT_B)
+        .send({ escrowId: 'escrow-000' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+
+    it('should surface coded transition errors from the state machine', async () => {
+      jest.spyOn(invoiceService, 'transitionInvoice').mockRejectedValue(
+        Object.assign(new Error('Invoice is already in state: linked_escrow'), {
+          code: 'ALREADY_IN_TARGET_STATE',
+        }),
+      );
+
+      const res = await request(app)
+        .post('/api/invoices/inv-002/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ escrowId: 'escrow-123' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('ALREADY_IN_TARGET_STATE');
+
+      invoiceService.transitionInvoice.mockRestore();
+    });
   });
 
   describe('POST /api/invoices/:id/reject', () => {
@@ -1084,6 +1137,16 @@ describe('Invoice State API Routes', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+
+    it('should handle unexpected errors when reading history', async () => {
+      jest.spyOn(invoiceService, 'getInvoiceById').mockRejectedValue(new Error('DB unavailable'));
+
+      const res = await request(app)
+        .get('/api/invoices/inv-001/history')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(500);
     });
   });
 

--- a/tests/kyc.gating.test.js
+++ b/tests/kyc.gating.test.js
@@ -327,6 +327,56 @@ describe('KYC Gating', () => {
     });
   });
 
+  // ── auditKycAccess ──────────────────────────────────────────────────────
+
+  describe('auditKycAccess', () => {
+    it('should call next and allow the request through', async () => {
+      const app = createApp({ smeId: 'sme-auth-01' });
+      app.use((req, res, next) => {
+        req.kyc = { smeId: 'sme-auth-01', status: 'verified' };
+        next();
+      });
+      app.post('/fund', kycGatingMiddleware.auditKycAccess, (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      const res = await request(app).post('/fund');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true });
+    });
+
+    it('should pass through requests with no req.kyc without throwing', async () => {
+      const app = createApp({ smeId: 'sme-auth-01' });
+      app.post('/fund', kycGatingMiddleware.auditKycAccess, (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      const res = await request(app).post('/fund');
+
+      expect(res.status).toBe(200);
+    });
+
+    it('should compose with requireKycForFunding on a fully gated route', async () => {
+      kycService.getKycStatus.mockResolvedValue({ status: 'verified', recordId: 'kyc-1' });
+
+      const app = createApp({ smeId: 'sme-auth-01' });
+      app.post(
+        '/fund',
+        kycGatingMiddleware.requireKycForFunding,
+        kycGatingMiddleware.auditKycAccess,
+        (req, res) => {
+          res.status(200).json({ success: true, kyc: req.kyc });
+        },
+      );
+
+      const res = await request(app).post('/fund');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+
   // ── canFundWithKycStatus (fail-closed semantics) ───────────────────────
 
   describe('canFundWithKycStatus', () => {


### PR DESCRIPTION

Closes #588 

Replace the mock-backed invoice state routes with a full transition engine (VALID_TRANSITIONS, validateTransition, executeTransition, getTransitionHistory, canLinkToEscrow) in invoiceStateMachine.js, and wire invoiceStateRoutes.js to resolve/persist invoices through the tenant-scoped invoiceService (Knex) instead of an in-memory store.

- Status is always derived from executeTransition()'s result; the client-supplied request body can never set status directly.
- Unknown or foreign-tenant invoices return 404 INVOICE_NOT_FOUND without leaking existence.
- POST /:id/link-escrow (the capital-moving path) is gated by requireKycForFunding + the newly added auditKycAccess middleware.
- Added GET /:id/state, POST /:id/transition|approve|link-escrow|reject, and GET /:id/history, all through the standardized responseHelper envelope.

Closes #588.