### PR TITLE
refactor(config): extract config business logic into service layer

### DIFF
--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -35,9 +35,8 @@ const {
 } = require('../schemas/config');
 const { adminConfigLimiter } = require('../middleware/rateLimit');
 const idempotencyMiddleware = require('../middleware/idempotency');
-const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
 const logger = require('../logger');
-const idempotencyMiddleware = require('../middleware/idempotency');
+const { applyConfigSection } = require('../services/configService');
 
 const router = express.Router();
 
@@ -196,17 +195,7 @@ router.post('/', idempotencyMiddleware, validateBody(runtimeConfigSchema), (req,
   const { section, config: validatedConfig } = req.validated;
 
   // Apply runtime configuration changes for supported sections.
-  if (section === 'cors') {
-    if (validatedConfig.origins) {
-      // Update the env var so reloadCorsOrigins can re-read it.
-      process.env.CORS_ALLOWED_ORIGINS = validatedConfig.origins.join(',');
-      reloadCorsOrigins();
-    }
-    if (validatedConfig.maxAge !== undefined) {
-      process.env.CORS_MAX_AGE = String(validatedConfig.maxAge);
-      reloadCorsMaxAge();
-    }
-  }
+  applyConfigSection(section, validatedConfig);
 
   logger.info(
     {

--- a/src/services/configService.js
+++ b/src/services/configService.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * @fileoverview Business logic for applying validated runtime configuration
+ * writes accepted by `POST /api/admin/config`.
+ *
+ * Extracted from `src/routes/adminConfig.js` (issue #879) so the route
+ * handler stays a thin HTTP layer (auth, validation, logging, response
+ * shaping) while the actual runtime side effects live here.
+ *
+ * @module services/configService
+ */
+
+const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
+
+/**
+ * Applies the runtime side effects for a validated configuration section.
+ *
+ * Currently only the `cors` section has an apply-time effect: it updates the
+ * relevant environment variable(s) and triggers the corresponding reload so
+ * the change takes effect without a server restart. All other sections are
+ * validated and echoed back by the route but have no runtime effect yet, so
+ * they are a no-op here.
+ *
+ * @param {string} section - The configuration section name (e.g. 'cors').
+ * @param {object} config - The validated, section-specific config payload.
+ * @returns {void}
+ */
+function applyConfigSection(section, config) {
+  if (section === 'cors') {
+    if (config.origins) {
+      // Update the env var so reloadCorsOrigins can re-read it.
+      process.env.CORS_ALLOWED_ORIGINS = config.origins.join(',');
+      reloadCorsOrigins();
+    }
+    if (config.maxAge !== undefined) {
+      process.env.CORS_MAX_AGE = String(config.maxAge);
+      reloadCorsMaxAge();
+    }
+  }
+}
+
+module.exports = {
+  applyConfigSection,
+};

--- a/src/services/configService.test.js
+++ b/src/services/configService.test.js
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview Unit tests for src/services/configService.js.
+ *
+ * Verifies the runtime config application logic extracted from
+ * src/routes/adminConfig.js (issue #879):
+ *  - cors section: origins-only, maxAge-only, both, and neither
+ *  - unknown sections remain a no-op
+ *  - reloadCorsOrigins / reloadCorsMaxAge are invoked exactly when expected
+ *
+ * `../config/cors` is mocked so we can assert on reload calls without
+ * depending on its real env-parsing behaviour (that's covered by
+ * src/config/cors.test.js).
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+jest.mock('../config/cors', () => ({
+  reloadCorsOrigins: jest.fn(),
+  reloadCorsMaxAge: jest.fn(),
+}));
+
+const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
+const { applyConfigSection } = require('./configService');
+
+describe('configService.applyConfigSection', () => {
+  /** Snapshot of the original environment before any test ran. */
+  let OLD_ENV;
+
+  beforeAll(() => {
+    OLD_ENV = { ...process.env };
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    delete process.env.CORS_MAX_AGE;
+  });
+
+  afterAll(() => {
+    process.env = { ...OLD_ENV };
+  });
+
+  describe('cors section — origins update', () => {
+    it('sets CORS_ALLOWED_ORIGINS from a joined origins array', () => {
+      applyConfigSection('cors', { origins: ['https://a.example.com', 'https://b.example.com'] });
+
+      expect(process.env.CORS_ALLOWED_ORIGINS).toBe('https://a.example.com,https://b.example.com');
+    });
+
+    it('calls reloadCorsOrigins exactly once with no arguments', () => {
+      applyConfigSection('cors', { origins: ['https://a.example.com'] });
+
+      expect(reloadCorsOrigins).toHaveBeenCalledTimes(1);
+      expect(reloadCorsOrigins).toHaveBeenCalledWith();
+    });
+
+    it('does not call reloadCorsMaxAge when only origins are provided', () => {
+      applyConfigSection('cors', { origins: ['https://a.example.com'] });
+
+      expect(reloadCorsMaxAge).not.toHaveBeenCalled();
+    });
+
+    it('does not touch CORS_MAX_AGE when only origins are provided', () => {
+      applyConfigSection('cors', { origins: ['https://a.example.com'] });
+
+      expect(process.env.CORS_MAX_AGE).toBeUndefined();
+    });
+  });
+
+  describe('cors section — maxAge update', () => {
+    it('sets CORS_MAX_AGE as a string from a numeric maxAge', () => {
+      applyConfigSection('cors', { maxAge: 3600 });
+
+      expect(process.env.CORS_MAX_AGE).toBe('3600');
+    });
+
+    it('calls reloadCorsMaxAge exactly once with no arguments', () => {
+      applyConfigSection('cors', { maxAge: 3600 });
+
+      expect(reloadCorsMaxAge).toHaveBeenCalledTimes(1);
+      expect(reloadCorsMaxAge).toHaveBeenCalledWith();
+    });
+
+    it('does not call reloadCorsOrigins when only maxAge is provided', () => {
+      applyConfigSection('cors', { maxAge: 3600 });
+
+      expect(reloadCorsOrigins).not.toHaveBeenCalled();
+    });
+
+    it('does not touch CORS_ALLOWED_ORIGINS when only maxAge is provided', () => {
+      applyConfigSection('cors', { maxAge: 3600 });
+
+      expect(process.env.CORS_ALLOWED_ORIGINS).toBeUndefined();
+    });
+
+    it('treats maxAge of 0 as provided (uses !== undefined, not truthiness)', () => {
+      applyConfigSection('cors', { maxAge: 0 });
+
+      expect(process.env.CORS_MAX_AGE).toBe('0');
+      expect(reloadCorsMaxAge).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cors section — both values provided', () => {
+    it('sets both env vars and calls both reload functions once each', () => {
+      applyConfigSection('cors', {
+        origins: ['https://app.example.com', 'https://admin.example.com'],
+        maxAge: 1800,
+      });
+
+      expect(process.env.CORS_ALLOWED_ORIGINS).toBe('https://app.example.com,https://admin.example.com');
+      expect(process.env.CORS_MAX_AGE).toBe('1800');
+      expect(reloadCorsOrigins).toHaveBeenCalledTimes(1);
+      expect(reloadCorsMaxAge).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cors section — missing values', () => {
+    it('leaves env vars untouched and calls no reload functions for an empty config object', () => {
+      applyConfigSection('cors', {});
+
+      expect(process.env.CORS_ALLOWED_ORIGINS).toBeUndefined();
+      expect(process.env.CORS_MAX_AGE).toBeUndefined();
+      expect(reloadCorsOrigins).not.toHaveBeenCalled();
+      expect(reloadCorsMaxAge).not.toHaveBeenCalled();
+    });
+
+    it('treats an empty origins array as provided (arrays are truthy), matching prior route behavior', () => {
+      applyConfigSection('cors', { origins: [] });
+
+      expect(process.env.CORS_ALLOWED_ORIGINS).toBe('');
+      expect(reloadCorsOrigins).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unknown sections', () => {
+    it.each(['webhook', 'reconciliation', 'kyc', 'retention', 'fraudThresholds'])(
+      'is a no-op for the "%s" section (no env mutation, no reload calls)',
+      (section) => {
+        applyConfigSection(section, { anything: 'goes-here', origins: ['https://should-not-apply.com'] });
+
+        expect(process.env.CORS_ALLOWED_ORIGINS).toBeUndefined();
+        expect(process.env.CORS_MAX_AGE).toBeUndefined();
+        expect(reloadCorsOrigins).not.toHaveBeenCalled();
+        expect(reloadCorsMaxAge).not.toHaveBeenCalled();
+      },
+    );
+
+    it('is a no-op for a completely unrecognized section name', () => {
+      expect(() => applyConfigSection('doesNotExist', { origins: ['https://x.com'], maxAge: 60 })).not.toThrow();
+
+      expect(process.env.CORS_ALLOWED_ORIGINS).toBeUndefined();
+      expect(process.env.CORS_MAX_AGE).toBeUndefined();
+      expect(reloadCorsOrigins).not.toHaveBeenCalled();
+      expect(reloadCorsMaxAge).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extracted runtime configuration application logic from `adminConfig` route handlers into a dedicated config service layer.

This keeps route handlers focused on HTTP handling while moving business logic into a reusable, testable service.

## Changes Made

- Added `src/services/configService.js`
  - Introduced `applyConfigSection()` service function
  - Moved CORS runtime configuration update logic from route handler into service layer
  - Preserved existing behavior for supported and unsupported config sections

- Updated `src/routes/adminConfig.js`
  - Replaced inline config mutation logic with service call
  - Kept request validation, response handling, and logging unchanged

- Added `src/services/configService.test.js`
  - Added unit tests for:
    - CORS origins updates
    - CORS maxAge updates
    - Combined updates
    - No-op scenarios
    - Unsupported sections

- Removed duplicate `idempotencyMiddleware` import causing a syntax error in `adminConfig.js`

## Testing

Tests added and verified:

- Config service unit tests passing
- Existing admin config behavior preserved

## Notes

This is a behavior-preserving refactor. No API responses or existing functionality were changed.