### PR TITLE
feat: implement optional idempotency for admin config updates with un…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,16 +4529,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-siwx/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-ui": {
       "version": "1.7.17",
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.17.tgz",
@@ -6643,16 +6633,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {

--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -35,6 +35,7 @@ const {
 } = require('../schemas/config');
 const { adminConfigLimiter } = require('../middleware/rateLimit');
 const logger = require('../logger');
+const idempotencyMiddleware = require('../middleware/idempotency');
 
 const router = express.Router();
 
@@ -46,6 +47,22 @@ router.use(adminConfigLimiter);
 
 // ── Apply admin auth + tenant extraction to every route ──────────────────────
 router.use(...adminStack);
+
+/**
+ * Conditionally applies idempotency logic if the client provides the header.
+ * Allows gradual rollout without breaking existing API clients.
+ *
+ * @param {object} req - Express request
+ * @param {object} res - Express response
+ * @param {function} next - Express next callback
+ * @returns {void}
+ */
+const optionalIdempotency = (req, res, next) => {
+  if (req.header('Idempotency-Key')) {
+    return idempotencyMiddleware(req, res, next);
+  }
+  next();
+};
 
 // ── POST /api/admin/config ────────────────────────────────────────────────────
 
@@ -71,9 +88,20 @@ router.use(...adminStack);
  *       requests per 60 s window. Returns `429` with a `Retry-After` header
  *       when the budget is exhausted.
  *
+ *       **Idempotency (issue #755)**: send an `Idempotency-Key` header (8-128
+ *       URL-safe characters) to safely retry requests. Retries with the same
+ *       key and payload will return the cached response.
+ *
  *     tags: [AdminConfig]
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: header
+ *         name: Idempotency-Key
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: Optional 8-128 character URL-safe string to safely retry requests without double-applying.
  *     requestBody:
  *       required: true
  *       content:
@@ -104,7 +132,7 @@ router.use(...adminStack);
  *                 message:
  *                   type: string
  *       400:
- *         description: Validation error — body contains invalid or missing fields.
+ *         description: Validation error — body contains invalid or missing fields, or idempotency key is malformed.
  *         content:
  *           application/problem+json:
  *             schema:
@@ -122,6 +150,18 @@ router.use(...adminStack);
  *         $ref: '#/components/responses/Problem401'
  *       403:
  *         $ref: '#/components/responses/Problem403'
+ *       409:
+ *         description: Idempotency conflict — the key was reused with a different payload.
+ *         content:
+ *           application/problem+json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 type:  { type: string }
+ *                 title: { type: string }
+ *                 status: { type: integer }
+ *                 detail: { type: string }
+ *                 code:   { type: string }
  *       429:
  *         description: Rate limit exceeded (issue #754) — see Retry-After header.
  *         headers:
@@ -144,7 +184,7 @@ router.use(...adminStack);
  *                 error:   { type: string }
  *                 message: { type: string }
  */
-router.post('/', validateBody(runtimeConfigSchema), (req, res) => {
+router.post('/', validateBody(runtimeConfigSchema), optionalIdempotency, (req, res) => {
   // validateBody attaches the parsed, coerced payload to req.validated
   const { section, config: validatedConfig } = req.validated;
 

--- a/tests/unit/adminConfig.idempotency.test.js
+++ b/tests/unit/adminConfig.idempotency.test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret-at-least-32-characters-long-string-for-jest';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+// Mock DB so we can test the idempotency middleware logic
+// `idempotencyMiddleware` expects knex to return a chainable query builder.
+const mockDb = jest.fn();
+
+// We need to implement a mock transaction and basic query builder since 
+// the idempotency middleware interacts with `idempotency_keys` table.
+const mockTrx = jest.fn();
+mockDb.transaction = jest.fn(async (cb) => {
+  return cb(mockTrx);
+});
+mockDb.fn = { now: jest.fn(() => '2023-01-01T00:00:00Z') };
+
+jest.mock('../../src/db/knex', () => mockDb);
+
+jest.mock('../../src/logger', () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+
+jest.mock('../../src/metrics', () => ({
+  webhookReplayTotal: { inc: jest.fn() },
+  idempotencyStorageFailureTotal: { inc: jest.fn() },
+  registry: { contentType: 'text/plain', metrics: jest.fn().mockResolvedValue('') },
+}));
+
+jest.mock('prom-client', () => ({
+  Counter:  class { constructor() {} inc() {} },
+  Gauge:    class { constructor() {} set() {} },
+  Registry: class {
+    constructor() { this.contentType = 'text/plain'; }
+    metrics() { return ''; }
+  },
+  collectDefaultMetrics: () => {},
+}), { virtual: true });
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const adminConfigRouter = require('../../src/routes/adminConfig');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const JWT_SECRET = process.env.JWT_SECRET;
+
+/** Mint a valid admin JWT for test requests. */
+function makeAdminToken(sub = 'admin-user', tenantId = 'tenant_test') {
+  return jwt.sign({ sub, tenantId, role: 'admin' }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Stub tenant extraction
+  app.use((req, _res, next) => {
+    if (!req.tenantId) { req.tenantId = 'tenant_test'; }
+    next();
+  });
+
+  app.use('/api/admin/config', adminConfigRouter);
+
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+
+  return app;
+}
+
+const APP = buildApp();
+const AUTH = `Bearer ${makeAdminToken()}`;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/config Idempotency', () => {
+  let mockWhere, mockFirst, mockInsert, mockUpdate, mockDel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockFirst = jest.fn();
+    mockInsert = jest.fn().mockResolvedValue([1]);
+    mockUpdate = jest.fn().mockResolvedValue(1);
+    mockDel = jest.fn().mockResolvedValue(1);
+    
+    mockWhere = jest.fn().mockReturnValue({
+      first: mockFirst,
+      del: mockDel,
+      update: mockUpdate,
+    });
+
+    // Both mockTrx and mockDb need to act as query builders
+    mockTrx.mockReturnValue({
+      where: mockWhere,
+      insert: mockInsert,
+    });
+
+    mockDb.mockReturnValue({
+      where: mockWhere,
+      update: mockUpdate,
+    });
+  });
+
+  const payload = {
+    section: 'fraudThresholds',
+    config: { fraudCeiling: 10000000, manualReviewThreshold: 1000000 },
+  };
+
+  it('bypasses idempotency if no header is provided', async () => {
+    const res = await request(APP)
+      .post('/api/admin/config')
+      .set('Authorization', AUTH)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.section).toBe('fraudThresholds');
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid Idempotency-Key format', async () => {
+    const res = await request(APP)
+      .post('/api/admin/config')
+      .set('Authorization', AUTH)
+      .set('Idempotency-Key', 'invalid key!') // space and ! are invalid
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must be 8–128 URL-safe characters/);
+  });
+
+  it('handles first execution of a new idempotency key', async () => {
+    // DB returns nothing for existing key
+    mockFirst.mockResolvedValueOnce(null);
+
+    const res = await request(APP)
+      .post('/api/admin/config')
+      .set('Authorization', AUTH)
+      .set('Idempotency-Key', 'valid-key-12345678')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.section).toBe('fraudThresholds');
+    
+    // Should have checked DB inside transaction
+    expect(mockDb.transaction).toHaveBeenCalled();
+    expect(mockTrx).toHaveBeenCalledWith('idempotency_keys');
+    expect(mockInsert).toHaveBeenCalled();
+    
+    // Should persist response after returning
+    // Since res.json is hooked, we need to wait a tick for the promise to resolve
+    await new Promise(setImmediate);
+    expect(mockDb).toHaveBeenCalledWith('idempotency_keys');
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      response_status: 200,
+    }));
+  });
+
+  it('replays response for exactly matching completed key', async () => {
+    const cachedResponse = {
+      section: 'fraudThresholds',
+      config: payload.config,
+      message: 'Replayed response',
+    };
+    
+    const crypto = require('crypto');
+    const fingerprint = crypto.createHash('sha256').update(JSON.stringify(payload), 'utf8').digest('hex');
+
+    // DB returns existing completed record
+    mockFirst.mockResolvedValueOnce({
+      idempotency_key: 'valid-key-12345678',
+      request_fingerprint: fingerprint,
+      response_status: 200,
+      response_body: JSON.stringify(cachedResponse),
+      created_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+    });
+
+    const res = await request(APP)
+      .post('/api/admin/config')
+      .set('Authorization', AUTH)
+      .set('Idempotency-Key', 'valid-key-12345678')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Replayed response');
+    
+    // Should not have inserted anything or overridden res.json logic
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 Conflict when key is reused with a different payload', async () => {
+    // DB returns record with different fingerprint
+    mockFirst.mockResolvedValueOnce({
+      idempotency_key: 'valid-key-12345678',
+      request_fingerprint: 'different-fingerprint-from-previous-request',
+      response_status: 200,
+      response_body: '{}',
+      created_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+    });
+
+    const res = await request(APP)
+      .post('/api/admin/config')
+      .set('Authorization', AUTH)
+      .set('Idempotency-Key', 'valid-key-12345678')
+      .send(payload);
+
+    expect(res.status).toBe(409);
+    expect(res.body.type).toMatch(/conflict/);
+    expect(res.body.detail).toMatch(/different request body/);
+  });
+});


### PR DESCRIPTION
closed #755 

## Description
This PR implements optional idempotency support for the `POST /api/admin/config` endpoint, preventing the double-application of configuration updates during request retries. The feature is designed for safe, gradual rollout—it only enforces idempotency if the client provides the `Idempotency-Key` header. 

## Changes Made
### 1. Route & Middleware Updates (`src/routes/adminConfig.js`)
- Introduced an `optionalIdempotency` wrapper around the existing `idempotencyMiddleware`. It checks for the presence of the `Idempotency-Key` header and delegates to the underlying idempotency logic, bypassing it if the header is absent.
- Integrated the `optionalIdempotency` middleware into the `POST /api/admin/config` route handler pipeline.

### 2. OpenAPI & API Documentation
- Updated the JSDoc for `POST /api/admin/config` to document the newly supported `Idempotency-Key` header parameter.
- Documented new failure scenarios:
  - **400 Bad Request:** Now includes validation errors for malformed idempotency keys.
  - **409 Conflict:** Added response schema for idempotency conflicts (i.e., when a key is reused with a different payload).

### 3. Unit Tests (`tests/unit/adminConfig.idempotency.test.js`)
- Added a comprehensive unit test suite leveraging `supertest` and Jest mocks for database transaction builders.
- **Coverage includes:**
  - Standard bypassing of the idempotency logic when the header is omitted.
  - Rejection of invalid `Idempotency-Key` formats.
  - Correct handling and persistence of the initial request.
  - Successful replay of cached responses for exactly matching keys and payloads.
  - Verification that a `409 Conflict` is returned when a key is reused with a modified request body.

## Verification
- Unit tests have been implemented and pass.
- The OpenAPI specification dynamically updates based on the JSDoc comments.

