### PR TITLE
refactor(config): add typed config accessors

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,6 +6,15 @@
 
 const z = require('zod');
 
+/** Express-compatible request size string. @type {z.ZodDefault<z.ZodString>} */
+const InvoiceFileMaxSizeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d+(?:\.\d+)?(?:b|kb|mb|gb)$/i, {
+    message: 'INVOICE_FILE_MAX_SIZE must be a size such as 512kb or 5mb.',
+  })
+  .default('5mb');
+
 /**
  * Complete configuration schema with defaults and validation.
  * Secrets have no defaults - must be provided.
@@ -51,6 +60,7 @@ const ConfigSchema = z
     // Public base URL for the API, used in the OpenAPI spec servers array.
     // Required in production and must use HTTPS. Falls back to localhost in development/test.
     PUBLIC_API_BASE_URL: z.string().url().optional(),
+    INVOICE_FILE_MAX_SIZE: InvoiceFileMaxSizeSchema,
   })
   .superRefine((data, ctx) => {
     if (data.NODE_ENV === 'test') { return; }
@@ -158,6 +168,27 @@ function get() {
   return config;
 }
 
+/**
+ * Returns a value from the validated configuration with key-aware JSDoc types.
+ * @template {keyof z.infer<typeof ConfigSchema>} K
+ * @param {K} key - Validated configuration key.
+ * @returns {z.infer<typeof ConfigSchema>[K]} The validated value for the key.
+ */
+function getValue(key) {
+  return get()[key];
+}
+
+/**
+ * Returns the validated invoice PDF upload limit used when routes are built.
+ * @returns {string} Express-compatible request size limit.
+ */
+function getInvoiceFileMaxSize() {
+  if (config) {
+    return config.INVOICE_FILE_MAX_SIZE;
+  }
+  return InvoiceFileMaxSizeSchema.parse(process.env.INVOICE_FILE_MAX_SIZE);
+}
+
 const securityHeaders = {
   contentSecurityPolicy: {
     directives: {
@@ -197,7 +228,10 @@ const securityHeaders = {
 module.exports = {
   validate,
   get,
+  getValue,
+  getInvoiceFileMaxSize,
   logRedactedSummary,
   ConfigSchema,
+  InvoiceFileMaxSizeSchema,
   securityHeaders,
 };

--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -2,7 +2,14 @@
  * Tests for centralized config module.
  */
 
-const { validate, get, logRedactedSummary, ConfigSchema } = require('./index');
+const {
+  validate,
+  get,
+  getValue,
+  getInvoiceFileMaxSize,
+  logRedactedSummary,
+  ConfigSchema,
+} = require('./index');
 
 describe('Config Validation', () => {
   const originalEnv = { ...process.env };
@@ -194,6 +201,47 @@ describe('Config Validation', () => {
     const config = get();
     expect(config).toBeDefined();
     expect(config.NODE_ENV).toBe('test');
+  });
+
+  test('typed accessors return validated and coerced values', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    process.env.PORT = '4321';
+    process.env.INVOICE_FILE_MAX_SIZE = '2mb';
+    validate();
+    expect(getValue('PORT')).toBe(4321);
+    expect(getInvoiceFileMaxSize()).toBe('2mb');
+  });
+
+  test('typed accessor preserves a missing optional value', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    delete process.env.PUBLIC_API_BASE_URL;
+    validate();
+    expect(getValue('PUBLIC_API_BASE_URL')).toBeUndefined();
+  });
+
+  test('upload limit accessor uses the validated default before boot validation', () => {
+    jest.isolateModules(() => {
+      delete process.env.INVOICE_FILE_MAX_SIZE;
+      const { getInvoiceFileMaxSize: getFreshLimit } = require('./index');
+      expect(getFreshLimit()).toBe('5mb');
+    });
+  });
+
+  test('rejects an invalid route value during boot validation', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'valid-secret-at-least-32-chars-long-here';
+    process.env.INVOICE_FILE_MAX_SIZE = 'unbounded';
+    expect(() => validate()).toThrow(/INVOICE_FILE_MAX_SIZE/i);
+  });
+
+  test('upload limit accessor rejects invalid values before full validation', () => {
+    jest.isolateModules(() => {
+      process.env.INVOICE_FILE_MAX_SIZE = '-1mb';
+      const { getInvoiceFileMaxSize: getFreshLimit } = require('./index');
+      expect(() => getFreshLimit()).toThrow(/INVOICE_FILE_MAX_SIZE/i);
+    });
   });
 });
 

--- a/src/routes/invoiceFile.js
+++ b/src/routes/invoiceFile.js
@@ -8,16 +8,17 @@ const express = require('express');
 const crypto = require('crypto');
 const storageService = require('../services/storage');
 const logger = require('../logger');
+const { getInvoiceFileMaxSize } = require('../config');
 const router = express.Router();
 
 /** PDF magic bytes. */
 const PDF_MAGIC_BYTES = Buffer.from('%PDF');
 
 /**
- * Configurable upload size limit from env, defaults to 5mb.
+ * Validated configurable upload size limit, defaults to 5mb.
  * @type {string}
  */
-const UPLOAD_SIZE_LIMIT = process.env.INVOICE_FILE_MAX_SIZE || '5mb';
+const UPLOAD_SIZE_LIMIT = getInvoiceFileMaxSize();
 
 /**
  * Computes the SHA-256 hash of a buffer.

--- a/tests/invoiceFile.upload.test.js
+++ b/tests/invoiceFile.upload.test.js
@@ -270,6 +270,11 @@ describe('config-driven upload size limit', () => {
     expect(fresh.UPLOAD_SIZE_LIMIT).toBe('2kb');
   });
 
+  it('rejects an invalid INVOICE_FILE_MAX_SIZE value when the route loads', () => {
+    process.env.INVOICE_FILE_MAX_SIZE = 'no-limit';
+    expect(() => require('../src/routes/invoiceFile')).toThrow(/INVOICE_FILE_MAX_SIZE/i);
+  });
+
   it('rejects upload when file exceeds env-configured limit', async () => {
     process.env.INVOICE_FILE_MAX_SIZE = '1kb';
     jest.resetModules();


### PR DESCRIPTION
## Summary

Closes #632.

- Add a key-aware typed accessor for validated configuration values.
- Add a focused accessor for the invoice upload-size limit.
- Add `INVOICE_FILE_MAX_SIZE` to the existing Zod configuration schema.
- Replace direct environment-variable access in the invoice-file route.
- Preserve the existing `5mb` default and route behavior.
- Add coverage for validated values, defaults, missing optional values, and invalid configuration.

## Testing

Passed:

```text
node --check src/config/index.js
node --check src/routes/invoiceFile.js
node --check src/config/index.test.js
node --check tests/invoiceFile.upload.test.js
git diff --check