### PR TITLE
feat(persistence): add metrics and structured logging

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -284,7 +284,7 @@ try {
   };
 }
 
-/** Shared registry — exported so tests can reset it between runs. */
+/** Shared registry ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â exported so tests can reset it between runs. */
 const registry = new client.Registry();
 
 if (typeof client.collectDefaultMetrics === 'function') {
@@ -651,7 +651,7 @@ const LOOPBACK = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 /**
  * Extracts the direct TCP connection IP address from the request.
  *
- * Reads `req.socket.remoteAddress` first — this is the actual TCP socket peer
+ * Reads `req.socket.remoteAddress` first ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â this is the actual TCP socket peer
  * and cannot be spoofed via `X-Forwarded-For` or any other HTTP header. Falls
  * back to `req.ip` when the socket address is unavailable (edge case in some
  * test environments or HTTP/2 proxies).
@@ -674,12 +674,12 @@ function extractClientIp(req) {
  *
  * ```
  * METRICS_BEARER_TOKEN set?
- *   ├── YES → constant-time compare Authorization header
- *   │         ├── match  → next()
- *   │         └── no match → 401 (no detail)
- *   └── NO  → extractClientIp(req) in LOOPBACK set?
- *             ├── yes → next()
- *             └── no  → 401 (no detail)
+ *   ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ YES ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ constant-time compare Authorization header
+ *   ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡         ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ match  ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ next()
+ *   ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡         ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ no match ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ 401 (no detail)
+ *   ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ NO  ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ extractClientIp(req) in LOOPBACK set?
+ *             ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ yes ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ next()
+ *             ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚ÂÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ no  ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ 401 (no detail)
  * ```
  *
  * The response is **always** a plain `{ error: 'Unauthorized' }` with no
@@ -703,7 +703,7 @@ function metricsAuth(req, res, next) {
     return;
   }
 
-  // No token configured — allow loopback only, using the direct TCP socket IP.
+  // No token configured ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â allow loopback only, using the direct TCP socket IP.
   // X-Forwarded-For is NEVER trusted for this check.
   const ip = extractClientIp(req);
   if (LOOPBACK.has(ip)) { return next(); }
@@ -995,6 +995,120 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
 });
 
 /**
+ * Bounded enum of allowed `endpoint` label values for persistence metrics.
+ * @readonly
+ */
+const PERSISTENCE_ENDPOINT_ENUM = Object.freeze([
+  'sme_invoice_upload',
+  'sme_invoice_presigned_url',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `status_class` label values.
+ * @readonly
+ */
+const PERSISTENCE_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
+
+/**
+ * Bounded enum of allowed `cause` label values for persistence errors.
+ * Raw error messages are NEVER used as labels.
+ * @readonly
+ */
+const PERSISTENCE_CAUSE_ENUM = Object.freeze([
+  'validation',
+  'storage',
+  'internal',
+  'none',
+]);
+
+/**
+ * Maps a raw persistence endpoint hint to a bounded metric label value.
+ *
+ * @param {unknown} raw - Raw endpoint identifier.
+ * @returns {string} Bounded value from {@link PERSISTENCE_ENDPOINT_ENUM}.
+ */
+function normalizePersistenceEndpoint(raw) {
+  const str = typeof raw === 'string' ? raw.trim() : '';
+  return PERSISTENCE_ENDPOINT_ENUM.includes(str) ? str : 'unknown';
+}
+
+/**
+ * Maps an HTTP status code to a bounded `status_class` label value.
+ *
+ * @param {unknown} status - HTTP status code.
+ * @returns {string} Bounded value from {@link PERSISTENCE_STATUS_CLASS_ENUM}.
+ */
+function normalizePersistenceStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
+
+/**
+ * Maps a raw persistence failure to a bounded `cause` label value.
+ *
+ * Recognises the storage-service error codes surfaced by the SME routes
+ * (INVALID_MIME_TYPE, FILE_TOO_LARGE, INVALID_TENANT_ID) as client-side
+ * `validation`, storage-layer failures as `storage`, and everything else as
+ * `internal`. A 2xx outcome maps to `none`.
+ *
+ * @param {unknown} err - Raw error object or code (null/undefined for success).
+ * @param {number} [status] - HTTP status code, used to disambiguate.
+ * @returns {string} Bounded value from {@link PERSISTENCE_CAUSE_ENUM}.
+ */
+function normalizePersistenceCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+
+  const errCode = err && typeof err === 'object' && 'code' in err ? String(err.code) : '';
+  if (['INVALID_MIME_TYPE', 'FILE_TOO_LARGE', 'INVALID_TENANT_ID'].includes(errCode)) {
+    return 'validation';
+  }
+  if (code >= 400 && code < 500) { return 'validation'; }
+  if (errCode.startsWith('STORAGE') || errCode === 'ENOENT' || errCode === 'EACCES') {
+    return 'storage';
+  }
+  return 'internal';
+}
+
+/**
+ * Histogram: Wall-clock duration of persistence-endpoint requests in seconds.
+ * @type {import('prom-client').Histogram}
+ */
+const persistenceRequestDurationSeconds = new client.Histogram({
+  name: 'persistence_request_duration_seconds',
+  help: 'Duration of persistence endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [registry],
+});
+
+/**
+ * Counter: Total persistence-endpoint requests.
+ * @type {import('prom-client').Counter}
+ */
+const persistenceRequestsTotal = new client.Counter({
+  name: 'persistence_requests_total',
+  help: 'Total number of persistence endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: Persistence-endpoint request errors by cause.
+ * @type {import('prom-client').Counter}
+ */
+const persistenceRequestErrorsTotal = new client.Counter({
+  name: 'persistence_request_errors_total',
+  help: 'Total number of persistence endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
+
+
+/**
  * Returns the shared Prometheus registry.
  *
  * @returns {import('prom-client').Registry} The metrics registry.
@@ -1035,4 +1149,12 @@ module.exports = {
   startMetricsRefresh,
   stopMetricsRefresh,
   webhookReplayTotal,
+  persistenceRequestDurationSeconds,
+  persistenceRequestsTotal,
+  persistenceRequestErrorsTotal,
+  normalizePersistenceEndpoint,
+  normalizePersistenceStatusClass,
+  normalizePersistenceCause,
+  PERSISTENCE_STATUS_CLASS_ENUM,
+  PERSISTENCE_CAUSE_ENUM,
 };

--- a/src/middleware/persistenceMetrics.js
+++ b/src/middleware/persistenceMetrics.js
@@ -1,0 +1,118 @@
+'use strict';
+
+/**
+ * @fileoverview Instrumentation wrapper for persistence endpoints.
+ *
+ * Wraps an async Express handler so that every request records:
+ *   - request duration (histogram, labelled by endpoint + status class)
+ *   - a request count (counter, labelled by endpoint + status class)
+ *   - an error count on failure (counter, labelled by endpoint + bounded cause)
+ *   - a single structured log line (no PII: ids and outcome only)
+ *
+ * Labels are bounded via the normalize* helpers in ../metrics to keep
+ * Prometheus time-series cardinality fixed.
+ *
+ * @module middleware/persistenceMetrics
+ */
+
+const {
+  persistenceRequestDurationSeconds,
+  persistenceRequestsTotal,
+  persistenceRequestErrorsTotal,
+  normalizePersistenceEndpoint,
+  normalizePersistenceStatusClass,
+  normalizePersistenceCause,
+} = require('../metrics');
+const logger = require('../logger');
+
+/**
+ * Records metrics and a structured log for one completed persistence request.
+ *
+ * Kept separate from {@link instrumentPersistence} so it can be unit-tested in
+ * isolation against each status class without driving a full HTTP request.
+ *
+ * @param {object} params
+ * @param {string} params.endpoint - Raw endpoint hint (bounded on use).
+ * @param {number} params.statusCode - Final HTTP status code.
+ * @param {number} params.durationSeconds - Wall-clock duration in seconds.
+ * @param {unknown} [params.error] - Error thrown by the handler, if any.
+ * @param {import('express').Request} [params.req] - Request, for a scoped logger.
+ * @returns {void}
+ */
+function recordPersistenceOutcome({ endpoint, statusCode, durationSeconds, error, req }) {
+  const ep = normalizePersistenceEndpoint(endpoint);
+  const statusClass = normalizePersistenceStatusClass(statusCode);
+
+  persistenceRequestDurationSeconds.labels(ep, statusClass).observe(durationSeconds);
+  persistenceRequestsTotal.labels(ep, statusClass).inc();
+
+  const cause = normalizePersistenceCause(error, statusCode);
+  if (cause !== 'none') {
+    persistenceRequestErrorsTotal.labels(ep, cause).inc();
+  }
+
+  // Structured log â€” safe fields only. Never log file contents, file names,
+  // buffers, or raw error messages that could contain user data.
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    endpoint: ep,
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'persistence request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'persistence request rejected');
+  } else {
+    log.info(fields, 'persistence request completed');
+  }
+}
+
+/**
+ * Wraps an async persistence handler with metrics + structured logging.
+ *
+ * The wrapped handler runs normally. Duration is measured from entry to the
+ * moment the response finishes (`res.on('finish')`), so the recorded status
+ * code is the one actually sent. If the handler throws, the error is recorded
+ * and re-thrown to the next error middleware.
+ *
+ * @param {string} endpoint - Bounded endpoint label (see PERSISTENCE_ENDPOINT_ENUM).
+ * @param {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>} handler
+ * @returns {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>}
+ */
+function instrumentPersistence(endpoint, handler) {
+  return async function instrumentedPersistenceHandler(req, res, next) {
+    const startNs = process.hrtime.bigint();
+    let recorded = false;
+
+    // Single source of truth: record on response finish, when the final status
+    // code is known. A thrown handler stashes its error on res.locals so the
+    // finish listener can classify the cause consistently with that status.
+    res.on('finish', () => {
+      if (recorded) { return; }
+      recorded = true;
+      const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+      recordPersistenceOutcome({
+        endpoint,
+        statusCode: res.statusCode,
+        durationSeconds,
+        error: res.locals && res.locals.persistenceError,
+        req,
+      });
+    });
+
+    try {
+      await handler(req, res, next);
+    } catch (err) {
+      if (res.locals) { res.locals.persistenceError = err; }
+      return next(err);
+    }
+  };
+}
+
+module.exports = { instrumentPersistence, recordPersistenceOutcome };

--- a/src/routes/sme/index.js
+++ b/src/routes/sme/index.js
@@ -13,6 +13,7 @@ const storageService = require('../../services/storage');
 const { extractTenant } = require('../../middleware/tenant');
 const idempotencyMiddleware = require('../../middleware/idempotency');
 const logger = require('../../logger');
+const { instrumentPersistence } = require('../../middleware/persistenceMetrics');
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -24,7 +25,7 @@ const upload = multer({
 router.use('/', metricsRoutes);
 
 // POST /api/sme/invoice/presigned-url - Request a presigned upload URL
-router.post('/invoice/presigned-url', express.json(), extractTenant, idempotencyMiddleware, async (req, res) => {
+router.post('/invoice/presigned-url', express.json(), extractTenant, idempotencyMiddleware, instrumentPersistence('sme_invoice_presigned_url', async (req, res) => {
   const requestLogger = logger.createRequestLogger(req);
   try {
     const { fileName, mimeType, fileSize } = req.body;
@@ -59,10 +60,10 @@ router.post('/invoice/presigned-url', express.json(), extractTenant, idempotency
     requestLogger.error({ err: error }, 'Presigned URL error');
     res.status(500).json({ error: 'Failed to generate presigned upload URL' });
   }
-});
+}));
 
 // POST /api/sme/invoice - Upload PDF invoice
-router.post('/invoice', upload.single('invoice'), extractTenant, async (req, res) => {
+router.post('/invoice', upload.single('invoice'), extractTenant, instrumentPersistence('sme_invoice_upload', async (req, res) => {
   const requestLogger = logger.createRequestLogger(req);
   try {
     if (!req.file) {
@@ -95,6 +96,6 @@ router.post('/invoice', upload.single('invoice'), extractTenant, async (req, res
     requestLogger.error({ err: error }, 'Upload error');
     res.status(500).json({ error: 'Failed to upload invoice' });
   }
-});
+}));
 
 module.exports = router;

--- a/tests/persistenceMetrics.test.js
+++ b/tests/persistenceMetrics.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const {
+  instrumentPersistence,
+  recordPersistenceOutcome,
+} = require('../src/middleware/persistenceMetrics');
+const metrics = require('../src/metrics');
+
+/** Reads a single counter value for a label set (real prom-client, async get). */
+async function counterValue(counter, labels) {
+  const metric = await counter.get();
+  const keys = Object.keys(labels);
+  const match = (metric.values || []).find((v) =>
+    keys.every((k) => String(v.labels[k]) === String(labels[k])),
+  );
+  return match ? match.value : 0;
+}
+
+describe('persistence metrics instrumentation', () => {
+  beforeEach(() => {
+    metrics.persistenceRequestDurationSeconds.reset();
+    metrics.persistenceRequestsTotal.reset();
+    metrics.persistenceRequestErrorsTotal.reset();
+  });
+
+  describe('normalizePersistenceStatusClass', () => {
+    it('maps 2xx, 4xx, 5xx correctly', async () => {
+      expect(metrics.normalizePersistenceStatusClass(201)).toBe('2xx');
+      expect(metrics.normalizePersistenceStatusClass(400)).toBe('4xx');
+      expect(metrics.normalizePersistenceStatusClass(503)).toBe('5xx');
+      expect(metrics.normalizePersistenceStatusClass('200')).toBe('2xx');
+    });
+  });
+
+  describe('normalizePersistenceEndpoint', () => {
+    it('passes known endpoints and collapses unknown', async () => {
+      expect(metrics.normalizePersistenceEndpoint('sme_invoice_upload')).toBe('sme_invoice_upload');
+      expect(metrics.normalizePersistenceEndpoint('nope')).toBe('unknown');
+      expect(metrics.normalizePersistenceEndpoint(42)).toBe('unknown');
+    });
+  });
+
+  describe('normalizePersistenceCause', () => {
+    it('returns none for success', async () => {
+      expect(metrics.normalizePersistenceCause(null, 200)).toBe('none');
+    });
+    it('maps storage-service validation codes to validation', async () => {
+      expect(metrics.normalizePersistenceCause({ code: 'INVALID_MIME_TYPE' }, 400)).toBe('validation');
+      expect(metrics.normalizePersistenceCause({ code: 'FILE_TOO_LARGE' }, 400)).toBe('validation');
+      expect(metrics.normalizePersistenceCause({ code: 'INVALID_TENANT_ID' }, 400)).toBe('validation');
+    });
+    it('maps any 4xx without a code to validation', async () => {
+      expect(metrics.normalizePersistenceCause(null, 422)).toBe('validation');
+    });
+    it('maps storage-layer error codes to storage', async () => {
+      expect(metrics.normalizePersistenceCause({ code: 'STORAGE_WRITE_FAILED' }, 500)).toBe('storage');
+      expect(metrics.normalizePersistenceCause({ code: 'ENOENT' }, 500)).toBe('storage');
+      expect(metrics.normalizePersistenceCause({ code: 'EACCES' }, 500)).toBe('storage');
+    });
+    it('maps other server errors to internal', async () => {
+      expect(metrics.normalizePersistenceCause(new Error('boom'), 500)).toBe('internal');
+      expect(metrics.normalizePersistenceCause({}, 500)).toBe('internal');
+    });
+  });
+
+  describe('recordPersistenceOutcome', () => {
+    it('records duration + request count and no error on success', async () => {
+      recordPersistenceOutcome({
+        endpoint: 'sme_invoice_upload',
+        statusCode: 200,
+        durationSeconds: 0.02,
+      });
+      expect(await counterValue(metrics.persistenceRequestsTotal, { endpoint: 'sme_invoice_upload', status_class: '2xx' })).toBe(1);
+      expect(await counterValue(metrics.persistenceRequestErrorsTotal, { endpoint: 'sme_invoice_upload', cause: 'none' })).toBe(0);
+    });
+
+    it('records a validation error on a 4xx', async () => {
+      recordPersistenceOutcome({
+        endpoint: 'sme_invoice_upload',
+        statusCode: 400,
+        durationSeconds: 0.01,
+        error: { code: 'INVALID_MIME_TYPE' },
+      });
+      expect(await counterValue(metrics.persistenceRequestsTotal, { endpoint: 'sme_invoice_upload', status_class: '4xx' })).toBe(1);
+      expect(await counterValue(metrics.persistenceRequestErrorsTotal, { endpoint: 'sme_invoice_upload', cause: 'validation' })).toBe(1);
+    });
+
+    it('records an internal error on a 5xx', async () => {
+      recordPersistenceOutcome({
+        endpoint: 'sme_invoice_upload',
+        statusCode: 500,
+        durationSeconds: 0.05,
+        error: new Error('boom'),
+      });
+      expect(await counterValue(metrics.persistenceRequestsTotal, { endpoint: 'sme_invoice_upload', status_class: '5xx' })).toBe(1);
+      expect(await counterValue(metrics.persistenceRequestErrorsTotal, { endpoint: 'sme_invoice_upload', cause: 'internal' })).toBe(1);
+    });
+
+    it('collapses an unknown endpoint to the bounded label', async () => {
+      recordPersistenceOutcome({ endpoint: 'mystery', statusCode: 200, durationSeconds: 0.01 });
+      expect(await counterValue(metrics.persistenceRequestsTotal, { endpoint: 'unknown', status_class: '2xx' })).toBe(1);
+    });
+
+    it('uses a request-scoped logger when a req is supplied', async () => {
+      const req = { id: 'r1', correlationId: 'c1' };
+      expect(() => recordPersistenceOutcome({
+        endpoint: 'sme_invoice_upload',
+        statusCode: 200,
+        durationSeconds: 0.01,
+        req,
+      })).not.toThrow();
+    });
+  });
+
+  describe('instrumentPersistence guard branches', () => {
+    const { EventEmitter } = require('events');
+
+    /** Minimal fake res that lets us emit finish manually and toggle locals. */
+    function fakeRes({ withLocals = true, statusCode = 200 } = {}) {
+      const res = new EventEmitter();
+      res.statusCode = statusCode;
+      res.headersSent = false;
+      if (withLocals) { res.locals = {}; }
+      return res;
+    }
+
+    it('records only once even if finish fires twice', async () => {
+      const res = fakeRes({ statusCode: 200 });
+      const handler = async () => {};
+      await instrumentPersistence('sme_invoice_upload', handler)({}, res, () => {});
+      res.emit('finish');
+      res.emit('finish'); // second emit must hit the `recorded` guard and no-op
+      expect(await counterValue(metrics.persistenceRequestsTotal, { endpoint: 'sme_invoice_upload', status_class: '2xx' })).toBe(1);
+    });
+
+    it('does not throw when res.locals is absent and the handler throws', async () => {
+      const res = fakeRes({ withLocals: false, statusCode: 500 });
+      const err = new Error('no-locals');
+      const handler = async () => { throw err; };
+      let passed;
+      await instrumentPersistence('sme_invoice_upload', handler)({}, res, (e) => { passed = e; });
+      expect(passed).toBe(err);
+      res.emit('finish'); // records with undefined error, status 500 -> internal
+      expect(await counterValue(metrics.persistenceRequestErrorsTotal, { endpoint: 'sme_invoice_upload', cause: 'internal' })).toBe(1);
+    });
+  });
+  describe('instrumentPersistence wrapper', () => {
+    function buildApp(handler, endpoint = 'sme_invoice_upload') {
+      const app = express();
+      app.use(express.json());
+      app.post('/persist', instrumentPersistence(endpoint, handler));
+      app.use((err, _req, res, _next) => res.status(res.statusCode >= 400 ? res.statusCode : 500).json({ error: 'x' }));
+      return app;
+    }
+
+    it('records a 2xx for a successful handler', async () => {
+      const app = buildApp(async (_req, res) => { res.status(201).json({ ok: true }); });
+      const res = await request(app).post('/persist').send({});
+      expect(res.status).toBe(201);
+      expect(await counterValue(metrics.persistenceRequestsTotal, { endpoint: 'sme_invoice_upload', status_class: '2xx' })).toBe(1);
+    });
+
+    it('records a 4xx when the handler responds with a client error', async () => {
+      const app = buildApp(async (_req, res) => { res.status(400).json({ error: 'bad' }); });
+      const res = await request(app).post('/persist').send({});
+      expect(res.status).toBe(400);
+      expect(await counterValue(metrics.persistenceRequestErrorsTotal, { endpoint: 'sme_invoice_upload', cause: 'validation' })).toBe(1);
+    });
+
+    it('records and re-throws when the handler throws', async () => {
+      const app = buildApp(async () => { const e = new Error('kaboom'); e.code = 'STORAGE_WRITE_FAILED'; throw e; });
+      const res = await request(app).post('/persist').send({});
+      expect(res.status).toBe(500);
+      expect(await counterValue(metrics.persistenceRequestErrorsTotal, { endpoint: 'sme_invoice_upload', cause: 'storage' })).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #776

## Summary

Instruments the persistence endpoints — `POST /api/sme/invoice` and `POST /api/sme/invoice/presigned-url` in `src/routes/sme/index.js` — which previously emitted almost no telemetry, making incidents hard to diagnose.

## Changes

- **`src/metrics.js`** — adds three metrics on the shared registry (auto-exposed via the existing `/metrics` handler): `persistence_request_duration_seconds` (histogram), `persistence_requests_total` (counter), and `persistence_request_errors_total` (counter). Labels are bounded via new `normalizePersistence*` helpers plus frozen enums, following the existing cardinality-safe pattern in this file.
- **`src/middleware/persistenceMetrics.js`** (new) — a reusable `instrumentPersistence(endpoint, handler)` wrapper. It records duration, a request count, and an error-cause counter, and emits one structured pino log per request. Metrics are recorded on `res.on('finish')` as the single source of truth, so the status class and the error cause always stay mutually consistent.
- **`src/routes/sme/index.js`** — wraps both persistence handlers with `instrumentPersistence`.
- **`tests/persistenceMetrics.test.js`** (new) — covers success, client-error (4xx), and server-error (5xx) label paths, all cause classifications, and the wrapper's guard branches.

## No PII

Structured logs contain only bounded fields: endpoint, status class, status code, duration, and a bounded cause. File names, file buffers, and raw error messages are never logged.

## Test output
<html>
<body>
<!--StartFragment--><p class="font-claude-response-body break-words whitespace-normal" dir="ltr">PASS tests/persistenceMetrics.test.js<br>
persistence metrics instrumentation<br>
normalizePersistenceStatusClass<br>
√ maps 2xx, 4xx, 5xx correctly<br>
normalizePersistenceEndpoint<br>
√ passes known endpoints and collapses unknown<br>
normalizePersistenceCause<br>
√ returns none for success<br>
√ maps storage-service validation codes to validation<br>
√ maps any 4xx without a code to validation<br>
√ maps storage-layer error codes to storage<br>
√ maps other server errors to internal<br>
recordPersistenceOutcome<br>
√ records duration + request count and no error on success<br>
√ records a validation error on a 4xx<br>
√ records an internal error on a 5xx<br>
√ collapses an unknown endpoint to the bounded label<br>
√ uses a request-scoped logger when a req is supplied<br>
instrumentPersistence guard branches<br>
√ records only once even if finish fires twice<br>
√ does not throw when res.locals is absent and the handler throws<br>
instrumentPersistence wrapper<br>
√ records a 2xx for a successful handler<br>
√ records a 4xx when the handler responds with a client error<br>
√ records and re-throws when the handler throws</p>
<p class="font-claude-response-body break-words whitespace-normal">-----------------------|---------|----------|---------|---------|-------------------</p>
<div dir="ltr" class="overflow-x-auto w-full px-2 mb-6 print:overflow-x-visible">
File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-- | -- | -- | -- | -- | --
All files | 100 | 100 | 100 | 100 |  
persistenceMetrics.js | 100 | 100 | 100 | 100 |  
----------------------- | --------- | ---------- | --------- | --------- | -------------------

</div>
<p class="font-claude-response-body break-words whitespace-normal" dir="ltr">Test Suites: 1 passed, 1 total<br>
Tests:       17 passed, 17 total<br>
Time:        3.993 s</p>
<div role="group" aria-label="Code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono);"></pre></div></div><!--EndFragment-->
</body>
</html>
Coverage on the new module is **100%** (statements, branches, functions, lines) — above the 95% requirement.

## Notes

- The pre-existing test `tests/sme.metrics.test.js` has one failing assertion on the base branch (a "Malformed cursor" pagination check, unrelated to this change): 18/19 pass both before and after this PR.
- Remaining `eslint` errors in `src/metrics.js` (lines 526–943) are also pre-existing and out of scope; all code added in this PR lints clean.