### PR TITLE
feat(health): add metrics and structured logging

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -44,6 +44,7 @@ const { validateHealthQuery, rejectBodyOnGet } = require('./schemas/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
+const { instrumentHealth } = require('./middleware/healthMetrics');
 const smeRoutes = require('./routes/sme');
 const invoiceFileRoutes = require('./routes/invoiceFile');
 const auditTrailRoutes = require('./routes/auditTrail');
@@ -160,27 +161,27 @@ function createApp() {
   // ── Health / Liveness / Readiness ──────────────────────────────────────
 
   // Liveness probe — no external dependencies
-  app.get('/health', rejectBodyOnGet, validateHealthQuery, (req, res) => {
+  app.get('/health', rejectBodyOnGet, validateHealthQuery, instrumentHealth('health_liveness', (req, res) => {
     res.json({
       status: 'ok',
       service: 'liquifact-api',
       version: '0.1.0',
       timestamp: new Date().toISOString(),
     });
-  });
+  }));
 
   // Liveness alias (Kubernetes convention)
-  app.get('/healthz', rejectBodyOnGet, validateHealthQuery, (req, res) => {
+  app.get('/healthz', rejectBodyOnGet, validateHealthQuery, instrumentHealth('health_liveness', (req, res) => {
     res.json({
       status: 'ok',
       service: 'liquifact-api',
       version: '0.1.0',
       timestamp: new Date().toISOString(),
     });
-  });
+  }));
 
   // Full health check (all dependencies)
-  app.get('/ready', rejectBodyOnGet, validateHealthQuery, async (req, res) => {
+  app.get('/ready', rejectBodyOnGet, validateHealthQuery, instrumentHealth('health_full', async (req, res) => {
     try {
       const { healthy, checks } = await performHealthChecks();
       const status = healthy ? 200 : 503;
@@ -199,10 +200,10 @@ function createApp() {
         error: error.message,
       });
     }
-  });
+  }));
 
   // Readiness probe (critical deps only: DB, Soroban RPC)
-  app.get('/readyz', rejectBodyOnGet, validateHealthQuery, async (req, res) => {
+  app.get('/readyz', rejectBodyOnGet, validateHealthQuery, instrumentHealth('health_readiness', async (req, res) => {
     try {
       const { healthy, checks } = await performReadinessChecks();
       const status = healthy ? 200 : 503;
@@ -221,7 +222,7 @@ function createApp() {
         error: error.message,
       });
     }
-  });
+  }));
 
   // API info
   app.get('/api', (req, res) => {

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1107,6 +1107,149 @@ const persistenceRequestErrorsTotal = new client.Counter({
   registers: [registry],
 });
 
+// ── Health endpoint metrics ────────────────────────────────────────────────
+
+/**
+ * Bounded enum of allowed `endpoint` label values for health metrics.
+ * @readonly
+ */
+const HEALTH_ENDPOINT_ENUM = Object.freeze([
+  'health_liveness',
+  'health_full',
+  'health_readiness',
+  'health_checks_list',
+  'health_reports_submit',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `status_class` label values for health metrics.
+ * @readonly
+ */
+const HEALTH_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
+
+/**
+ * Bounded enum of allowed `cause` label values for health metrics.
+ * Raw error messages are NEVER used as labels.
+ * @readonly
+ */
+const HEALTH_CAUSE_ENUM = Object.freeze([
+  'validation',
+  'timeout',
+  'dependency_failure',
+  'internal',
+  'none',
+]);
+
+/**
+ * Maps a raw health endpoint hint to a bounded metric label value.
+ *
+ * @param {unknown} raw - Raw endpoint identifier.
+ * @returns {string} Bounded value from {@link HEALTH_ENDPOINT_ENUM}.
+ */
+function normalizeHealthEndpoint(raw) {
+  const str = typeof raw === 'string' ? raw.trim() : '';
+  return HEALTH_ENDPOINT_ENUM.includes(str) ? str : 'unknown';
+}
+
+/**
+ * Maps an HTTP status code to a bounded `status_class` label value.
+ *
+ * @param {unknown} status - HTTP status code.
+ * @returns {string} Bounded value from {@link HEALTH_STATUS_CLASS_ENUM}.
+ */
+function normalizeHealthStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
+
+/**
+ * Maps a raw health endpoint failure to a bounded `cause` label value.
+ *
+ * A 2xx outcome maps to `none`. 4xx responses map to `validation`.
+ * 5xx errors with timeout-like characteristics map to `timeout`;
+ * errors indicating dependency failure (database, Soroban RPC, storage, etc.)
+ * map to `dependency_failure`; everything else maps to `internal`.
+ *
+ * @param {unknown} err - Raw error object or code (null/undefined for success).
+ * @param {number} [status] - HTTP status code, used to disambiguate.
+ * @returns {string} Bounded value from {@link HEALTH_CAUSE_ENUM}.
+ */
+function normalizeHealthCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+
+  if (code >= 400 && code < 500) { return 'validation'; }
+
+  if (err) {
+    const errCode = typeof err === 'object' && 'code' in err ? String(err.code) : '';
+    const errMessage = typeof err === 'object' && 'message' in err ? String(err.message).toLowerCase() : '';
+
+    // Timeout-like errors
+    if (
+      errCode === 'ETIMEDOUT' ||
+      errCode === 'ECONNABORTED' ||
+      errCode === 'ABORT_ERR' ||
+      errMessage.includes('timeout') ||
+      errMessage.includes('timed out') ||
+      errMessage.includes('abort')
+    ) {
+      return 'timeout';
+    }
+
+    // Dependency failure indicators
+    if (
+      errCode === 'ECONNREFUSED' ||
+      errCode === 'ENOTFOUND' ||
+      errCode === 'POOL_ACQUIRE_TIMEOUT' ||
+      errMessage.includes('database') ||
+      errMessage.includes('unreachable') ||
+      errMessage.includes('soroban') ||
+      errMessage.includes('storage') ||
+      errMessage.includes('reconciliation')
+    ) {
+      return 'dependency_failure';
+    }
+  }
+
+  return 'internal';
+}
+
+/**
+ * Histogram: Wall-clock duration of health endpoint requests in seconds.
+ * @type {import('prom-client').Histogram}
+ */
+const healthRequestDurationSeconds = new client.Histogram({
+  name: 'health_request_duration_seconds',
+  help: 'Duration of health endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [registry],
+});
+
+/**
+ * Counter: Total health endpoint requests.
+ * @type {import('prom-client').Counter}
+ */
+const healthRequestsTotal = new client.Counter({
+  name: 'health_requests_total',
+  help: 'Total number of health endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: Health endpoint request errors by cause.
+ * @type {import('prom-client').Counter}
+ */
+const healthRequestErrorsTotal = new client.Counter({
+  name: 'health_request_errors_total',
+  help: 'Total number of health endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
 
 /**
  * Returns the shared Prometheus registry.
@@ -1156,6 +1299,15 @@ module.exports = {
   normalizeSorobanRpcOutcome,
   normalizeSorobanRetryCause,
   normalizeReminderReason,
+  healthRequestDurationSeconds,
+  healthRequestsTotal,
+  healthRequestErrorsTotal,
+  normalizeHealthEndpoint,
+  normalizeHealthStatusClass,
+  normalizeHealthCause,
+  HEALTH_ENDPOINT_ENUM,
+  HEALTH_STATUS_CLASS_ENUM,
+  HEALTH_CAUSE_ENUM,
   startMetricsRefresh,
   stopMetricsRefresh,
 };

--- a/src/middleware/healthMetrics.js
+++ b/src/middleware/healthMetrics.js
@@ -1,0 +1,118 @@
+'use strict';
+
+/**
+ * @fileoverview Instrumentation wrapper for health endpoints.
+ *
+ * Wraps an async Express handler so that every request records:
+ *   - request duration (histogram, labelled by endpoint + status class)
+ *   - a request count (counter, labelled by endpoint + status class)
+ *   - an error count on failure (counter, labelled by endpoint + bounded cause)
+ *   - a single structured log line (no PII: endpoint and outcome only)
+ *
+ * Labels are bounded via the normalizeHealth* helpers in ../metrics to keep
+ * Prometheus time-series cardinality fixed.
+ *
+ * @module middleware/healthMetrics
+ */
+
+const {
+  healthRequestDurationSeconds,
+  healthRequestsTotal,
+  healthRequestErrorsTotal,
+  normalizeHealthEndpoint,
+  normalizeHealthStatusClass,
+  normalizeHealthCause,
+} = require('../metrics');
+const logger = require('../logger');
+
+/**
+ * Records metrics and a structured log for one completed health request.
+ *
+ * Kept separate from {@link instrumentHealth} so it can be unit-tested in
+ * isolation against each status class without driving a full HTTP request.
+ *
+ * @param {object} params
+ * @param {string} params.endpoint - Raw endpoint hint (bounded on use).
+ * @param {number} params.statusCode - Final HTTP status code.
+ * @param {number} params.durationSeconds - Wall-clock duration in seconds.
+ * @param {unknown} [params.error] - Error thrown by the handler, if any.
+ * @param {import('express').Request} [params.req] - Request, for a scoped logger.
+ * @returns {void}
+ */
+function recordHealthOutcome({ endpoint, statusCode, durationSeconds, error, req }) {
+  const ep = normalizeHealthEndpoint(endpoint);
+  const statusClass = normalizeHealthStatusClass(statusCode);
+
+  healthRequestDurationSeconds.labels(ep, statusClass).observe(durationSeconds);
+  healthRequestsTotal.labels(ep, statusClass).inc();
+
+  const cause = normalizeHealthCause(error, statusCode);
+  if (cause !== 'none') {
+    healthRequestErrorsTotal.labels(ep, cause).inc();
+  }
+
+  // Structured log — safe fields only. Never log PII, dependency URLs,
+  // or raw error messages that could contain sensitive data.
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    endpoint: ep,
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'health endpoint request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'health endpoint request rejected');
+  } else {
+    log.info(fields, 'health endpoint request completed');
+  }
+}
+
+/**
+ * Wraps an async health handler with metrics + structured logging.
+ *
+ * The wrapped handler runs normally. Duration is measured from entry to the
+ * moment the response finishes (`res.on('finish')`), so the recorded status
+ * code is the one actually sent. If the handler throws, the error is recorded
+ * and re-thrown to the next error middleware.
+ *
+ * @param {string} endpoint - Bounded endpoint label (see HEALTH_ENDPOINT_ENUM).
+ * @param {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>} handler
+ * @returns {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>}
+ */
+function instrumentHealth(endpoint, handler) {
+  return async function instrumentedHealthHandler(req, res, next) {
+    const startNs = process.hrtime.bigint();
+    let recorded = false;
+
+    // Single source of truth: record on response finish, when the final status
+    // code is known. A thrown handler stashes its error on res.locals so the
+    // finish listener can classify the cause consistently with that status.
+    res.on('finish', () => {
+      if (recorded) { return; }
+      recorded = true;
+      const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+      recordHealthOutcome({
+        endpoint,
+        statusCode: res.statusCode,
+        durationSeconds,
+        error: res.locals && res.locals.healthError,
+        req,
+      });
+    });
+
+    try {
+      await handler(req, res, next);
+    } catch (err) {
+      if (res.locals) { res.locals.healthError = err; }
+      return next(err);
+    }
+  };
+}
+
+module.exports = { instrumentHealth, recordHealthOutcome };

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -37,6 +37,7 @@ const {
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { healthReportSchema, parseValidationErrors } = require('../schemas/healthReport');
 const logger = require('../logger');
+const { instrumentHealth } = require('../middleware/healthMetrics');
 
 /**
  * @swagger
@@ -86,7 +87,7 @@ const logger = require('../logger');
  *         description: Malformed or tampered cursor.
  *         $ref: '#/components/responses/Problem400'
  */
-router.get('/checks', async (req, res, next) => {
+router.get('/checks', instrumentHealth('health_checks_list', async (req, res, next) => {
   try {
     const limit = resolveLimit(req.query.limit);
     const rawCursor = req.query.cursor;
@@ -163,7 +164,7 @@ router.get('/checks', async (req, res, next) => {
   } catch (error) {
     next(error);
   }
-});
+}));
 
 // ── Health report write endpoint ─────────────────────────────────────────────
 
@@ -237,7 +238,7 @@ router.get('/checks', async (req, res, next) => {
 router.post(
   '/reports',
   idempotencyMiddleware,
-  (req, res) => {
+  instrumentHealth('health_reports_submit', (req, res) => {
     const requestLogger = logger.createRequestLogger(req);
 
     // Validate the request body with Zod
@@ -279,7 +280,7 @@ router.post(
       },
       message: `Health report for '${serviceName}' accepted.`,
     });
-  }
+  })
 );
 
 module.exports = router;

--- a/tests/health.metrics.test.js
+++ b/tests/health.metrics.test.js
@@ -1,0 +1,316 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const { instrumentHealth, recordHealthOutcome } = require('../src/middleware/healthMetrics');
+const metrics = require('../src/metrics');
+
+/** Reads a single counter value for a label set (real prom-client, async get). */
+async function counterValue(counter, labels) {
+  const metric = await counter.get();
+  const keys = Object.keys(labels);
+  const match = (metric.values || []).find((v) =>
+    keys.every((k) => String(v.labels[k]) === String(labels[k])),
+  );
+  return match ? match.value : 0;
+}
+
+describe('health metrics instrumentation', () => {
+  beforeEach(() => {
+    metrics.healthRequestDurationSeconds.reset();
+    metrics.healthRequestsTotal.reset();
+    metrics.healthRequestErrorsTotal.reset();
+  });
+
+  describe('normalizeHealthStatusClass', () => {
+    it('maps 2xx, 4xx, 5xx correctly', () => {
+      expect(metrics.normalizeHealthStatusClass(200)).toBe('2xx');
+      expect(metrics.normalizeHealthStatusClass(201)).toBe('2xx');
+      expect(metrics.normalizeHealthStatusClass(400)).toBe('4xx');
+      expect(metrics.normalizeHealthStatusClass(404)).toBe('4xx');
+      expect(metrics.normalizeHealthStatusClass(503)).toBe('5xx');
+      expect(metrics.normalizeHealthStatusClass(500)).toBe('5xx');
+      expect(metrics.normalizeHealthStatusClass('200')).toBe('2xx');
+    });
+  });
+
+  describe('normalizeHealthEndpoint', () => {
+    it('passes known endpoints', () => {
+      expect(metrics.normalizeHealthEndpoint('health_liveness')).toBe('health_liveness');
+      expect(metrics.normalizeHealthEndpoint('health_full')).toBe('health_full');
+      expect(metrics.normalizeHealthEndpoint('health_readiness')).toBe('health_readiness');
+      expect(metrics.normalizeHealthEndpoint('health_checks_list')).toBe('health_checks_list');
+      expect(metrics.normalizeHealthEndpoint('health_reports_submit')).toBe('health_reports_submit');
+    });
+
+    it('collapses unknown endpoints to unknown', () => {
+      expect(metrics.normalizeHealthEndpoint('nope')).toBe('unknown');
+      expect(metrics.normalizeHealthEndpoint('')).toBe('unknown');
+      expect(metrics.normalizeHealthEndpoint(42)).toBe('unknown');
+      expect(metrics.normalizeHealthEndpoint(null)).toBe('unknown');
+    });
+  });
+
+  describe('normalizeHealthCause', () => {
+    it('returns none for success (no error, 2xx)', () => {
+      expect(metrics.normalizeHealthCause(null, 200)).toBe('none');
+      expect(metrics.normalizeHealthCause(undefined, 201)).toBe('none');
+    });
+
+    it('maps 4xx to validation', () => {
+      expect(metrics.normalizeHealthCause(null, 400)).toBe('validation');
+      expect(metrics.normalizeHealthCause({ message: 'invalid' }, 400)).toBe('validation');
+      expect(metrics.normalizeHealthCause({ message: 'bad request' }, 404)).toBe('validation');
+    });
+
+    it('maps timeout-like errors to timeout', () => {
+      expect(metrics.normalizeHealthCause({ code: 'ETIMEDOUT' }, 500)).toBe('timeout');
+      expect(metrics.normalizeHealthCause({ code: 'ECONNABORTED' }, 500)).toBe('timeout');
+      expect(metrics.normalizeHealthCause({ code: 'ABORT_ERR' }, 500)).toBe('timeout');
+      expect(metrics.normalizeHealthCause({ message: 'Connection timed out' }, 500)).toBe('timeout');
+      expect(metrics.normalizeHealthCause({ message: 'Request aborted' }, 503)).toBe('timeout');
+    });
+
+    it('maps dependency failures to dependency_failure', () => {
+      expect(metrics.normalizeHealthCause({ code: 'ECONNREFUSED' }, 500)).toBe('dependency_failure');
+      expect(metrics.normalizeHealthCause({ code: 'ENOTFOUND' }, 500)).toBe('dependency_failure');
+      expect(metrics.normalizeHealthCause({ code: 'POOL_ACQUIRE_TIMEOUT' }, 503)).toBe('dependency_failure');
+      expect(metrics.normalizeHealthCause({ message: 'Database unreachable' }, 503)).toBe('dependency_failure');
+      expect(metrics.normalizeHealthCause({ message: 'Soroban RPC error' }, 503)).toBe('dependency_failure');
+      expect(metrics.normalizeHealthCause({ message: 'Storage connectivity failed' }, 503)).toBe('dependency_failure');
+      expect(metrics.normalizeHealthCause({ message: 'Reconciliation check failed' }, 503)).toBe('dependency_failure');
+    });
+
+    it('maps other server errors to internal', () => {
+      expect(metrics.normalizeHealthCause(new Error('boom'), 500)).toBe('internal');
+      expect(metrics.normalizeHealthCause({}, 500)).toBe('internal');
+      expect(metrics.normalizeHealthCause({ code: 'UNKNOWN_ERR' }, 500)).toBe('internal');
+    });
+
+    it('handles non-error objects gracefully', () => {
+      expect(metrics.normalizeHealthCause('just a string', 500)).toBe('internal');
+      expect(metrics.normalizeHealthCause(42, 500)).toBe('internal');
+    });
+  });
+
+  describe('recordHealthOutcome', () => {
+    it('records duration + request count and no error on success', async () => {
+      recordHealthOutcome({
+        endpoint: 'health_liveness',
+        statusCode: 200,
+        durationSeconds: 0.02,
+      });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_liveness', status_class: '2xx' })).toBe(1);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_liveness', cause: 'none' })).toBe(0);
+    });
+
+    it('records a validation error on a 4xx', async () => {
+      recordHealthOutcome({
+        endpoint: 'health_checks_list',
+        statusCode: 400,
+        durationSeconds: 0.01,
+        error: { message: 'Invalid cursor' },
+      });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_checks_list', status_class: '4xx' })).toBe(1);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_checks_list', cause: 'validation' })).toBe(1);
+    });
+
+    it('records a dependency_failure error on a 5xx with dependency message', async () => {
+      recordHealthOutcome({
+        endpoint: 'health_full',
+        statusCode: 503,
+        durationSeconds: 0.5,
+        error: { message: 'Database unreachable' },
+      });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_full', status_class: '5xx' })).toBe(1);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_full', cause: 'dependency_failure' })).toBe(1);
+    });
+
+    it('records a timeout error on a 5xx with timeout message', async () => {
+      recordHealthOutcome({
+        endpoint: 'health_readiness',
+        statusCode: 503,
+        durationSeconds: 5.0,
+        error: { message: 'Connection timed out' },
+      });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_readiness', status_class: '5xx' })).toBe(1);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_readiness', cause: 'timeout' })).toBe(1);
+    });
+
+    it('records an internal error on an unknown 5xx', async () => {
+      recordHealthOutcome({
+        endpoint: 'health_reports_submit',
+        statusCode: 500,
+        durationSeconds: 0.1,
+        error: new Error('unexpected'),
+      });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_reports_submit', status_class: '5xx' })).toBe(1);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_reports_submit', cause: 'internal' })).toBe(1);
+    });
+
+    it('collapses an unknown endpoint to the bounded label', async () => {
+      recordHealthOutcome({ endpoint: 'mystery_endpoint', statusCode: 200, durationSeconds: 0.01 });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'unknown', status_class: '2xx' })).toBe(1);
+    });
+
+    it('uses a request-scoped logger when a req is supplied', async () => {
+      const req = { id: 'r2', correlationId: 'c2' };
+      expect(() => recordHealthOutcome({
+        endpoint: 'health_liveness',
+        statusCode: 200,
+        durationSeconds: 0.01,
+        req,
+      })).not.toThrow();
+    });
+
+    it('records correct status_class for 503 (5xx)', async () => {
+      recordHealthOutcome({ endpoint: 'health_full', statusCode: 503, durationSeconds: 0.3 });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_full', status_class: '5xx' })).toBe(1);
+    });
+
+    it('records correct status_class for 201 (2xx)', async () => {
+      recordHealthOutcome({ endpoint: 'health_reports_submit', statusCode: 201, durationSeconds: 0.05 });
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_reports_submit', status_class: '2xx' })).toBe(1);
+    });
+  });
+
+  describe('instrumentHealth guard branches', () => {
+    const { EventEmitter } = require('events');
+
+    /** Minimal fake res that lets us emit finish manually and toggle locals. */
+    function fakeRes({ withLocals = true, statusCode = 200 } = {}) {
+      const res = new EventEmitter();
+      res.statusCode = statusCode;
+      res.headersSent = false;
+      if (withLocals) { res.locals = {}; }
+      return res;
+    }
+
+    it('records only once even if finish fires twice', async () => {
+      const res = fakeRes({ statusCode: 200 });
+      const handler = async () => {};
+      await instrumentHealth('health_liveness', handler)({}, res, () => {});
+      res.emit('finish');
+      res.emit('finish'); // second emit must hit the `recorded` guard and no-op
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_liveness', status_class: '2xx' })).toBe(1);
+    });
+
+    it('does not throw when res.locals is absent and the handler throws', async () => {
+      const res = fakeRes({ withLocals: false, statusCode: 500 });
+      const err = new Error('no-locals');
+      const handler = async () => { throw err; };
+      let passed;
+      await instrumentHealth('health_full', handler)({}, res, (e) => { passed = e; });
+      expect(passed).toBe(err);
+      res.emit('finish'); // records with undefined error, status 500 -> internal
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_full', cause: 'internal' })).toBe(1);
+    });
+  });
+
+  describe('instrumentHealth wrapper', () => {
+    function buildApp(handler, endpoint = 'health_liveness') {
+      const app = express();
+      app.use(express.json());
+      app.get('/test-health', instrumentHealth(endpoint, handler));
+      app.use((err, _req, res, _next) => res.status(res.statusCode >= 400 ? res.statusCode : 500).json({ error: 'x' }));
+      return app;
+    }
+
+    it('records a 2xx for a successful handler', async () => {
+      const app = buildApp(async (_req, res) => { res.status(200).json({ status: 'ok' }); });
+      const res = await request(app).get('/test-health');
+      expect(res.status).toBe(200);
+      expect(await counterValue(metrics.healthRequestsTotal, { endpoint: 'health_liveness', status_class: '2xx' })).toBe(1);
+    });
+
+    it('records a 4xx when the handler responds with a client error', async () => {
+      const app = buildApp(async (_req, res) => { res.status(400).json({ error: 'bad' }); }, 'health_checks_list');
+      const res = await request(app).get('/test-health');
+      expect(res.status).toBe(400);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_checks_list', cause: 'validation' })).toBe(1);
+    });
+
+    it('records and re-throws when the handler throws', async () => {
+      const app = buildApp(async () => { const e = new Error('kaboom'); throw e; }, 'health_full');
+      const res = await request(app).get('/test-health');
+      expect(res.status).toBe(500);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_full', cause: 'internal' })).toBeGreaterThanOrEqual(1);
+    });
+
+    it('records a timeout cause when handler throws a timeout-like error', async () => {
+      const app = buildApp(async () => { const e = new Error('Connection timed out'); e.code = 'ETIMEDOUT'; throw e; }, 'health_full');
+      const res = await request(app).get('/test-health');
+      expect(res.status).toBe(500);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_full', cause: 'timeout' })).toBeGreaterThanOrEqual(1);
+    });
+
+    it('records a dependency_failure cause for a 503 with dependency error', async () => {
+      const app = buildApp(async (_req, res) => {
+        const err = new Error('Database unreachable');
+        res.locals.healthError = err;
+        res.status(503).json({ ready: false, error: err.message });
+      }, 'health_readiness');
+      const res = await request(app).get('/test-health');
+      expect(res.status).toBe(503);
+      expect(await counterValue(metrics.healthRequestErrorsTotal, { endpoint: 'health_readiness', cause: 'dependency_failure' })).toBeGreaterThanOrEqual(1);
+    });
+
+    it('records all endpoint types correctly', async () => {
+      const endpoints = [
+        'health_liveness',
+        'health_full',
+        'health_readiness',
+        'health_checks_list',
+        'health_reports_submit',
+      ];
+
+      for (const ep of endpoints) {
+        const app = buildApp(async (_req, res) => { res.status(200).json({ ok: true }); }, ep);
+        await request(app).get('/test-health');
+        expect(await counterValue(metrics.healthRequestsTotal, { endpoint: ep, status_class: '2xx' })).toBe(1);
+      }
+    });
+  });
+
+  describe('health metrics counters are exported on /metrics endpoint', () => {
+    it('metrics module exposes health metrics', () => {
+      expect(metrics.healthRequestDurationSeconds).toBeDefined();
+      expect(metrics.healthRequestsTotal).toBeDefined();
+      expect(metrics.healthRequestErrorsTotal).toBeDefined();
+    });
+
+    it('health metrics use the shared registry', () => {
+      const registry = metrics.getRegistry();
+      const healthDurationMetric = registry.getSingleMetric('health_request_duration_seconds');
+      const healthRequestsTotalMetric = registry.getSingleMetric('health_requests_total');
+      const healthRequestErrorsMetric = registry.getSingleMetric('health_request_errors_total');
+
+      expect(healthDurationMetric).toBeDefined();
+      expect(healthRequestsTotalMetric).toBeDefined();
+      expect(healthRequestErrorsMetric).toBeDefined();
+    });
+  });
+
+  describe('HEALTH_ENDPOINT_ENUM completeness', () => {
+    it('contains all expected endpoint labels', () => {
+      const enm = metrics.HEALTH_ENDPOINT_ENUM;
+      expect(enm).toContain('health_liveness');
+      expect(enm).toContain('health_full');
+      expect(enm).toContain('health_readiness');
+      expect(enm).toContain('health_checks_list');
+      expect(enm).toContain('health_reports_submit');
+      expect(enm).toContain('unknown');
+    });
+  });
+
+  describe('HEALTH_CAUSE_ENUM completeness', () => {
+    it('contains all expected cause labels', () => {
+      const enm = metrics.HEALTH_CAUSE_ENUM;
+      expect(enm).toContain('validation');
+      expect(enm).toContain('timeout');
+      expect(enm).toContain('dependency_failure');
+      expect(enm).toContain('internal');
+      expect(enm).toContain('none');
+    });
+  });
+});


### PR DESCRIPTION
Instrument the health endpoints with Prometheus metrics and structured logging:

- Add health-specific metrics to src/metrics.js:
  - healthRequestDurationSeconds histogram (endpoint x status_class)
  - healthRequestsTotal counter (endpoint x status_class)
  - healthRequestErrorsTotal counter (endpoint x cause)
  - Bounded label enums: HEALTH_ENDPOINT_ENUM, HEALTH_STATUS_CLASS_ENUM, HEALTH_CAUSE_ENUM
  - Bounded normalizers: normalizeHealthEndpoint, normalizeHealthStatusClass, normalizeHealthCause

- Create src/middleware/healthMetrics.js:
  - instrumentHealth(endpoint, handler) wrapper that records duration, counts, errors, and structured logs
  - recordHealthOutcome() for isolated testing of outcome recording
  - Follows the same pattern as persistenceMetrics.js

- Instrument health endpoints in src/app.js:
  - GET /health and /healthz → health_liveness
  - GET /ready → health_full
  - GET /readyz → health_readiness

- Instrument health endpoints in src/routes/health.js:
  - GET /api/health/checks → health_checks_list
  - POST /api/health/reports → health_reports_submit

- Add comprehensive tests in tests/health.metrics.test.js (30 tests):
  - Normalizer function tests (status class, endpoint, cause)
  - recordHealthOutcome tests (success, 4xx, 5xx, unknown endpoint, scoped logger)
  - instrumentHealth guard branches (double finish, missing locals)
  - instrumentHealth wrapper integration tests (all status classes, timeout, dependency_failure)
  - Metrics registry export verification
  - Enum completeness verification

All metrics are exposed on the existing /metrics endpoint via the shared Prometheus registry. No PII is logged — only endpoint, status_class, statusCode, durationSeconds, and bounded cause labels.

Closes #771 