### PR TITLE
feat(escrow-read): add response caching with invalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,7 @@ SENTRY_ENVIRONMENT=production
 
 # Cache
 ESCROW_CACHE_TTL_SECONDS=30
+ESCROW_CACHE_MAX_ENTRIES=500
 REDIS_ESCROW_CACHE_ENABLED=false
 # REDIS_URL=redis://localhost:6379
 # Strict TTL for cached escrow summaries. Value is clamped to [5, 300].

--- a/src/cache/redis.js
+++ b/src/cache/redis.js
@@ -270,6 +270,27 @@ class RedisEscrowSummaryCache {
       return false;
     }
   }
+
+  /**
+   * Deletes an invoice summary after a successful escrow write.
+   * Failures are non-fatal because callers can still invalidate their local cache.
+   * @param {string} invoiceId The invoice ID.
+   * @returns {Promise<boolean>} Whether Redis accepted the deletion.
+   */
+  async deleteSummary(invoiceId) {
+    if (!this.client || !isValidInvoiceId(invoiceId)) {
+      return false;
+    }
+    try {
+      const result = await this.circuitBreaker.execute(() =>
+        withTimeout(this.client.del(this.key(invoiceId)), this.timeoutMs)
+      );
+      return result !== null;
+    } catch {
+      redisCacheFailOpenTotal.inc();
+      return false;
+    }
+  }
 }
 
 /**

--- a/src/config/cache.js
+++ b/src/config/cache.js
@@ -1,11 +1,12 @@
 const DEFAULT_ESCROW_TTL_SECONDS = 30;
+const DEFAULT_ESCROW_MAX_ENTRIES = 500;
 
 /**
  * Parses the escrow cache TTL from environment variables.
  * Falls back to the default if the value is missing or not a valid number.
  *
  * @param {NodeJS.ProcessEnv} env - Environment variables to read from.
- * @returns {{ escrowTtl: number }} Cache configuration with TTL in milliseconds.
+ * @returns {{ escrowTtl: number, escrowMaxEntries: number }} Cache configuration.
  */
 function parseCacheConfig(env = process.env) {
   const raw = env.ESCROW_CACHE_TTL_SECONDS;
@@ -13,9 +14,14 @@ function parseCacheConfig(env = process.env) {
   const seconds = Number.isFinite(parsed) && parsed > 0
     ? parsed
     : DEFAULT_ESCROW_TTL_SECONDS;
+  const rawMaxEntries = Number.parseInt(env.ESCROW_CACHE_MAX_ENTRIES, 10);
+  const maxEntries = Number.isFinite(rawMaxEntries) && rawMaxEntries > 0
+    ? rawMaxEntries
+    : DEFAULT_ESCROW_MAX_ENTRIES;
 
   return {
     escrowTtl: seconds * 1000,
+    escrowMaxEntries: maxEntries,
   };
 }
 

--- a/src/config/cache.test.js
+++ b/src/config/cache.test.js
@@ -14,6 +14,13 @@ describe('cacheConfig', () => {
     delete process.env.ESCROW_CACHE_TTL_SECONDS;
     const { cacheConfig } = require('./cache');
     expect(cacheConfig.escrowTtl).toBe(30000);
+    expect(cacheConfig.escrowMaxEntries).toBe(500);
+  });
+
+  it('parses ESCROW_CACHE_MAX_ENTRIES', () => {
+    process.env.ESCROW_CACHE_MAX_ENTRIES = '25';
+    const { cacheConfig } = require('./cache');
+    expect(cacheConfig.escrowMaxEntries).toBe(25);
   });
 
   it('parses ESCROW_CACHE_TTL_SECONDS from env and converts to ms', () => {

--- a/src/jobs/escrowIndexer.js
+++ b/src/jobs/escrowIndexer.js
@@ -3,6 +3,7 @@
 const db = require('../db/knex');
 const logger = require('../logger');
 const { resolveInvoiceByAddress } = require('../config/escrowMap');
+const { escrowReadCache } = require('../services/escrowReadCache');
 const {
   escrowIndexerEventsProcessedTotal,
   escrowIndexerEventsSkippedTotal,
@@ -14,6 +15,12 @@ const { StrKey } = require('@stellar/stellar-sdk');
 const { indexerEventSchema } = require('../schemas/indexerEvent');
 
 class ValidationError extends Error {
+  /**
+   * Creates an indexer event validation error.
+   * @param {string} message Human-readable failure.
+   * @param {string} code Stable error code.
+   * @param {object|null} details Validation details.
+   */
   constructor(message, code, details = null) {
     super(message);
     this.name = 'ValidationError';
@@ -300,6 +307,8 @@ async function persistEscrowEvent({ store, transactionRunner }, rawEvent) {
     }
   });
 
+  // Projection writes supersede any process-local response cached for this invoice.
+  escrowReadCache.invalidate(event.invoiceId);
   return event;
 }
 

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1107,6 +1107,25 @@ const persistenceRequestErrorsTotal = new client.Counter({
   registers: [registry],
 });
 
+const escrowReadCacheHitsTotal = new client.Counter({
+  name: 'escrow_read_cache_hits_total',
+  help: 'Total escrow read cache hits',
+  registers: [registry],
+});
+
+const escrowReadCacheMissesTotal = new client.Counter({
+  name: 'escrow_read_cache_misses_total',
+  help: 'Total escrow read cache misses',
+  registers: [registry],
+});
+
+const escrowReadCacheEvictionsTotal = new client.Counter({
+  name: 'escrow_read_cache_evictions_total',
+  help: 'Total escrow read cache evictions',
+  labelNames: ['reason'],
+  registers: [registry],
+});
+
 
 /**
  * Returns the shared Prometheus registry.
@@ -1149,6 +1168,17 @@ module.exports = {
   idempotencyStorageFailureTotal,
   cacheStoreErrorsTotal,
   redisCacheFailOpenTotal,
+  escrowReadCacheHitsTotal,
+  escrowReadCacheMissesTotal,
+  escrowReadCacheEvictionsTotal,
+  persistenceRequestDurationSeconds,
+  persistenceRequestsTotal,
+  persistenceRequestErrorsTotal,
+  PERSISTENCE_STATUS_CLASS_ENUM,
+  PERSISTENCE_CAUSE_ENUM,
+  normalizePersistenceEndpoint,
+  normalizePersistenceStatusClass,
+  normalizePersistenceCause,
   sorobanCircuitBreakerStateTransitionsTotal,
   normalizeJobType,
   normalizeReminderReason,

--- a/src/routes/invest.js
+++ b/src/routes/invest.js
@@ -26,6 +26,7 @@ const { requireKycForFunding } = require('../middleware/kycGating');
 const { legalHoldGate } = require('../middleware/legalHoldGate');
 const { resolveEscrowAddress, EscrowNotFoundError } = require('../config/escrowMap');
 const { submitFundEscrow, EscrowSubmitError } = require('../services/escrowSubmit');
+const { invalidateEscrowReadCache } = require('../services/escrowRead');
 const {
   persistCommitment,
   normalizeAmountStroopsInput,
@@ -294,6 +295,9 @@ router.post(
       ledger: submitResult.ledger,
       idempotencyKey,
     });
+
+    // A successful escrow write makes any previously cached read stale.
+    await invalidateEscrowReadCache(invoiceId);
 
     // 7. Return real status — never return internal detail fields like idempotencyKey
     return res.status(200).json({

--- a/src/services/escrowRead.js
+++ b/src/services/escrowRead.js
@@ -39,6 +39,7 @@ const logger = require("../logger");
 const { getTokenMetadata } = require("./tokenMeta");
 const db = require("../db/knex");
 const { createRedisEscrowSummaryCache } = require("../cache/redis");
+const { escrowReadCache } = require("./escrowReadCache");
 
 const cache = createRedisEscrowSummaryCache();
 
@@ -680,15 +681,22 @@ async function getEscrowStateWithProjection(invoiceId, options = {}) {
   const safeId = invoiceId.trim();
   const { dbClient } = options;
 
-  // 1. Try cache first if enabled. Cache wins on hit.
+  // 1. The bounded local cache avoids DB/Redis work on the hottest reads.
+  const localCached = escrowReadCache.get(safeId);
+  if (localCached !== undefined) {
+    return localCached;
+  }
+
+  // 2. Try the optional shared Redis cache. Cache wins on hit.
   if (cache) {
     const cacheResult = await cache.getSummary(safeId);
     if (cacheResult.hit) {
+      escrowReadCache.set(safeId, cacheResult.value);
       return cacheResult.value;
     }
   }
 
-  // 2. Read from the projection table via the shared helper, so projection
+  // 3. Read from the projection table via the shared helper, so projection
   //    shape stays consistent with readEscrowState / readFundedAmount /
   //    readEscrowStateWithAttestations.
   const projectionState = await _readBaseStateFromProjection(safeId, dbClient);
@@ -700,10 +708,11 @@ async function getEscrowStateWithProjection(invoiceId, options = {}) {
         projectionState.latest_ledger_sequence,
       );
     }
+    escrowReadCache.set(safeId, projectionState);
     return projectionState;
   }
 
-  // 3. Fallback to live RPC read (neutral stub currently; real Soroban call
+  // 4. Fallback to live RPC read (neutral stub currently; real Soroban call
   //    once the contract is deployed).
   const baseState = await _fetchBaseEscrowState(safeId, undefined, { dbClient });
   // Issue #424 — read the tri-state so unknown failures stay distinguishable
@@ -735,8 +744,26 @@ async function getEscrowStateWithProjection(invoiceId, options = {}) {
     // For live reads, we might not know the exact ledger, so we omit it.
     await cache.setSummary(safeId, state);
   }
+  escrowReadCache.set(safeId, state);
 
   return state;
+}
+
+/**
+ * Invalidates the cached response for an invoice after an escrow write.
+ * @param {string} invoiceId Invoice whose cached read is stale.
+ * @returns {Promise<boolean>} Whether a local or shared entry was removed.
+ */
+async function invalidateEscrowReadCache(invoiceId) {
+  if (typeof invoiceId !== "string") {
+    return false;
+  }
+  const safeId = invoiceId.trim();
+  const localInvalidated = escrowReadCache.invalidate(safeId);
+  const redisInvalidated = cache
+    ? await cache.deleteSummary(safeId)
+    : false;
+  return localInvalidated || redisInvalidated;
 }
 
 module.exports = {
@@ -748,6 +775,7 @@ module.exports = {
   fetchAttestationAppendLog,
   validateInvoiceId,
   getEscrowStateWithProjection,
+  invalidateEscrowReadCache,
   LEGAL_HOLD_STATUS,
   LEGAL_HOLD_UNKNOWN_REASONS,
   // Exported so the gate can reuse the canonical rule instead of

--- a/src/services/escrowReadCache.js
+++ b/src/services/escrowReadCache.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const { cacheConfig } = require('../config/cache');
+const {
+  escrowReadCacheHitsTotal,
+  escrowReadCacheMissesTotal,
+  escrowReadCacheEvictionsTotal,
+} = require('../metrics');
+
+/**
+ * Bounded in-process TTL cache. Map insertion order provides LRU eviction:
+ * every hit is reinserted at the newest position.
+ */
+class EscrowReadCache {
+  /**
+   * Creates a bounded escrow response cache.
+   * @param {object} [options] Cache options.
+   * @param {number} [options.ttlMs] Entry lifetime in milliseconds.
+   * @param {number} [options.maxEntries] Maximum retained responses.
+   * @param {Function} [options.now] Clock used for deterministic tests.
+   */
+  constructor({
+    ttlMs = cacheConfig.escrowTtl,
+    maxEntries = cacheConfig.escrowMaxEntries,
+    now = Date.now,
+  } = {}) {
+    this.ttlMs = ttlMs;
+    this.maxEntries = maxEntries;
+    this.now = now;
+    this.entries = new Map();
+  }
+
+  /**
+   * Reads and refreshes the recency of a cached response.
+   * @param {string} invoiceId Cache key.
+   * @returns {object|undefined} Cached response, or undefined on a miss.
+   */
+  get(invoiceId) {
+    const entry = this.entries.get(invoiceId);
+    if (!entry) {
+      escrowReadCacheMissesTotal.inc();
+      return undefined;
+    }
+
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(invoiceId);
+      escrowReadCacheMissesTotal.inc();
+      escrowReadCacheEvictionsTotal.labels('expired').inc();
+      return undefined;
+    }
+
+    this.entries.delete(invoiceId);
+    this.entries.set(invoiceId, entry);
+    escrowReadCacheHitsTotal.inc();
+    return entry.value;
+  }
+
+  /**
+   * Stores a response and evicts least-recent entries beyond the bound.
+   * @param {string} invoiceId Cache key.
+   * @param {object} value Escrow read response.
+   * @returns {void}
+   */
+  set(invoiceId, value) {
+    if (this.entries.has(invoiceId)) {
+      this.entries.delete(invoiceId);
+    }
+    this.entries.set(invoiceId, {
+      value,
+      expiresAt: this.now() + this.ttlMs,
+    });
+
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      this.entries.delete(oldestKey);
+      escrowReadCacheEvictionsTotal.labels('capacity').inc();
+    }
+  }
+
+  /**
+   * Removes one invoice response.
+   * @param {string} invoiceId Cache key.
+   * @returns {boolean} Whether an entry existed.
+   */
+  invalidate(invoiceId) {
+    return this.entries.delete(invoiceId);
+  }
+
+  /**
+   * Removes every entry. Intended for lifecycle and test cleanup.
+   * @returns {void}
+   */
+  clear() {
+    this.entries.clear();
+  }
+}
+
+const escrowReadCache = new EscrowReadCache();
+
+module.exports = {
+  EscrowReadCache,
+  escrowReadCache,
+};

--- a/src/services/escrowReadCache.test.js
+++ b/src/services/escrowReadCache.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const {
+  escrowReadCacheHitsTotal,
+  escrowReadCacheMissesTotal,
+  escrowReadCacheEvictionsTotal,
+} = require('../metrics');
+const { EscrowReadCache } = require('./escrowReadCache');
+
+describe('EscrowReadCache', () => {
+  let clock;
+  let cache;
+
+  beforeEach(() => {
+    clock = 1000;
+    cache = new EscrowReadCache({
+      ttlMs: 100,
+      maxEntries: 2,
+      now: () => clock,
+    });
+    jest.spyOn(escrowReadCacheHitsTotal, 'inc').mockImplementation(() => {});
+    jest.spyOn(escrowReadCacheMissesTotal, 'inc').mockImplementation(() => {});
+    jest.spyOn(escrowReadCacheEvictionsTotal, 'labels').mockReturnValue({ inc: jest.fn() });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records a cold miss and then serves a hit', () => {
+    expect(cache.get('inv-1')).toBeUndefined();
+    cache.set('inv-1', { status: 'funded' });
+    expect(cache.get('inv-1')).toEqual({ status: 'funded' });
+    expect(escrowReadCacheMissesTotal.inc).toHaveBeenCalledTimes(1);
+    expect(escrowReadCacheHitsTotal.inc).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires entries at the configured TTL', () => {
+    cache.set('inv-1', { status: 'funded' });
+    clock += 100;
+    expect(cache.get('inv-1')).toBeUndefined();
+    expect(escrowReadCacheEvictionsTotal.labels).toHaveBeenCalledWith('expired');
+  });
+
+  it('evicts the least recently used entry at capacity', () => {
+    cache.set('inv-1', 1);
+    cache.set('inv-2', 2);
+    expect(cache.get('inv-1')).toBe(1);
+    cache.set('inv-3', 3);
+    expect(cache.get('inv-2')).toBeUndefined();
+    expect(cache.get('inv-1')).toBe(1);
+    expect(cache.get('inv-3')).toBe(3);
+    expect(escrowReadCacheEvictionsTotal.labels).toHaveBeenCalledWith('capacity');
+  });
+
+  it('invalidates only the affected invoice', () => {
+    cache.set('inv-1', 1);
+    cache.set('inv-2', 2);
+    expect(cache.invalidate('inv-1')).toBe(true);
+    expect(cache.get('inv-1')).toBeUndefined();
+    expect(cache.get('inv-2')).toBe(2);
+  });
+});

--- a/tests/cache.redis.test.js
+++ b/tests/cache.redis.test.js
@@ -120,6 +120,15 @@ describe('RedisEscrowSummaryCache', () => {
     expect(result.value).toEqual({ invoiceId: 'inv_ok', status: 'not_found' });
   });
 
+  it('deletes the affected invoice on write invalidation', async () => {
+    const client = new FakeRedisClient();
+    const cache = new RedisEscrowSummaryCache({ client });
+    await cache.setSummary('inv_write', { status: 'pending' }, 10);
+
+    expect(await cache.deleteSummary('inv_write')).toBe(true);
+    expect((await cache.getSummary('inv_write')).hit).toBe(false);
+  });
+
   it('does not create cache instance when optional redis cache is disabled', () => {
     const cache = createRedisEscrowSummaryCache({
       env: {


### PR DESCRIPTION
## Summary

- add a bounded in-process LRU cache for hot escrow-read responses
- make TTL and maximum entries configurable with `ESCROW_CACHE_TTL_SECONDS` and `ESCROW_CACHE_MAX_ENTRIES`
- expose Prometheus hit, miss, and eviction counters
- invalidate local and Redis entries after successful funding writes
- invalidate local responses when the escrow indexer updates a projection
- cover cold misses, hits, TTL expiry, write invalidation, and capacity eviction

Closes #789.

## Validation

Changed-file ESLint:

```text
$ eslint src/cache/redis.js src/config/cache.js src/config/cache.test.js src/jobs/escrowIndexer.js src/metrics.js src/routes/invest.js src/services/escrowRead.js src/services/escrowReadCache.js src/services/escrowReadCache.test.js tests/cache.redis.test.js
PASS (no output)
```

Direct behavioral validation:

```text
direct cache checks: PASS (cold miss, hit, invalidation, LRU eviction, TTL expiry)
```

Required repository commands currently encounter upstream/environment blockers:

```text
$ npm test
Validation Error:
Module <rootDir>/tests/mocks/setup.js in the setupFilesAfterEnv option was not found.
<rootDir> is: C:\Users\USER\Desktop\Drip7\Liquifact-backend

Root cause on this machine:
unrs-resolver: Cannot find native binding (Node.js v24.18.0)
```

```text
$ npm run build
tsconfig.build.json(3,3): error TS5103: Invalid value for '--ignoreDeprecations'.
```

```text
$ npm run lint
67 problems (62 errors, 5 warnings)
```

The full lint failure is pre-existing on `upstream/main` and includes unresolved merge markers in `tests/idempotency.test.js`, undefined identifiers in `src/routes/adminWebhooks.js`, and unrelated JSDoc/unused-variable failures. All files changed by this PR pass ESLint.
