### PR TITLE
feat: add structured metrics and logging for kyc-webhooks

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1107,6 +1107,97 @@ const persistenceRequestErrorsTotal = new client.Counter({
   registers: [registry],
 });
 
+// ── KYC webhook metrics (issue #731) ────────────────────────────────────────
+
+/**
+ * Bounded enum of allowed `status_class` label values for KYC webhook metrics.
+ * @readonly
+ */
+const _KYC_WEBHOOK_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
+
+/**
+ * Bounded enum of allowed `cause` label values for KYC webhook error metrics.
+ * Raw error messages are NEVER used as labels.
+ * @readonly
+ */
+const KYC_WEBHOOK_CAUSE_ENUM = Object.freeze([
+  'missing_secret',
+  'missing_signature',
+  'invalid_signature',
+  'invalid_payload',
+  'missing_sme_id',
+  'missing_status',
+  'unknown_status',
+  'persistence_error',
+  'internal',
+  'none',
+]);
+
+/**
+ * Maps an HTTP status code to a bounded `status_class` label value.
+ *
+ * @param {unknown} status - HTTP status code.
+ * @returns {string} Bounded value from {@link KYC_WEBHOOK_STATUS_CLASS_ENUM}.
+ */
+function normalizeKycWebhookStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
+
+/**
+ * Maps a KYC webhook error scenario to a bounded `cause` label value.
+ * Raw error messages or PII are never used.
+ *
+ * @param {object} params
+ * @param {number} params.status - HTTP status code.
+ * @param {string} [params.errorCode] - Structured error classification.
+ * @returns {string} Bounded value from {@link KYC_WEBHOOK_CAUSE_ENUM}.
+ */
+function normalizeKycWebhookCause({ status, errorCode }) {
+  if (errorCode && KYC_WEBHOOK_CAUSE_ENUM.includes(errorCode)) {
+    return errorCode;
+  }
+  const code = Number(status);
+  if (code < 400) { return 'none'; }
+  return 'internal';
+}
+
+/**
+ * Histogram: Wall-clock duration of KYC webhook endpoint requests in seconds.
+ * @type {import('prom-client').Histogram}
+ */
+const kycWebhookRequestDurationSeconds = new client.Histogram({
+  name: 'kyc_webhook_request_duration_seconds',
+  help: 'Duration of KYC webhook endpoint requests in seconds',
+  labelNames: ['status_class'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [registry],
+});
+
+/**
+ * Counter: Total KYC webhook requests by status class.
+ * @type {import('prom-client').Counter}
+ */
+const kycWebhookRequestsTotal = new client.Counter({
+  name: 'kyc_webhook_requests_total',
+  help: 'Total number of KYC webhook endpoint requests',
+  labelNames: ['status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: KYC webhook request errors by cause.
+ * @type {import('prom-client').Counter}
+ */
+const kycWebhookErrorsTotal = new client.Counter({
+  name: 'kyc_webhook_errors_total',
+  help: 'Total number of KYC webhook endpoint request errors by cause',
+  labelNames: ['cause'],
+  registers: [registry],
+});
+
 
 /**
  * Returns the shared Prometheus registry.
@@ -1150,6 +1241,11 @@ module.exports = {
   cacheStoreErrorsTotal,
   redisCacheFailOpenTotal,
   sorobanCircuitBreakerStateTransitionsTotal,
+  kycWebhookRequestDurationSeconds,
+  kycWebhookRequestsTotal,
+  kycWebhookErrorsTotal,
+  normalizeKycWebhookStatusClass,
+  normalizeKycWebhookCause,
   normalizeJobType,
   normalizeReminderReason,
   normalizeSorobanRpcMethod,

--- a/src/routes/kyc.js
+++ b/src/routes/kyc.js
@@ -4,6 +4,13 @@ const express = require('express');
 const { verifySignature } = require('../services/webhooks');
 const kycService = require('../services/kycService');
 const logger = require('../logger');
+const {
+  kycWebhookRequestDurationSeconds,
+  kycWebhookRequestsTotal,
+  kycWebhookErrorsTotal,
+  normalizeKycWebhookStatusClass,
+  normalizeKycWebhookCause,
+} = require('../metrics');
 
 const router = express.Router();
 
@@ -104,6 +111,21 @@ function parseJsonPayload(rawBody) {
  *                   type: string
  */
 router.post('/webhook', async (req, res) => {
+  const startTime = process.hrtime.bigint();
+  let statusClass = '2xx';
+  let cause = 'none';
+
+  const finish = (httpStatus, errorCode) => {
+    const elapsed = Number(process.hrtime.bigint() - startTime) / 1e9;
+    statusClass = normalizeKycWebhookStatusClass(httpStatus);
+    cause = normalizeKycWebhookCause({ status: httpStatus, errorCode });
+    kycWebhookRequestDurationSeconds.observe({ status_class: statusClass }, elapsed);
+    kycWebhookRequestsTotal.inc({ status_class: statusClass });
+    if (cause !== 'none') {
+      kycWebhookErrorsTotal.inc({ cause });
+    }
+  };
+
   const config = kycService.getKycProviderConfig();
   const secret = config.apiSecret;
   const signatureHeader = req.header('X-Signature');
@@ -111,16 +133,19 @@ router.post('/webhook', async (req, res) => {
 
   if (!secret) {
     logger.warn({ route: '/api/kyc/webhook' }, 'KYC webhook secret is not configured');
+    finish(503, 'missing_secret');
     return res.status(503).json({ error: 'KYC webhook ingestion is not configured' });
   }
 
   if (!signatureHeader) {
+    finish(401, 'missing_signature');
     return res.status(401).json({ error: 'Missing X-Signature header' });
   }
 
   const verification = verifySignature(secret, rawBody, signatureHeader);
   if (!verification.valid) {
     logger.warn({ error: verification.error }, 'Invalid KYC webhook signature');
+    finish(401, 'invalid_signature');
     return res.status(401).json({ error: 'Invalid webhook signature' });
   }
 
@@ -128,6 +153,7 @@ router.post('/webhook', async (req, res) => {
   try {
     payload = parseJsonPayload(rawBody);
   } catch (error) {
+    finish(400, 'invalid_payload');
     return res.status(400).json({ error: error.message });
   }
 
@@ -137,10 +163,12 @@ router.post('/webhook', async (req, res) => {
   const verifiedAt = payload.verifiedAt || payload.verified_at || null;
 
   if (!smeId || typeof smeId !== 'string') {
+    finish(400, 'missing_sme_id');
     return res.status(400).json({ error: 'Missing or invalid smeId' });
   }
 
   if (!status || typeof status !== 'string') {
+    finish(400, 'missing_status');
     return res.status(400).json({ error: 'Missing or invalid status' });
   }
 
@@ -154,6 +182,7 @@ router.post('/webhook', async (req, res) => {
       { smeId, status },
       'KYC webhook received status outside PROVIDER_STATUS_MAP; rejecting (fail-closed)',
     );
+    finish(400, 'unknown_status');
     return res.status(400).json({ error: `Unknown provider status: ${status}` });
   }
 
@@ -174,10 +203,12 @@ router.post('/webhook', async (req, res) => {
       'KYC webhook ingested successfully'
     );
 
+    finish(200);
     return res.status(200).json({ success: true, smeId: record.smeId, status: record.status });
   } catch (error) {
     logger.error({ smeId, error: error.message }, 'Failed to process KYC webhook');
-    return res.status(400).json({ error: error.message });
+    finish(500, 'persistence_error');
+    return res.status(500).json({ error: error.message });
   }
 });
 

--- a/tests/kyc.provider.test.js
+++ b/tests/kyc.provider.test.js
@@ -1036,3 +1036,329 @@ describe('KYC webhook route', () => {
     expect(update).toHaveBeenCalled();
   });
 });
+
+// ── 18. KYC webhook metrics (issue #731) ────────────────────────────────────
+
+describe('KYC webhook metrics (issue #731)', () => {
+  let app;
+  let metrics;
+
+  beforeEach(() => {
+    app = require('express')();
+    app.use(require('express').raw({ type: 'application/json', limit: '100kb' }));
+    app.use('/api/kyc', kycRoutes);
+    metrics = require('../src/metrics');
+    metrics.kycWebhookRequestDurationSeconds.reset();
+    metrics.kycWebhookRequestsTotal.reset();
+    metrics.kycWebhookErrorsTotal.reset();
+  });
+
+  function getHashEntries(metric) {
+    return Object.values(metric.hashMap || {});
+  }
+
+  it('emits 2xx status class metric on successful webhook ingestion', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = {
+      smeId: 'sme-metric-01',
+      status: 'approved',
+      recordId: 'rec_metric_01',
+      verifiedAt: '2026-06-24T12:00:00.000Z',
+    };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue([1]),
+      update: jest.fn().mockResolvedValue(1),
+    }));
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(200);
+
+    const reqEntries = getHashEntries(metrics.kycWebhookRequestsTotal);
+    const req2xx = reqEntries.find((e) => e.labels.status_class === '2xx');
+    expect(req2xx).toBeDefined();
+    expect(req2xx.value).toBe(1);
+
+    const durationEntries = getHashEntries(metrics.kycWebhookRequestDurationSeconds);
+    const dur2xx = durationEntries.find((e) => e.labels && e.labels.status_class === '2xx');
+    expect(dur2xx).toBeDefined();
+  });
+
+  it('emits 4xx status class and missing_signature cause on missing X-Signature', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = { smeId: 'sme-metric-02', status: 'approved' };
+    const rawBody = JSON.stringify(payload);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .send(rawBody);
+
+    expect(res.status).toBe(401);
+
+    const reqEntries = getHashEntries(metrics.kycWebhookRequestsTotal);
+    const req4xx = reqEntries.find((e) => e.labels.status_class === '4xx');
+    expect(req4xx).toBeDefined();
+    expect(req4xx.value).toBe(1);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errSig = errEntries.find((e) => e.labels.cause === 'missing_signature');
+    expect(errSig).toBeDefined();
+    expect(errSig.value).toBe(1);
+  });
+
+  it('emits 4xx status class and invalid_signature cause on bad signature', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = { smeId: 'sme-metric-03', status: 'approved' };
+    const rawBody = JSON.stringify(payload);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', 't=123,v1=deadbeef')
+      .send(rawBody);
+
+    expect(res.status).toBe(401);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errSig = errEntries.find((e) => e.labels.cause === 'invalid_signature');
+    expect(errSig).toBeDefined();
+    expect(errSig.value).toBe(1);
+  });
+
+  it('emits 4xx and unknown_status cause for unrecognized provider status', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = { smeId: 'sme-metric-04', status: 'mystery_status' };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(400);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errStatus = errEntries.find((e) => e.labels.cause === 'unknown_status');
+    expect(errStatus).toBeDefined();
+    expect(errStatus.value).toBe(1);
+  });
+
+  it('emits 5xx status class and missing_secret cause when KYC_PROVIDER_SECRET is absent', async () => {
+    delete process.env.KYC_PROVIDER_SECRET;
+
+    const payload = { smeId: 'sme-metric-05', status: 'approved' };
+    const rawBody = JSON.stringify(payload);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .send(rawBody);
+
+    expect(res.status).toBe(503);
+
+    const reqEntries = getHashEntries(metrics.kycWebhookRequestsTotal);
+    const req5xx = reqEntries.find((e) => e.labels.status_class === '5xx');
+    expect(req5xx).toBeDefined();
+    expect(req5xx.value).toBe(1);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errSecret = errEntries.find((e) => e.labels.cause === 'missing_secret');
+    expect(errSecret).toBeDefined();
+    expect(errSecret.value).toBe(1);
+  });
+
+  it('emits 4xx and invalid_payload cause for malformed JSON body', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const rawBody = '{ invalid json';
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(400);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errPayload = errEntries.find((e) => e.labels.cause === 'invalid_payload');
+    expect(errPayload).toBeDefined();
+    expect(errPayload.value).toBe(1);
+  });
+
+  it('emits 4xx and missing_sme_id cause when smeId is absent', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = { status: 'approved' };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Missing or invalid smeId/);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errSme = errEntries.find((e) => e.labels.cause === 'missing_sme_id');
+    expect(errSme).toBeDefined();
+    expect(errSme.value).toBe(1);
+  });
+
+  it('emits 4xx and missing_status cause when status is absent', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = { smeId: 'sme-metric-07' };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Missing or invalid status/);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errStatus = errEntries.find((e) => e.labels.cause === 'missing_status');
+    expect(errStatus).toBeDefined();
+    expect(errStatus.value).toBe(1);
+  });
+
+  it('emits 5xx and persistence_error cause when persistKycRecord throws', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = {
+      smeId: 'sme-metric-08',
+      status: 'approved',
+      recordId: 'rec_metric_08',
+    };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockRejectedValue(new Error('DB write failed')),
+      update: jest.fn().mockResolvedValue(1),
+    }));
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/DB write failed/);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const errPersist = errEntries.find((e) => e.labels.cause === 'persistence_error');
+    expect(errPersist).toBeDefined();
+    expect(errPersist.value).toBe(1);
+  });
+
+  it('no error metric is emitted for 2xx success responses', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'webhook-secret';
+
+    const payload = {
+      smeId: 'sme-metric-09',
+      status: 'approved',
+      recordId: 'rec_metric_09',
+    };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('webhook-secret', rawBody);
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue([1]),
+      update: jest.fn().mockResolvedValue(1),
+    }));
+
+    await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    const errEntries = getHashEntries(metrics.kycWebhookErrorsTotal);
+    const noneValues = errEntries.filter((v) => v.labels.cause === 'none');
+    expect(noneValues.length).toBe(0);
+  });
+});
+
+// ── 19. KYC webhook metrics normalizers (issue #731) ────────────────────────
+
+describe('normalizeKycWebhookStatusClass (issue #731)', () => {
+  const { normalizeKycWebhookStatusClass } = require('../src/metrics');
+
+  it('returns 2xx for successful statuses', () => {
+    expect(normalizeKycWebhookStatusClass(200)).toBe('2xx');
+    expect(normalizeKycWebhookStatusClass(201)).toBe('2xx');
+  });
+
+  it('returns 4xx for client error statuses', () => {
+    expect(normalizeKycWebhookStatusClass(400)).toBe('4xx');
+    expect(normalizeKycWebhookStatusClass(401)).toBe('4xx');
+    expect(normalizeKycWebhookStatusClass(404)).toBe('4xx');
+  });
+
+  it('returns 5xx for server error statuses', () => {
+    expect(normalizeKycWebhookStatusClass(500)).toBe('5xx');
+    expect(normalizeKycWebhookStatusClass(503)).toBe('5xx');
+  });
+
+  it('handles non-numeric input gracefully', () => {
+    expect(normalizeKycWebhookStatusClass('400')).toBe('4xx');
+    expect(normalizeKycWebhookStatusClass(undefined)).toBe('2xx');
+    expect(normalizeKycWebhookStatusClass(null)).toBe('2xx');
+  });
+});
+
+describe('normalizeKycWebhookCause (issue #731)', () => {
+  const { normalizeKycWebhookCause } = require('../src/metrics');
+
+  it('returns none for 2xx responses without error code', () => {
+    expect(normalizeKycWebhookCause({ status: 200 })).toBe('none');
+    expect(normalizeKycWebhookCause({ status: 201 })).toBe('none');
+  });
+
+  it('returns the errorCode when it is a valid bounded value', () => {
+    expect(normalizeKycWebhookCause({ status: 400, errorCode: 'missing_sme_id' })).toBe('missing_sme_id');
+    expect(normalizeKycWebhookCause({ status: 401, errorCode: 'invalid_signature' })).toBe('invalid_signature');
+    expect(normalizeKycWebhookCause({ status: 503, errorCode: 'missing_secret' })).toBe('missing_secret');
+  });
+
+  it('returns internal for unknown error codes', () => {
+    expect(normalizeKycWebhookCause({ status: 500, errorCode: 'something_unexpected' })).toBe('internal');
+    expect(normalizeKycWebhookCause({ status: 400, errorCode: '' })).toBe('4xx' ? 'internal' : 'internal');
+  });
+
+  it('returns internal for 4xx without an error code', () => {
+    expect(normalizeKycWebhookCause({ status: 400 })).toBe('internal');
+    expect(normalizeKycWebhookCause({ status: 500 })).toBe('internal');
+  });
+});


### PR DESCRIPTION
## Summary
- Add internal to KYC_WEBHOOK_CAUSE_ENUM for fallback classification
- Change persistence error from 4xx to 5xx (500 status code)
- Switch to process.hrtime.bigint() for monotonic timing
- Update tests to match new behavior (83/83 pass)

Fixes #731