### PR TITLE
test(config): fix stale boot-gate tests and cover PUBLIC_API_BASE_URL rules

### DIFF
--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -25,8 +25,10 @@ describe('Config Validation', () => {
     expect(config.NODE_ENV).toBe('development');
     expect(config.PORT).toBe(3001);
     expect(config.JWT_SECRET).toBe(process.env.JWT_SECRET);
-    expect(config.JWT_ISSUER).toBe('liquifact-platform');
-    expect(config.JWT_AUDIENCE).toBe('liquifact-client');
+    // JWT_ISSUER/JWT_AUDIENCE are optional with no default — enforcement in
+    // src/middleware/auth.js is conditional on these being explicitly set.
+    expect(config.JWT_ISSUER).toBeUndefined();
+    expect(config.JWT_AUDIENCE).toBeUndefined();
     expect(config.JWT_ALGORITHMS).toBe('HS256');
   });
 
@@ -37,6 +39,8 @@ describe('Config Validation', () => {
     process.env.JWT_ISSUER = 'custom-issuer';
     process.env.JWT_AUDIENCE = 'custom-audience';
     process.env.JWT_ALGORITHMS = 'HS256,HS384';
+    // Required in production by the PUBLIC_API_BASE_URL superRefine rule.
+    process.env.PUBLIC_API_BASE_URL = 'https://api.example.com';
 
     const config = validate();
     expect(config.PORT).toBe(8080);
@@ -113,10 +117,12 @@ describe('Config Validation', () => {
 
       process.env.NODE_ENV = 'production';
       process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
-      
+      // Required in production by the PUBLIC_API_BASE_URL superRefine rule.
+      process.env.PUBLIC_API_BASE_URL = 'https://api.example.com';
+
       const { startServer } = require('../index');
       startServer();
-      
+
       expect(exitSpy).not.toHaveBeenCalled();
       listenSpy.mockRestore();
     });
@@ -136,6 +142,39 @@ describe('Config Validation', () => {
     delete process.env.KYC_PROVIDER_URL;
     process.env.KYC_PROVIDER_API_KEY = 'some-key';
     expect(() => validate()).toThrow(/KYC_PROVIDER_URL/i);
+  });
+
+  test('rejects missing PUBLIC_API_BASE_URL in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    delete process.env.PUBLIC_API_BASE_URL;
+
+    expect(() => validate()).toThrow(/PUBLIC_API_BASE_URL must be set in production/i);
+  });
+
+  test('rejects non-HTTPS PUBLIC_API_BASE_URL in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    process.env.PUBLIC_API_BASE_URL = 'http://api.example.com';
+
+    expect(() => validate()).toThrow(/must use HTTPS/i);
+  });
+
+  test('rejects loopback PUBLIC_API_BASE_URL in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    process.env.PUBLIC_API_BASE_URL = 'https://localhost:3001';
+
+    expect(() => validate()).toThrow(/must not be a loopback address/i);
+  });
+
+  test('accepts a valid HTTPS non-loopback PUBLIC_API_BASE_URL in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    process.env.PUBLIC_API_BASE_URL = 'https://api.liquifact.com';
+
+    const config = validate();
+    expect(config.PUBLIC_API_BASE_URL).toBe('https://api.liquifact.com');
   });
 
   test('allows half-set KYC configuration in test env', () => {


### PR DESCRIPTION
## Summary

Closes #591.

The config boot-validation gate itself was **already implemented** on `main` before this PR:
- `src/index.js` / `src/server.js` call `validate()` before the server binds/listens, via `runBootConfigValidation()`.
- On `ZodError`, `logRedactedSummary()` prints only key names + messages (never secret values), then `process.exit(1)`.
- `NODE_ENV=test` skips the boot-time call so the existing lazy `get()`-based test bootstrap is unaffected.
- The KYC `KYC_PROVIDER_URL`/`KYC_PROVIDER_API_KEY` pairing rule is enforced in the schema's `superRefine` for all non-test environments.
- `README.md` and `.env.example` already document the startup validation gate and `PUBLIC_API_BASE_URL` production rules.

**What this PR actually changes:** `src/config/index.test.js` had **3 failing tests on a clean checkout** (see "Defect found" below), which meant `npm test` did not pass for this file even though the underlying feature worked correctly. This PR fixes those tests and adds explicit coverage for the `PUBLIC_API_BASE_URL` production rules (missing / non-HTTPS / loopback / valid), per the issue's "cover edge cases" requirement.

## Defect found (test-only, no production behaviour changed)

On a fresh `npm install && npm test`, `src/config/index.test.js` failed 3/15 tests:

1. **`validates minimal config with defaults`** asserted `JWT_ISSUER`/`JWT_AUDIENCE` default to `'liquifact-platform'`/`'liquifact-client'`, but the Zod schema has no such defaults (`z.string().optional()`), and `src/middleware/auth.js` only enforces issuer/audience claims when they are explicitly set (`if (cfg.JWT_ISSUER) { options.issuer = ... }`). There is no reference to these default strings anywhere else in the codebase. This was a stale/incorrect test assertion, not a schema bug — fixed the assertions to expect `undefined`, matching the intentional "optional, no default" behaviour.
2. **`overrides defaults`** and **`boot validation gate does not exit on valid config`** set `NODE_ENV=production` but did not set `PUBLIC_API_BASE_URL`, which the `superRefine` rule requires in production. These tests were written before (or not updated alongside) that production requirement. Fixed by adding a valid `PUBLIC_API_BASE_URL` to both.

No `src/config/index.js`, `src/index.js`, or `src/server.js` logic was changed — only test assertions.

## Coverage added

New tests for the `PUBLIC_API_BASE_URL` production `superRefine` branches that were previously untested:
- missing in production → rejected
- non-HTTPS in production → rejected
- loopback hostname in production → rejected
- valid HTTPS non-loopback URL in production → accepted

`src/config/index.js` coverage: **95% statements / 96.8% branches / 100% functions / 97.3% lines** (the one remaining uncovered branch, `!data.CURSOR_SECRET && !data.JWT_SECRET`, is unreachable given `JWT_SECRET` is a mandatory non-optional field in the same schema — flagging as dead code rather than chasing it with a test).

## Test output

```
$ npx jest src/config/index.test.js --runInBand
Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total

$ npx eslint src/config/index.js src/config/index.test.js src/index.js src/server.js
(no errors)

$ npm run build
> tsc -p tsconfig.build.json
(no errors)
```

**Note on full `npm test`:** a full run on a clean checkout currently has numerous failures unrelated to this change or to config validation (`tests/openapi.test.js`, `smeAuth.stub.test.js`, `tests/invoices.test.js`, `tests/cache.redis.test.js`, `src/config/stellar.test.js`, `src/__tests__/rateLimit.test.js`, `tests/auditTrail.api.test.js`, `tests/shutdown.test.js`, `tests/cursorPagination.secret.test.js`, `tests/escrowSubmit.preflight.test.js`) and an uncaught `TypeError: Invalid invoice ID` from `src/services/invoiceService.js` that crashes the Jest process mid-run. These pre-date this PR (reproducible on `main` before any of my changes) and are out of scope for this config-gate issue — flagging for maintainers to track separately.

## Security notes

- No secret values are ever logged: `logRedactedSummary()` only prints `issue.path` (key names) and `issue.message`. Verified by the existing `logRedactedSummary output does not contain secrets` test, which asserts the logged output does **not** contain the actual short `JWT_SECRET` or `KYC_PROVIDER_API_KEY` values.
- Fail-closed: any `ZodError` at boot causes `process.exit(1)` before the port is bound (production/development only; `NODE_ENV=test` preserves the existing lazy-validation test bootstrap).
- The KYC URL+key pairing rule (`superRefine`) still runs in all non-test environments — unchanged by this PR.

## Test plan
- [x] `npx jest src/config/index.test.js` — 19/19 passing
- [x] `npx eslint` on touched files — clean
- [x] `npm run build` — clean
- [x] Valid config boots (no `process.exit`)
- [x] Short `JWT_SECRET` fails validation
- [x] Half-set KYC vars fail validation (non-test env only)
- [x] Test-mode lazy `get()` path unaffected
- [x] `PUBLIC_API_BASE_URL` missing/non-HTTPS/loopback rejected in production; valid HTTPS accepted
