### PR TITLE
feat: Add rate limiting to persistence endpoints and structured metrics/logging to indexer endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,6 +4529,16 @@
         }
       }
     },
+    "node_modules/@reown/appkit-siwx/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@reown/appkit-ui": {
       "version": "1.7.17",
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.17.tgz",
@@ -6633,6 +6643,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1112,16 +1112,35 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
   registers: [registry],
 });
 
-/**
- * Bounded enum of allowed `status_class` label values.
- * @readonly
- */
+// ── Persistence endpoint metrics (issue #774) ──────────────────────────────
 
 /**
- * Bounded enum of allowed `cause` label values for persistence errors.
+ * Bounded enum of allowed `endpoint` label values for persistence metrics.
+ * @readonly
+ */
+const PERSISTENCE_ENDPOINT_ENUM = Object.freeze([
+  'sme_invoice_upload',
+  'sme_invoice_presigned_url',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `status_class` label values for persistence metrics.
+ * @readonly
+ */
+const PERSISTENCE_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
+
+/**
+ * Bounded enum of allowed `cause` label values for persistence error metrics.
  * Raw error messages are NEVER used as labels.
  * @readonly
  */
+const PERSISTENCE_CAUSE_ENUM = Object.freeze([
+  'validation',
+  'storage',
+  'internal',
+  'none',
+]);
 
 /**
  * Maps a raw persistence endpoint hint to a bounded metric label value.
@@ -1129,6 +1148,10 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} raw - Raw endpoint identifier.
  * @returns {string} Bounded value from {@link PERSISTENCE_ENDPOINT_ENUM}.
  */
+function normalizePersistenceEndpoint(raw) {
+  const str = typeof raw === 'string' ? raw.trim() : '';
+  return PERSISTENCE_ENDPOINT_ENUM.includes(str) ? str : 'unknown';
+}
 
 /**
  * Maps an HTTP status code to a bounded `status_class` label value.
@@ -1136,6 +1159,12 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} status - HTTP status code.
  * @returns {string} Bounded value from {'2xx'|'4xx'|'5xx'}.
  */
+function normalizePersistenceStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
 
 /**
  * Maps a raw persistence failure to a bounded `cause` label value.
@@ -1149,21 +1178,159 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {number} [status] - HTTP status code, used to disambiguate.
  * @returns {string} Bounded value from {'validation'|'storage'|'internal'|'none'}.
  */
+function normalizePersistenceCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+
+  if (code >= 400 && code < 500) {
+    // Recognize storage-service validation error codes
+    if (err && typeof err === 'object' && 'code' in err) {
+      const errCode = String(err.code);
+      if (errCode === 'INVALID_MIME_TYPE' || errCode === 'FILE_TOO_LARGE' || errCode === 'INVALID_TENANT_ID') {
+        return 'validation';
+      }
+    }
+    return 'validation';
+  }
+
+  if (err && typeof err === 'object' && 'code' in err) {
+    const errCode = String(err.code);
+    // Recognize storage-layer error codes
+    if (
+      errCode === 'STORAGE_WRITE_FAILED' ||
+      errCode === 'ENOENT' ||
+      errCode === 'EACCES' ||
+      errCode.startsWith('ERR_')
+    ) {
+      return 'storage';
+    }
+  }
+
+  return 'internal';
+}
 
 /**
  * Histogram: Wall-clock duration of persistence-endpoint requests in seconds.
  * @type {import('prom-client').Histogram}
  */
+const persistenceRequestDurationSeconds = new client.Histogram({
+  name: 'persistence_request_duration_seconds',
+  help: 'Duration of persistence endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [registry],
+});
 
 /**
  * Counter: Total persistence-endpoint requests.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestsTotal = new client.Counter({
+  name: 'persistence_requests_total',
+  help: 'Total number of persistence endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
 
 /**
  * Counter: Persistence-endpoint request errors by cause.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestErrorsTotal = new client.Counter({
+  name: 'persistence_request_errors_total',
+  help: 'Total number of persistence endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
+
+// ── Indexer endpoint metrics (issue #761) ──────────────────────────────────
+
+/**
+ * Bounded enum of allowed `status_class` label values for indexer metrics.
+ * @readonly
+ */
+const INDEXER_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
+
+/**
+ * Bounded enum of allowed `cause` label values for indexer error metrics.
+ * Raw error messages are NEVER used as labels.
+ * @readonly
+ */
+const INDEXER_CAUSE_ENUM = Object.freeze([
+  'validation',
+  'authorization',
+  'internal',
+  'none',
+]);
+
+/**
+ * Maps an HTTP status code to a bounded `status_class` label value.
+ *
+ * @param {unknown} status - HTTP status code.
+ * @returns {string} Bounded value from {'2xx'|'4xx'|'5xx'}.
+ */
+function normalizeIndexerStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
+
+/**
+ * Maps a raw indexer failure to a bounded `cause` label value.
+ *
+ * A 2xx outcome maps to `none`. 4xx responses are treated as validation errors
+ * unless they're 401/403 which indicate authorization failures. 5xx errors
+ * are treated as internal errors.
+ *
+ * @param {unknown} err - Raw error object or code (null/undefined for success).
+ * @param {number} [status] - HTTP status code, used to disambiguate.
+ * @returns {string} Bounded value from {'validation'|'authorization'|'internal'|'none'}.
+ */
+function normalizeIndexerCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+
+  if (code === 401 || code === 403) { return 'authorization'; }
+  if (code >= 400 && code < 500) { return 'validation'; }
+
+  return 'internal';
+}
+
+/**
+ * Histogram: Wall-clock duration of indexer endpoint requests in seconds.
+ * @type {import('prom-client').Histogram}
+ */
+const indexerRequestDurationSeconds = new client.Histogram({
+  name: 'indexer_request_duration_seconds',
+  help: 'Duration of indexer endpoint requests in seconds',
+  labelNames: ['status_class'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [registry],
+});
+
+/**
+ * Counter: Total indexer endpoint requests.
+ * @type {import('prom-client').Counter}
+ */
+const indexerRequestsTotal = new client.Counter({
+  name: 'indexer_requests_total',
+  help: 'Total number of indexer endpoint requests',
+  labelNames: ['status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: Indexer endpoint request errors by cause.
+ * @type {import('prom-client').Counter}
+ */
+const indexerRequestErrorsTotal = new client.Counter({
+  name: 'indexer_request_errors_total',
+  help: 'Total number of indexer endpoint request errors by cause',
+  labelNames: ['cause'],
+  registers: [registry],
+});
+
 
 /**
  * Bounded enum of allowed `status_class` label values for metrics endpoint.
@@ -1525,11 +1692,19 @@ module.exports = {
   persistenceRequestDurationSeconds,
   persistenceRequestsTotal,
   persistenceRequestErrorsTotal,
+  PERSISTENCE_ENDPOINT_ENUM,
   PERSISTENCE_STATUS_CLASS_ENUM,
   PERSISTENCE_CAUSE_ENUM,
   normalizePersistenceEndpoint,
   normalizePersistenceStatusClass,
   normalizePersistenceCause,
+  indexerRequestDurationSeconds,
+  indexerRequestsTotal,
+  indexerRequestErrorsTotal,
+  INDEXER_STATUS_CLASS_ENUM,
+  INDEXER_CAUSE_ENUM,
+  normalizeIndexerStatusClass,
+  normalizeIndexerCause,
   sorobanCircuitBreakerStateTransitionsTotal,
   kycWebhookRequestDurationSeconds,
   kycWebhookRequestsTotal,

--- a/src/middleware/indexerMetrics.js
+++ b/src/middleware/indexerMetrics.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * @fileoverview Instrumentation wrapper for the indexer endpoint.
+ *
+ * Wraps the async Express handler for GET /api/admin/indexer/events so that
+ * every request records:
+ *   - request duration (histogram, labelled by status class)
+ *   - a request count (counter, labelled by status class)
+ *   - an error count on failure (counter, labelled by bounded cause)
+ *   - a single structured log line (no PII: outcome only)
+ *
+ * Labels are bounded to keep Prometheus time-series cardinality fixed.
+ *
+ * @module middleware/indexerMetrics
+ */
+
+const {
+  indexerRequestDurationSeconds,
+  indexerRequestsTotal,
+  indexerRequestErrorsTotal,
+  normalizeIndexerStatusClass,
+  normalizeIndexerCause,
+} = require('../metrics');
+const logger = require('../logger');
+
+/**
+ * Records metrics and a structured log for one completed indexer request.
+ *
+ * Kept separate from {@link instrumentIndexer} so it can be unit-tested in
+ * isolation against each status class without driving a full HTTP request.
+ *
+ * @param {object} params
+ * @param {number} params.statusCode - Final HTTP status code.
+ * @param {number} params.durationSeconds - Wall-clock duration in seconds.
+ * @param {unknown} [params.error] - Error thrown by the handler, if any.
+ * @param {import('express').Request} [params.req] - Request, for a scoped logger.
+ * @returns {void}
+ */
+function recordIndexerOutcome({ statusCode, durationSeconds, error, req }) {
+  const statusClass = normalizeIndexerStatusClass(statusCode);
+
+  indexerRequestDurationSeconds.labels(statusClass).observe(durationSeconds);
+  indexerRequestsTotal.labels(statusClass).inc();
+
+  const cause = normalizeIndexerCause(error, statusCode);
+  if (cause !== 'none') {
+    indexerRequestErrorsTotal.labels(cause).inc();
+  }
+
+  // Structured log – safe fields only. Never log file contents, raw error messages,
+  // or other data that could contain PII.
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'indexer request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'indexer request rejected');
+  } else {
+    log.info(fields, 'indexer request completed');
+  }
+}
+
+/**
+ * Wraps the async indexer handler with metrics + structured logging.
+ *
+ * The wrapped handler runs normally. Duration is measured from entry to the
+ * moment the response finishes (`res.on('finish')`), so the recorded status
+ * code is the one actually sent. If the handler throws, the error is recorded
+ * and re-thrown to the next error middleware.
+ *
+ * @param {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>} handler
+ * @returns {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>}
+ */
+function instrumentIndexer(handler) {
+  return async function instrumentedIndexerHandler(req, res, next) {
+    const startNs = process.hrtime.bigint();
+    let recorded = false;
+
+    // Single source of truth: record on response finish, when the final status
+    // code is known. A thrown handler stashes its error on res.locals so the
+    // finish listener can classify the cause consistently with that status.
+    res.on('finish', () => {
+      if (recorded) { return; }
+      recorded = true;
+      const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+      recordIndexerOutcome({
+        statusCode: res.statusCode,
+        durationSeconds,
+        error: res.locals && res.locals._error,
+        req,
+      });
+    });
+
+    try {
+      await handler(req, res, next);
+    } catch (err) {
+      // Stash the error so the finish listener can classify it
+      res.locals = res.locals || {};
+      res.locals._error = err;
+      next(err);
+    }
+  };
+}
+
+module.exports = {
+  recordIndexerOutcome,
+  instrumentIndexer,
+};

--- a/src/middleware/persistenceRateLimit.js
+++ b/src/middleware/persistenceRateLimit.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * @fileoverview Per-client rate limiting for persistence endpoints.
+ *
+ * Implements configurable rate limiting for persistence routes (SME invoice
+ * uploads) to prevent abuse and accidental overload. Limits are applied
+ * per-client using API key or IP address as the client identifier.
+ *
+ * Returns 429 Too Many Requests with a Retry-After header when limits
+ * are exceeded. Configuration is driven by environment variables.
+ *
+ * @module middleware/persistenceRateLimit
+ */
+
+const rateLimit = require('express-rate-limit');
+const RedisStore = require('rate-limit-redis');
+const logger = require('../logger');
+
+/**
+ * Creates a rate limiter for persistence endpoints.
+ *
+ * Configuration:
+ * - PERSISTENCE_RATE_LIMIT_WINDOW_MS: Time window in milliseconds (default: 60000 = 1 minute)
+ * - PERSISTENCE_RATE_LIMIT_MAX_REQUESTS: Max requests per window per client (default: 10)
+ * - REDIS_URL: Optional Redis connection URL for distributed rate limiting
+ *
+ * Key derivation:
+ * 1. If API key is present in request, use API key
+ * 2. Otherwise, use client IP address
+ *
+ * @param {object} [redisClient] - Optional Redis client for distributed limiting.
+ * @returns {import('express').RequestHandler} Express rate limiter middleware.
+ */
+function createPersistenceRateLimiter(redisClient) {
+  const windowMs = parseInt(process.env.PERSISTENCE_RATE_LIMIT_WINDOW_MS, 10) || 60000; // 1 minute default
+  const maxRequests = parseInt(process.env.PERSISTENCE_RATE_LIMIT_MAX_REQUESTS, 10) || 10; // 10 requests default
+
+  const limiterConfig = {
+    windowMs,
+    max: maxRequests,
+    // Use API key if available, otherwise use IP
+    keyGenerator: (req, res) => {
+      // API key takes precedence for rate limit key generation
+      if (req.apiKey) {
+        return `persistence:apikey:${req.apiKey}`;
+      }
+      // Fall back to IP address
+      const clientIp = req.ip || req.socket.remoteAddress || 'unknown';
+      return `persistence:ip:${clientIp}`;
+    },
+    // Custom handler for rate limit exceeded
+    handler: (req, res) => {
+      const retryAfter = req.rateLimit.resetTime
+        ? Math.ceil((req.rateLimit.resetTime - Date.now()) / 1000)
+        : Math.ceil(windowMs / 1000);
+
+      res.set('Retry-After', String(retryAfter));
+      res.status(429).json({
+        error: 'Too Many Requests',
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: `Rate limit exceeded. Maximum ${maxRequests} requests per ${windowMs / 1000} seconds.`,
+        retryAfter,
+      });
+    },
+    // Skip successful rate limit checks
+    skip: (req, res) => false,
+    // Log rate limit events for monitoring
+    onLimitReached: (req, res, options) => {
+      const clientId = options.keyGenerator(req, res);
+      logger.warn(
+        { clientId, windowMs, maxRequests },
+        'Persistence endpoint rate limit reached',
+      );
+    },
+  };
+
+  // Use Redis store if available for distributed rate limiting
+  if (redisClient) {
+    limiterConfig.store = new RedisStore({
+      client: redisClient,
+      prefix: 'persistence-ratelimit:',
+      expiry: Math.ceil(windowMs / 1000),
+    });
+  }
+
+  return rateLimit(limiterConfig);
+}
+
+module.exports = {
+  createPersistenceRateLimiter,
+};

--- a/src/routes/adminIndexer.js
+++ b/src/routes/adminIndexer.js
@@ -21,6 +21,7 @@ const { CursorError } = require('../utils/cursorPagination');
 const { adminStack } = require('../middleware/stacks');
 const responseHelper = require('../utils/responseHelper');
 const logger = require('../logger');
+const { instrumentIndexer } = require('../middleware/indexerMetrics');
 
 /**
  * Maximum page size clamped by the service layer.
@@ -250,7 +251,7 @@ function _parseQuery(query) {
  *       403:
  *         $ref: '#/components/responses/Problem403'
  */
-router.get('/events', async (req, res, next) => {
+router.get('/events', instrumentIndexer(async (req, res, next) => {
   try {
     // ── 1. Parse and validate query parameters ──────────────────────────────
     const { isValid, fieldErrors, params } = _parseQuery(req.query);

--- a/src/routes/sme/index.js
+++ b/src/routes/sme/index.js
@@ -14,6 +14,7 @@ const { extractTenant } = require('../../middleware/tenant');
 const idempotencyMiddleware = require('../../middleware/idempotency');
 const logger = require('../../logger');
 const { instrumentPersistence } = require('../../middleware/persistenceMetrics');
+const { createPersistenceRateLimiter } = require('../../middleware/persistenceRateLimit');
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -22,10 +23,13 @@ const upload = multer({
   },
 });
 
+// Initialize persistence rate limiter
+const persistenceRateLimiter = createPersistenceRateLimiter();
+
 router.use('/', metricsRoutes);
 
 // POST /api/sme/invoice/presigned-url - Request a presigned upload URL
-router.post('/invoice/presigned-url', express.json(), extractTenant, idempotencyMiddleware, instrumentPersistence('sme_invoice_presigned_url', async (req, res) => {
+router.post('/invoice/presigned-url', persistenceRateLimiter, express.json(), extractTenant, idempotencyMiddleware, instrumentPersistence('sme_invoice_presigned_url', async (req, res) => {
   const requestLogger = logger.createRequestLogger(req);
   try {
     const { fileName, mimeType, fileSize } = req.body;
@@ -63,7 +67,7 @@ router.post('/invoice/presigned-url', express.json(), extractTenant, idempotency
 }));
 
 // POST /api/sme/invoice - Upload PDF invoice
-router.post('/invoice', upload.single('invoice'), extractTenant, instrumentPersistence('sme_invoice_upload', async (req, res) => {
+router.post('/invoice', persistenceRateLimiter, upload.single('invoice'), extractTenant, instrumentPersistence('sme_invoice_upload', async (req, res) => {
   const requestLogger = logger.createRequestLogger(req);
   try {
     if (!req.file) {

--- a/tests/indexerMetrics.test.js
+++ b/tests/indexerMetrics.test.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const {
+  instrumentIndexer,
+  recordIndexerOutcome,
+} = require('../src/middleware/indexerMetrics');
+const metrics = require('../src/metrics');
+
+/** Reads a single counter value for a label set (real prom-client, async get). */
+async function counterValue(counter, labels) {
+  const metric = await counter.get();
+  const keys = Object.keys(labels);
+  const match = (metric.values || []).find((v) =>
+    keys.every((k) => String(v.labels[k]) === String(labels[k])),
+  );
+  return match ? match.value : 0;
+}
+
+describe('indexer metrics instrumentation', () => {
+  beforeEach(() => {
+    metrics.indexerRequestDurationSeconds.reset();
+    metrics.indexerRequestsTotal.reset();
+    metrics.indexerRequestErrorsTotal.reset();
+  });
+
+  describe('normalizeIndexerStatusClass', () => {
+    it('maps 2xx, 4xx, 5xx correctly', () => {
+      expect(metrics.normalizeIndexerStatusClass(200)).toBe('2xx');
+      expect(metrics.normalizeIndexerStatusClass(201)).toBe('2xx');
+      expect(metrics.normalizeIndexerStatusClass(400)).toBe('4xx');
+      expect(metrics.normalizeIndexerStatusClass(401)).toBe('4xx');
+      expect(metrics.normalizeIndexerStatusClass(403)).toBe('4xx');
+      expect(metrics.normalizeIndexerStatusClass(503)).toBe('5xx');
+      expect(metrics.normalizeIndexerStatusClass('200')).toBe('2xx');
+    });
+  });
+
+  describe('normalizeIndexerCause', () => {
+    it('returns none for success', () => {
+      expect(metrics.normalizeIndexerCause(null, 200)).toBe('none');
+    });
+
+    it('returns authorization for 401/403', () => {
+      expect(metrics.normalizeIndexerCause(null, 401)).toBe('authorization');
+      expect(metrics.normalizeIndexerCause(null, 403)).toBe('authorization');
+    });
+
+    it('returns validation for other 4xx errors', () => {
+      expect(metrics.normalizeIndexerCause(null, 400)).toBe('validation');
+      expect(metrics.normalizeIndexerCause(null, 422)).toBe('validation');
+      expect(metrics.normalizeIndexerCause(new Error('bad input'), 400)).toBe('validation');
+    });
+
+    it('returns internal for 5xx errors', () => {
+      expect(metrics.normalizeIndexerCause(new Error('boom'), 500)).toBe('internal');
+      expect(metrics.normalizeIndexerCause(null, 500)).toBe('internal');
+      expect(metrics.normalizeIndexerCause({}, 503)).toBe('internal');
+    });
+  });
+
+  describe('recordIndexerOutcome', () => {
+    it('records duration + request count and no error on success', async () => {
+      recordIndexerOutcome({
+        statusCode: 200,
+        durationSeconds: 0.05,
+      });
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '2xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'none' })).toBe(0);
+    });
+
+    it('records a validation error on a 4xx', async () => {
+      recordIndexerOutcome({
+        statusCode: 400,
+        durationSeconds: 0.01,
+        error: new Error('invalid query'),
+      });
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '4xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'validation' })).toBe(1);
+    });
+
+    it('records an authorization error on 401/403', async () => {
+      recordIndexerOutcome({
+        statusCode: 401,
+        durationSeconds: 0.01,
+        error: new Error('unauthorized'),
+      });
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '4xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'authorization' })).toBe(1);
+    });
+
+    it('records an internal error on a 5xx', async () => {
+      recordIndexerOutcome({
+        statusCode: 500,
+        durationSeconds: 0.1,
+        error: new Error('database error'),
+      });
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '5xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'internal' })).toBe(1);
+    });
+  });
+
+  describe('instrumentIndexer', () => {
+    let app;
+
+    beforeEach(() => {
+      app = express();
+    });
+
+    it('wraps handler and records metrics on success', async () => {
+      app.get('/test', instrumentIndexer(async (req, res) => {
+        res.json({ data: 'test' });
+      }));
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(200);
+
+      // Give time for the finish event
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '2xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'none' })).toBe(0);
+    });
+
+    it('wraps handler and records metrics on 4xx error', async () => {
+      app.get('/test', instrumentIndexer(async (req, res) => {
+        res.status(400).json({ error: 'bad request' });
+      }));
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '4xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'validation' })).toBe(1);
+    });
+
+    it('wraps handler and records metrics on 5xx error', async () => {
+      app.get('/test', instrumentIndexer(async (req, res, next) => {
+        next(new Error('internal server error'));
+      }));
+
+      // Add error middleware to handle the thrown error
+      app.use((err, req, res, next) => {
+        res.status(500).json({ error: err.message });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(await counterValue(metrics.indexerRequestsTotal, { status_class: '5xx' })).toBe(1);
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'internal' })).toBe(1);
+    });
+
+    it('records request duration with reasonable precision', async () => {
+      app.get('/test', instrumentIndexer(async (req, res) => {
+        // Simulate some work
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        res.json({ success: true });
+      }));
+
+      await request(app).get('/test');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const metric = await metrics.indexerRequestDurationSeconds.get();
+      const values = metric.values || [];
+      const hasValue = values.some((v) => v.value > 0 && v.value < 1);
+      expect(hasValue).toBe(true);
+    });
+
+    it('handles both authorization and validation 4xx errors correctly', async () => {
+      const app1 = express();
+      app1.get('/test', instrumentIndexer(async (req, res) => {
+        res.status(401).json({ error: 'unauthorized' });
+      }));
+
+      await request(app1).get('/test');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'authorization' })).toBe(1);
+
+      metrics.indexerRequestErrorsTotal.reset();
+
+      const app2 = express();
+      app2.get('/test', instrumentIndexer(async (req, res) => {
+        res.status(400).json({ error: 'bad request' });
+      }));
+
+      await request(app2).get('/test');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(await counterValue(metrics.indexerRequestErrorsTotal, { cause: 'validation' })).toBe(1);
+    });
+  });
+});

--- a/tests/persistenceRateLimit.test.js
+++ b/tests/persistenceRateLimit.test.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const { createPersistenceRateLimiter } = require('../src/middleware/persistenceRateLimit');
+
+describe('Persistence Rate Limiter Middleware', () => {
+  let app;
+  let limiter;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Create a limiter with tight limits for testing
+    process.env.PERSISTENCE_RATE_LIMIT_WINDOW_MS = '1000'; // 1 second
+    process.env.PERSISTENCE_RATE_LIMIT_MAX_REQUESTS = '3'; // 3 requests max
+
+    limiter = createPersistenceRateLimiter();
+
+    app.post('/test', limiter, (req, res) => {
+      res.json({ success: true });
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.PERSISTENCE_RATE_LIMIT_WINDOW_MS;
+    delete process.env.PERSISTENCE_RATE_LIMIT_MAX_REQUESTS;
+  });
+
+  it('should allow requests within the limit', async () => {
+    const res1 = await request(app).post('/test');
+    expect(res1.status).toBe(200);
+
+    const res2 = await request(app).post('/test');
+    expect(res2.status).toBe(200);
+
+    const res3 = await request(app).post('/test');
+    expect(res3.status).toBe(200);
+  });
+
+  it('should reject requests exceeding the limit with 429', async () => {
+    // Make max requests
+    await request(app).post('/test');
+    await request(app).post('/test');
+    await request(app).post('/test');
+
+    // Next request should be rate limited
+    const res = await request(app).post('/test');
+    expect(res.status).toBe(429);
+  });
+
+  it('should include Retry-After header on rate limit exceeded', async () => {
+    await request(app).post('/test');
+    await request(app).post('/test');
+    await request(app).post('/test');
+
+    const res = await request(app).post('/test');
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBeDefined();
+    expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
+  });
+
+  it('should return proper error response on rate limit', async () => {
+    await request(app).post('/test');
+    await request(app).post('/test');
+    await request(app).post('/test');
+
+    const res = await request(app).post('/test');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('Too Many Requests');
+    expect(res.body.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(res.body.retryAfter).toBeDefined();
+  });
+
+  it('should use API key for rate limit key when available', async () => {
+    // Override the limiter with a custom app that includes API key
+    const app2 = express();
+    app2.use(express.json());
+
+    app2.post('/test', (req, res, next) => {
+      // Simulate API key middleware
+      req.apiKey = 'test-api-key-123';
+      next();
+    }, limiter, (req, res) => {
+      res.json({ success: true });
+    });
+
+    // Make requests with same API key
+    const res1 = await request(app2).post('/test');
+    expect(res1.status).toBe(200);
+
+    const res2 = await request(app2).post('/test');
+    expect(res2.status).toBe(200);
+
+    const res3 = await request(app2).post('/test');
+    expect(res3.status).toBe(200);
+
+    // Should be rate limited now
+    const res4 = await request(app2).post('/test');
+    expect(res4.status).toBe(429);
+  });
+
+  it('should use IP address for rate limit key when API key is not available', async () => {
+    // Make requests with same IP
+    const res1 = await request(app).post('/test').set('X-Forwarded-For', '192.168.1.1');
+    expect(res1.status).toBe(200);
+
+    const res2 = await request(app).post('/test').set('X-Forwarded-For', '192.168.1.1');
+    expect(res2.status).toBe(200);
+
+    const res3 = await request(app).post('/test').set('X-Forwarded-For', '192.168.1.1');
+    expect(res3.status).toBe(200);
+
+    // Should be rate limited now
+    const res4 = await request(app).post('/test').set('X-Forwarded-For', '192.168.1.1');
+    expect(res4.status).toBe(429);
+  });
+
+  it('should use default configuration when env vars are not set', () => {
+    delete process.env.PERSISTENCE_RATE_LIMIT_WINDOW_MS;
+    delete process.env.PERSISTENCE_RATE_LIMIT_MAX_REQUESTS;
+
+    const limiter2 = createPersistenceRateLimiter();
+    expect(limiter2).toBeDefined();
+
+    // Default should be 60000ms window and 10 requests
+    // (Can't easily verify without triggering actual limits)
+  });
+
+  it('should reset after the configured window expires', (done) => {
+    process.env.PERSISTENCE_RATE_LIMIT_WINDOW_MS = '500'; // 500ms window for faster testing
+    const fastLimiter = createPersistenceRateLimiter();
+
+    const app2 = express();
+    app2.use(express.json());
+    app2.post('/test', fastLimiter, (req, res) => {
+      res.json({ success: true });
+    });
+
+    // Make max requests
+    request(app2).post('/test').end(() => {
+      request(app2).post('/test').end(() => {
+        request(app2).post('/test').end(() => {
+          // Should be rate limited
+          request(app2).post('/test').end((err, res) => {
+            expect(res.status).toBe(429);
+
+            // Wait for window to expire
+            setTimeout(() => {
+              // After window expires, request should succeed again
+              request(app2).post('/test').end((err, res2) => {
+                expect(res2.status).toBe(200);
+                done();
+              });
+            }, 600);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This pull request addresses two critical feature requests for enhanced API reliability and observability:

### Issue #774: Add rate limiting to persistence endpoints
- Implements per-client (API key / IP) rate limiting for persistence endpoints
- Applies configurable rate limits with 429 Too Many Requests responses
- Returns Retry-After header for better client behavior
- Configuration via `PERSISTENCE_RATE_LIMIT_WINDOW_MS` and `PERSISTENCE_RATE_LIMIT_MAX_REQUESTS` env vars
- Includes comprehensive tests for rate limiting middleware
- Supports optional Redis backend for distributed rate limiting

### Issue #761: Add structured metrics and logging to indexer endpoint
- Adds comprehensive metrics instrumentation to the indexer endpoint (GET /api/admin/indexer/events)
- Tracks request duration, HTTP status code, and error causes
- Emits structured logs with no PII (status and timing information only)
- Metrics exposed on existing /metrics endpoint with proper Prometheus labels
- Includes comprehensive tests for metrics middleware

### Changes

#### Rate Limiting (#774)
- New middleware: `src/middleware/persistenceRateLimit.js`
- Applied to: POST /api/sme/invoice and POST /api/sme/invoice/presigned-url
- Test file: `tests/persistenceRateLimit.test.js`

#### Indexer Metrics (#761)
- New middleware: `src/middleware/indexerMetrics.js`
- Applied to: GET /api/admin/indexer/events
- Prometheus metrics: indexer_request_duration_seconds, indexer_requests_total, indexer_request_errors_total
- Test file: `tests/indexerMetrics.test.js`

#### Metrics Registry Updates
- Added persistence metrics (duration, requests total, errors total)
- Added indexer metrics (duration, requests total, errors total)
- Added metric normalization functions for status classes and error causes

closes #774
closes #761