### PR TITLE
Docs/config 21 flow

### DIFF
--- a/docs/config-flow.md
+++ b/docs/config-flow.md
@@ -1,0 +1,237 @@
+# Config Request Lifecycle
+
+> **Scope:** `Liquifact/Liquifact-backend`
+> **Last updated:** 2026-07-25
+> **Cross-reference:** `src/routes/adminConfig.js` · `src/schemas/config.js` · `src/middleware/stacks.js` · `src/middleware/rateLimit.js` · `src/middleware/idempotency.js`
+
+## Overview
+
+The admin config surface exposes two HTTP endpoints — a write endpoint for updating runtime configuration sections and a read endpoint for listing valid section names. Both are admin-only, rate-limited, and tenant-scoped. The write path validates the request body against a section-specific Zod schema, applies an idempotency guard when the client supplies an `Idempotency-Key` header, performs side effects for CORS configuration, and logs the change — but does **not** persist the config to a database (configuration is ephemeral and held in process memory).
+
+---
+
+## Flow diagram
+
+```mermaid
+flowchart LR
+  subgraph POST
+    A[POST /api/admin/config\nbody: { section, config }]
+    --> B[adminConfigLimiter\nsrc/middleware/rateLimit.js]
+    --> C[adminStack\nsrc/middleware/stacks.js]
+    --> D[idempotencyMiddleware\nsrc/middleware/idempotency.js]
+    --> E[validateBody runtimeConfigSchema\nsrc/schemas/config.js]
+    --> F[Handler: apply side effects\nsrc/routes/adminConfig.js]
+    --> G[200 response\nsrc/routes/adminConfig.js]
+  end
+
+  subgraph GET
+    H[GET /api/admin/config/sections]
+    --> I[adminConfigLimiter\nsrc/middleware/rateLimit.js]
+    --> J[adminStack\nsrc/middleware/stacks.js]
+    --> K[Return CONFIG_SECTIONS\nsrc/routes/adminConfig.js]
+  end
+```
+
+---
+
+## POST /api/admin/config
+
+### Stage 1 — Rate limiting
+
+**File:** `src/middleware/rateLimit.js:297` — `adminConfigLimiter`
+
+Mounted **before** the admin auth stack (`router.use(adminConfigLimiter)` at `src/routes/adminConfig.js:48`). This ordering means failed authentication attempts still consume the per-client rate-limit budget, defending against auth-flooding attacks.
+
+The limiter is a `express-rate-limit` instance configured with:
+
+| Parameter | Value |
+|-----------|-------|
+| `windowMs` | `CONFIG_RATE_LIMIT_WINDOW_MS` (env `RATE_LIMIT_CONFIG_WINDOW_MS`, default 60 s) |
+| `limit` | `CONFIG_RATE_LIMIT_MAX` (env `RATE_LIMIT_CONFIG_MAX`, default 20) |
+| `keyGenerator` | `adminConfigKeyGenerator` — uses `X-API-Key` header if present (prefix `apikey_`), otherwise falls back to `req.ip`. |
+| `store` | `resolveRateLimitStore('config')` — Redis-backed in production, in-memory fallback in development/test. |
+| `handler` | `adminConfigHandler` — returns a structured `RATE_LIMITED` JSON body with `Retry-After` header. |
+
+**Error path:** When the budget is exhausted, the handler returns `429` with:
+```json
+{
+  "type": "https://liquifact.com/probs/too-many-requests",
+  "title": "Too Many Requests",
+  "status": 429,
+  "code": "RATE_LIMITED",
+  "retryable": true,
+  "retry_hint": "Wait for the rate-limit window to reset before retrying.",
+  "scope": "config",
+  "error": "Too many requests.",
+  "message": "Rate limit threshold breached for /api/admin/config. Please try again later."
+}
+```
+
+### Stage 2 — Auth and tenant extraction
+
+**File:** `src/middleware/stacks.js:63` — `adminStack`
+
+Applied via `router.use(...adminStack)` at `src/routes/adminConfig.js:51`.
+
+The stack executes:
+
+1. **`adminAuth`** (`src/middleware/stacks.js:32`):
+   - If `x-api-key` header is present: delegates to `authenticateApiKey()` (`src/middleware/apiKeyAuth.js:91`) with **no** `requiredScope` — any valid, non-revoked key is accepted. Attaches `req.apiClient`.
+   - Otherwise: delegates to `authenticateToken` (`src/middleware/auth.js:57`). Validates `Authorization: Bearer <JWT>` with algorithm allowlist (default `HS256`), optional issuer/audience checks. Attaches `req.user`.
+
+2. **`extractTenant`** (`src/middleware/tenant.js:54`):
+   - Resolves `req.tenantId` from `x-tenant-id` header (highest priority) or `req.user.tenantId` (JWT claim). Returns `400` if neither source yields a value.
+
+**Error paths:**
+- JWT missing/invalid/expired: `authenticateToken` calls `next(new AppError(...))` which is caught by `handleInternalError` in `src/app.js:96`, returning 401.
+- API key missing/invalid/revoked: `authenticateApiKey` responds directly with 401 JSON (bypasses the centralized error handler).
+- Tenant resolution failure: `extractTenant` responds with `400` `{ error: 'Missing tenant context.' }`.
+
+### Stage 3 — Idempotency
+
+**File:** `src/middleware/idempotency.js` — `idempotencyMiddleware`
+
+The route mounts `idempotencyMiddleware` directly at `src/routes/adminConfig.js:194`. Note there is also a redundant second import and an unused `optionalIdempotency` wrapper at line 62 (see [Known issues](#known-issues)).
+
+The middleware checks for an `Idempotency-Key` header. When present, it validates the key against the pattern `^[A-Za-z0-9._:-]{8,128}$` and looks it up in the `idempotency_keys` database table:
+
+- **First request:** Stores the request fingerprint (SHA-256 of the body) with status `IN_PROGRESS`, then allows the handler to execute. After the handler responds, the response status and body are cached.
+- **Retry with same key and body:** Returns the cached response directly (status `COMPLETED`).
+- **Retry with same key and different body:** Returns `409 Conflict`.
+- **No header:** The request passes through without idempotency checks.
+
+**Error paths:**
+- Invalid key format: Returns `400` with a structured error.
+- Storage failure: Logs a warning, increments `idempotencyStorageFailureTotal` metric, but still allows the request to proceed.
+- TTL expiry: Keys and cached responses expire after `IDEMPOTENCY_TTL_HOURS` (default 24 hours).
+
+### Stage 4 — Body validation
+
+**File:** `src/schemas/config.js:361` — `runtimeConfigSchema` validated via `validateBody()` from `src/schemas/invoice.js:329`
+
+`validateBody` is a generic Express middleware factory. It calls `schema.safeParse(req.body)`, and on success attaches the parsed/coerced result to `req.validated`. On failure, it returns `400` with an RFC 7807 `application/problem+json` body containing a `fieldErrors` map.
+
+The `runtimeConfigSchema` is a top-level Zod object with:
+
+```
+{ section: enum, config: record }
+```
+
+It then dispatches to a section-specific schema via `.superRefine()`:
+
+| Section | Schema | Key fields |
+|---------|--------|------------|
+| `webhook` | `webhookConfigSchema` (`src/schemas/config.js:108`) | `url` (HTTPS URL, ≤2048 chars), `secret` (16–256 chars), `events` (array, 1–50 items, each ≤100 chars), `maxRetries` (0–10), `timeoutMs` (500–30000), `enabled` (boolean) |
+| `reconciliation` | `reconciliationConfigSchema` (`src/schemas/config.js:149`) | `batchSize` (1–500), `maxDriftSeconds` (0–3600), `scheduleExpression` (≤100 chars), `enabled` (boolean). Must provide at least one field. |
+| `kyc` | `kycConfigSchema` (`src/schemas/config.js:184`) | `providerUrl` (HTTPS URL, ≤2048 chars), `apiKey` (8–256 chars), `timeoutMs` (500–30000), `retries` (0–5). Both `providerUrl` and `apiKey` required together. |
+| `retention` | `retentionConfigSchema` (`src/schemas/config.js:214`) | `retentionDays` (1–3650), `purgeEnabled` (boolean), `batchSize` (1–1000), `purgeCron` (≤100 chars), `legalHoldReasons` (array, ≤20 items, each ≤100 chars). Must provide at least one field. |
+| `fraudThresholds` | `fraudThresholdsSchema` (`src/schemas/config.js:304`) | `fraudCeiling` (1–1e9), `manualReviewThreshold` (1–1e9). Cross-field: `manualReviewThreshold` ≤ `fraudCeiling`. Must provide at least one field. |
+| `cors` | `corsConfigSchema` (`src/schemas/config.js:259`) | `origins` (array of valid URL origins, 1–20 items, each ≤2048 chars, must be root origin), `maxAge` (60–86400). Must provide at least one field. |
+
+All section schemas use `.strict()` to reject unknown keys, preventing prototype-pollution payloads. String fields are length-bounded and trimmed. Numeric fields are range-checked.
+
+**Error path:** Validation failure returns `400` with:
+```json
+{
+  "type": "https://liquifact.io/problems/validation-error",
+  "title": "Validation Error",
+  "status": 400,
+  "detail": "Request body contains invalid or missing fields.",
+  "fieldErrors": {
+    "config.url": "url must be a valid URL",
+    "config.secret": "secret must be at least 16 characters"
+  }
+}
+```
+Field error paths are prefixed with `config.` (e.g. `config.url` instead of just `url`).
+
+### Stage 5 — Handler (side effects)
+
+**File:** `src/routes/adminConfig.js:194`
+
+The handler receives `req.validated` from the `validateBody` middleware, containing `{ section, config }`.
+
+For most sections, the handler simply logs the update and returns `200` — **no database write occurs**. The config update is acknowledged at the API level but actual runtime behavior changes depend on how the consuming module reads its configuration (e.g., environment variables, feature flags, module-level state).
+
+The **`cors` section** is special — it has immediate side effects:
+
+```js
+if (section === 'cors') {
+  if (validatedConfig.origins) {
+    process.env.CORS_ALLOWED_ORIGINS = validatedConfig.origins.join(',');
+    reloadCorsOrigins();
+  }
+  if (validatedConfig.maxAge !== undefined) {
+    process.env.CORS_MAX_AGE = String(validatedConfig.maxAge);
+    reloadCorsMaxAge();
+  }
+}
+```
+
+`reloadCorsOrigins()` and `reloadCorsMaxAge()` (`src/config/cors.js`) update the in-memory CORS allowlist and max-age used by all subsequent requests. This is the only runtime side effect of the config endpoint.
+
+A structured log line is emitted with `tenantId`, `section`, and `adminClient` (API key client ID or JWT subject).
+
+**Error path:** The handler does not throw. Validation errors are handled by middleware before reaching the handler. There is no database persistence, so there are no store-level error paths.
+
+### Stage 6 — Response
+
+On success, returns `200` with:
+```json
+{
+  "section": "webhook",
+  "config": { "url": "https://hooks.example.com", "secret": "whsec_...", "events": ["invoice.paid"], "enabled": true },
+  "message": "Configuration section 'webhook' validated and accepted."
+}
+```
+
+---
+
+## GET /api/admin/config/sections
+
+### Stages 1–2
+
+Same as POST: `adminConfigLimiter` → `adminStack` (auth + tenant).
+
+### Stage 3 — Response
+
+**File:** `src/routes/adminConfig.js:257`
+
+Returns `200` with the static list of valid section names:
+```json
+{ "sections": ["webhook", "reconciliation", "kyc", "retention", "fraudThresholds", "cors"] }
+```
+
+The list is defined at `src/schemas/config.js:335` (`CONFIG_SECTIONS`). No database access, no side effects.
+
+---
+
+## Edge cases and gotchas
+
+### No database persistence
+
+The POST handler does **not** write configuration to any database table. It validates, logs, applies in-memory CORS changes, and returns. Configuration is ephemeral — a process restart resets all sections except CORS (which is re-read from environment variables at boot). This is a deliberate design choice; the endpoint serves as a validation gate and logging surface.
+
+### CORS reload is a special side effect
+
+Only the `cors` section triggers runtime behavior changes via `reloadCorsOrigins()` and `reloadCorsMaxAge()`. The other five sections are accepted and logged but have no automated side effects — consuming modules must check environment variables or feature flags independently.
+
+### Idempotency middleware ordering
+
+The `idempotencyMiddleware` is mounted **after** auth. This means idempotency checks run on every authenticated request, even those that don't carry an `Idempotency-Key` header (the middleware simply passes through when the header is absent). The route also defines an `optionalIdempotency` wrapper at line 62 that conditionally calls the middleware only when the header is present, but this wrapper is **never used** — the route directly mounts `idempotencyMiddleware` instead.
+
+### Known issue: duplicate import
+
+`src/routes/adminConfig.js` imports `idempotencyMiddleware` twice, at lines 37 and 40. The second declaration shadows the first and **causes a parse error** in current ESLint and Node.js strict mode. This is a pre-existing bug — the file cannot be required without hitting `SyntaxError: Identifier 'idempotencyMiddleware' has already been declared`.
+
+### Rate limiter runs before auth
+
+The `adminConfigLimiter` is mounted before `adminStack`, so failed auth attempts still consume the rate-limit budget. This prevents an attacker from cycling through API keys or tokens without being throttled.
+
+### Key generation for rate limiting
+
+The rate limiter keys on `X-API-Key` when present (prefixed with `apikey_`), falling back to `req.ip`. This means multiple clients sharing the same NAT IP are counted separately when they use distinct API keys, but a malicious actor who cycles API keys from the same IP is still throttled by the IP-based fallback.
+
+### Idempotency TTL
+
+Idempotency keys expire after 24 hours by default (`IDEMPOTENCY_TTL_HOURS`). After expiry, the same key can be reused for a new request. The TTL is configurable via environment variable.

--- a/docs/indexer-flow.md
+++ b/docs/indexer-flow.md
@@ -1,0 +1,252 @@
+# Indexer Request Lifecycle
+
+> **Scope:** `Liquifact/Liquifact-backend`
+> **Last updated:** 2026-07-25
+> **Cross-reference:** `src/jobs/escrowIndexer.js` · `src/routes/adminIndexer.js` · `src/services/indexerService.js` · `src/schemas/indexerEvent.js` · `src/middleware/stacks.js` · `src/utils/cursorPagination.js`
+
+## Overview
+
+The indexer subsystem has two distinct paths. The **background indexing path** polls the Stellar Horizon events API, validates incoming contract events against a Zod schema, resolves each event to a business `invoiceId`, and persists raw events and per-invoice projections to PostgreSQL. The **admin read path** serves a cursor-paginated HTTP endpoint (`GET /api/admin/indexer/events`) so operators can inspect the raw event log without querying the database directly.
+
+This document traces both paths end-to-end, from entry point through every layer to persistence (or response), with real file and function references at each stage.
+
+---
+
+## Flow diagram
+
+```mermaid
+flowchart LR
+  subgraph Background_Indexing_Path
+    A1[Horizon Events API]
+    --> B1[fetchEscrowEventsFromHorizon\nsrc/jobs/escrowIndexer.js]
+    --> C1[deriveInvoiceId\nsrc/jobs/escrowIndexer.js]
+    --> D1[normalizeEvent → indexerEventSchema\nsrc/jobs/escrowIndexer.js → src/schemas/indexerEvent.js]
+    --> E1[persistEscrowEvent\nsrc/jobs/escrowIndexer.js]
+    --> F1[upsertEvent → escrow_events\nstore.upsertEvent in createKnexEscrowEventStore]
+    --> G1[upsertProjection → escrow_event_projection\nstore.upsertProjection in createKnexEscrowEventStore]
+    --> H1[escrowReadCache.invalidate\nsrc/services/escrowReadCache.js]
+  end
+
+  subgraph Admin_Read_Path
+    A2[GET /api/admin/indexer/events]
+    --> B2[adminStack middleware\nsrc/middleware/stacks.js]
+    --> C2[_parseQuery\nsrc/routes/adminIndexer.js]
+    --> D2[listIndexerEvents\nsrc/services/indexerService.js]
+    --> E2[Knex query: escrow_events\nsrc/services/indexerService.js]
+    --> F2[Response\nsrc/routes/adminIndexer.js]
+  end
+```
+
+---
+
+## Background indexing path
+
+This path runs in a polling loop. The `createEscrowIndexer()` factory (`src/jobs/escrowIndexer.js:425`) returns `{ start, stop, runCycle }`. Calling `start()` runs an immediate cycle then sets a `setInterval` timer (default `ESCROW_INDEXER_POLL_INTERVAL_MS = 15_000`). The indexer is **not** started by the main server — the module exports the factory and its primitives so deployment tooling can decide when and how to run it (e.g. as a separate process).
+
+### Stage 1 — Fetch events from Horizon
+
+**File:** `src/jobs/escrowIndexer.js:327` — `fetchEscrowEventsFromHorizon()`
+
+Built from `STELLAR_HORIZON_URL` (default `https://horizon-testnet.stellar.org`). Constructs a `GET /events` URL with `order=asc`, `limit` (default 100), and optional `cursor`. Parses the HAL response (`_embedded.records`).
+
+For each record, calls `deriveInvoiceId(record)` (`src/jobs/escrowIndexer.js:89`). The derivation priority is:
+
+1. An explicit `invoice_id` / `invoiceId` field on the record.
+2. The event `value` body (`body.invoice_id` / `body.invoiceId`).
+3. An explicit `invoice_id` / `invoiceId` field in one of the topic entries.
+4. Reverse lookup via `resolveInvoiceByAddress` (`src/config/escrowMap`) on `record.contract_id`.
+
+Any record that does not yield a valid `invoiceId` (matching `/^[a-zA-Z0-9_-]{1,128}$/`) is **filtered out** and not included in the returned `events` array. The next cursor is derived from the last record's `paging_token`.
+
+**Error path:** A non-`2xx` Horizon response throws an error. The cycle's `try/catch` in `runEscrowIndexerCycle` increments `escrowIndexerCycleFailuresTotal` and logs the error. The cursor is **not** advanced.
+
+### Stage 2 — Normalize and validate
+
+**File:** `src/jobs/escrowIndexer.js:162` — `normalizeEvent()`
+
+Calls `indexerEventSchema.safeParse(rawEvent)` (`src/schemas/indexerEvent.js:15`). This Zod schema enforces:
+
+| Field | Type | Constraint |
+|-------|------|------------|
+| `eventId` | string | 1–256 chars, trimmed |
+| `invoiceId` | string | `/^[a-zA-Z0-9_-]{1,128}$/`, trimmed |
+| `eventType` | string | 1–128 chars, trimmed |
+| `ledgerSequence` | number | Positive integer, ≤ `Number.MAX_SAFE_INTEGER` |
+| `pagingToken` | string | Max 2048 chars, defaults to `''` |
+| `contractId` | string \| null | Optional; must match `/^C[A-Z2-7]{55}$/` if present |
+| `txHash` | string \| null | Optional; must match `/^[0-9a-fA-F]{64}$/` if present |
+| `eventBody` | unknown | Optional, no validation |
+| `observedAt` | string | Optional; must be valid ISO 8601 datetime if present |
+
+The schema uses `.strict()` so unknown fields cause a validation failure.
+
+**Error path:** On validation failure, `normalizeEvent` throws a `ValidationError` with code `VALIDATION_ERROR` and field-level detail. The cycle's `for` loop catches it, increments the `skipped` counter, logs a warning, and continues to the next event.
+
+### Stage 3 — Persist event and update projection
+
+**File:** `src/jobs/escrowIndexer.js:299` — `persistEscrowEvent()`
+
+Runs inside a Knex **transaction**:
+
+1. **`store.upsertEvent(trx, event)`** (`src/jobs/escrowIndexer.js:222`): Inserts into `escrow_events` with `.onConflict('event_id').ignore()`. This makes duplicate `event_id` values idempotent — the first write wins, subsequent ones are silently ignored.
+
+2. **`store.findProjection(event.invoiceId)`** (`src/jobs/escrowIndexer.js:218`): Reads the current per-invoice projection row from `escrow_event_projection`.
+
+3. **`shouldReplaceProjection(current, event)`** (`src/jobs/escrowIndexer.js:272`): Compares ledger sequence (higher wins), then paging token as tiebreaker.
+
+4. **`store.upsertProjection(trx, event)`** (`src/jobs/escrowIndexer.js:239`): If the projection should be replaced, upserts into `escrow_event_projection` on `invoice_id` via `.onConflict('invoice_id').merge()`.
+
+5. **`escrowReadCache.invalidate(event.invoiceId)`** (`src/jobs/escrowIndexer.js:312`): Busts the process-local `escrowReadCache` so subsequent `GET /api/escrow/:invoiceId` calls re-read from the projection table.
+
+**Error path:** If the transaction throws, no events from that transaction are persisted, and the error propagates to the cycle's `for` loop, where it is caught, logged, and skipped.
+
+### Stage 4 — Advance cursor
+
+**File:** `src/jobs/escrowIndexer.js:411` — `runEscrowIndexerCycle()`
+
+After all events in the batch are processed, if `nextCursor` differs from the previous cursor, calls `store.saveCursor(nextCursor)` (`src/jobs/escrowIndexer.js:211`) which upserts into `escrow_indexer_state` where `key = 'horizon_cursor'`.
+
+The cursor is **not** advanced if:
+- The batch was empty (no records returned).
+- An HTTP or network error occurred before events could be parsed.
+
+### Stage 5 — Emit metrics
+
+**File:** `src/jobs/escrowIndexer.js:461` — inside `createEscrowIndexer`'s `runCycle`
+
+After the cycle completes, four Prometheus metrics are updated:
+
+| Metric | Type | Condition |
+|--------|------|-----------|
+| `escrow_indexer_events_processed_total` | Counter | Incremented by `processed` count |
+| `escrow_indexer_events_skipped_total` | Counter | Incremented by `skipped` count |
+| `escrow_indexer_cycle_failures_total` | Counter | Incremented when `processed` or `skipped` is invalid, or when an unhandled exception occurs |
+| `escrow_indexer_last_cursor_advance_timestamp_seconds` | Gauge | Set to `Date.now() / 1000` when cursor advances |
+
+Each count is validated (must be a non-negative integer) before being passed to `.inc()`.
+
+---
+
+## Admin read path
+
+### Stage 1 — Express global middleware
+
+**File:** `src/app.js`
+
+Before reaching the indexer router, every request passes through these middleware layers (in order):
+
+1. CORS (`createCorsOptions`)
+2. JSON body limit (100 KB) and URL-encoded body limit (50 KB)
+3. Security headers (`createSecurityMiddleware`)
+4. Audit middleware (`auditMiddleware`)
+5. Request ID (`requestId`)
+6. Correlation ID (`correlationIdMiddleware`)
+
+### Stage 2 — Auth and tenant extraction
+
+**File:** `src/middleware/stacks.js:63` — `adminStack`
+
+Applied to every route in the admin indexer router via `router.use(...adminStack)` (`src/routes/adminIndexer.js:33`).
+
+The stack executes:
+
+1. **`adminAuth`** (`src/middleware/stacks.js:32`):
+   - If the `x-api-key` header is present: delegates to `authenticateApiKey()` (`src/middleware/apiKeyAuth.js:91`). The middleware factory is called with **no** `requiredScope` — any valid, non-revoked key is accepted. After successful auth, `req.apiClient` is set.
+   - Otherwise: delegates to `authenticateToken` (`src/middleware/auth.js:57`). Validates `Authorization: Bearer <JWT>` with algorithm allowlist (default `HS256`), optional issuer/audience checks, and attaches `req.user`.
+
+2. **`extractTenant`** (`src/middleware/tenant.js:54`):
+   - Resolves `req.tenantId` from `x-tenant-id` header (highest priority) or `req.user.tenantId` (JWT claim).
+
+**Error paths:**
+- JWT missing/invalid/expired: `authenticateToken` calls `next(new AppError(...))` which is caught by the `handleInternalError` handler in `src/app.js:96`, returning 401.
+- API key missing/invalid/revoked: `authenticateApiKey` responds directly with a 401 JSON body (bypasses the centralized error handler).
+- Tenant cannot be resolved (`extractTenant`): responds with 400 and a JSON body `{ error: 'Missing tenant context.' }`.
+
+### Stage 3 — Query parameter validation
+
+**File:** `src/routes/adminIndexer.js:41` — `_parseQuery()`
+
+A pure function that validates and normalises query parameters. Rejects unknown parameters with a `400` and a `_unknown` detail key.
+
+Allowed parameters and their constraints:
+
+| Parameter | Validation | Error detail key |
+|-----------|-----------|------------------|
+| `invoiceId` | `/^[a-zA-Z0-9_-]{1,128}$/` | `invoiceId` |
+| `eventType` | Non-empty string, ≤ 128 chars | `eventType` |
+| `contractId` | `/^C[A-Z2-7]{55}$/` (Stellar contract address) | `contractId` |
+| `sortBy` | One of `observed_at`, `ledger_sequence` | `sortBy` |
+| `order` | `asc` or `desc` (case-insensitive) | `order` |
+| `cursor` | Non-empty string, ≤ 2048 chars | `cursor` |
+| `page` | Integer ≥ 1 (ignored when `cursor` is present) | `page` |
+| `limit` | Integer 1–100 | `limit` |
+
+Returns `{ isValid, fieldErrors, params }`. If `isValid` is `false`, the route responds immediately with `400` and the field-level errors.
+
+### Stage 4 — Service layer (listing)
+
+**File:** `src/services/indexerService.js:150` — `listIndexerEvents()`
+
+Receives the validated `params` object with `filters`, `sorting`, and `pagination` sub-objects.
+
+**Filtering** (`_applyFilters`, line 103): Applies exact-match Knex `.where()` clauses for `invoiceId`, `eventType`, and `contractId` to both the count query and the data query.
+
+**Pagination modes:**
+
+1. **Cursor (keyset) mode** (when `pagination.cursor` is provided):
+   - Calls `decodeCursor(cursor, sortField)` (`src/utils/cursorPagination.js:88`). This decodes the base64url payload, verifies the HMAC-SHA256 signature using `CURSOR_SECRET` or `JWT_SECRET` (with a dev fallback), validates the sort field matches the request's `sortBy`, and optionally checks cursor TTL (`CURSOR_TTL_ENABLED`).
+   - Applies a keyset predicate: `WHERE (sortField > lastValue) OR (sortField = lastValue AND event_id > lastId)` (or `<` for `DESC`).
+   - Fetches `limit + 1` rows to determine `hasMore` without a second count query.
+   - Encodes a `nextCursor` for the last row in the returned page via `encodeCursor`.
+
+2. **Offset mode** (legacy, when `page`/`limit` are provided without cursor):
+   - Standard `LIMIT/OFFSET` pagination.
+   - Still returns `nextCursor` so callers can migrate to cursor mode.
+
+**Error paths:**
+- Malformed/tampered cursor: `decodeCursor` throws `CursorError`. The route handler (`src/routes/adminIndexer.js:274`) catches it and returns `400` with a `VALIDATION_ERROR` code and the cursor error message in `details.cursor`.
+- Database error: Propagates as an unhandled exception caught by the route's outer `catch`, which calls `next(error)` and ultimately hits `handleInternalError` in `src/app.js`, returning 500.
+
+### Stage 5 — Response
+
+**File:** `src/routes/adminIndexer.js:300`
+
+On success: returns `200` with the response envelope from `responseHelper.success()`. The `meta` object includes `total`, `limit`, `hasMore`, and `nextCursor`. In offset mode, `page` and `totalPages` are also included. A structured log line is emitted with request ID, count, total, and cursor usage.
+
+The `event_body` column is **excluded** from the list response to keep payloads small (controlled by `SELECT_COLUMNS` in `src/services/indexerService.js:79`).
+
+---
+
+## Edge cases and gotchas
+
+### Idempotency (background path)
+
+Duplicate events with the same `eventId` are silently ignored by the `ON CONFLICT DO NOTHING` upsert. The projection upsert uses `ON CONFLICT DO UPDATE` (merge), so a duplicate event with a newer ledger sequence will replace the projection. This means the projection always reflects the most recent event for a given invoice.
+
+### Cursor security (admin read path)
+
+Cursors are opaque, base64url-encoded, and HMAC-SHA256-signed. The secret is resolved from `CURSOR_SECRET` or `JWT_SECRET`. In development/test, a weak literal fallback (`dev-cursor-secret-change-in-prod`) is used. Any tampering is detected by the `decodeCursor` function and returns `400`. Cursor TTL is optional (`CURSOR_TTL_ENABLED`).
+
+### Tenant isolation (admin read path)
+
+`extractTenant` runs as part of `adminStack`, but the service layer (`listIndexerEvents`) does **not** filter `escrow_events` by `req.tenantId`. The `escrow_events` table is treated as admin-level data with no tenant partition. This is a deliberate design choice documented in the route file.
+
+### Invoice ID derivation (background path)
+
+The derivation priority in `deriveInvoiceId` explicitly avoids treating bare topic symbols (like the event-name symbol `escrow_funded`) as invoice IDs. Only explicitly-labelled `invoice_id` / `invoiceId` fields in topics are trusted. The fallback reverse lookup via `resolveInvoiceByAddress` returns `null` if the contract address maps to itself (i.e. the mapping is for a contract, not an invoice), preventing mis-keying.
+
+### No tenant filtering on escrow_events
+
+The `listIndexerEvents` service performs no tenant-scoped filtering despite `extractTenant` running. All admin users see all events regardless of tenant context.
+
+### Skipped events do not stall ingestion
+
+When an event fails validation in the background path, the cycle logs a warning, increments the skipped counter, and continues processing the remaining events. The cursor is advanced past the entire batch (based on the last record's `paging_token`), so skipped events are not re-fetched on the next cycle.
+
+### Re-entrancy guard
+
+The `createEscrowIndexer`'s `runCycle` uses a `running` flag (`src/jobs/escrowIndexer.js:444`) to prevent concurrent cycles. If `runCycle` is called while a previous cycle is still in flight, it returns `null` immediately.
+
+### Metric validation
+
+Before incrementing Prometheus counters, the cycle validates that `processed` and `skipped` are non-negative integers. An invalid value increments `escrow_indexer_cycle_failures_total` instead. This prevents a bug in a single cycle from corrupting counters.


### PR DESCRIPTION
## docs: config request lifecycle end-to-end flow

Closes #820

Add `docs/config-flow.md` documenting the full lifecycle of both `POST /api/admin/config` and `GET /api/admin/config/sections` endpoints.

**Coverage includes:**
- Rate limiting (per-client keyed by API key/IP)
- Auth stack (JWT or API key) and tenant extraction
- Idempotency middleware with TTL-based caching
- Zod body validation via `runtimeConfigSchema` with section-specific sub-schemas
- Handler side effects (CORS reload is the only runtime effect)
- Response shapes for both success and error paths
- Edge cases: no DB persistence, rate-limiter-before-auth ordering, duplicate import bug
