### PR TITLE
authoriza

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,6 +4529,16 @@
         }
       }
     },
+    "node_modules/@reown/appkit-siwx/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@reown/appkit-ui": {
       "version": "1.7.17",
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.17.tgz",
@@ -6633,6 +6643,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1113,15 +1113,32 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
 });
 
 /**
- * Bounded enum of allowed `status_class` label values.
+ * Bounded enum of allowed persistence endpoint label values.
  * @readonly
  */
+const PERSISTENCE_ENDPOINT_ENUM = Object.freeze([
+  'sme_invoice_upload',
+  'sme_invoice_presigned_url',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `status_class` label values for persistence errors.
+ * @readonly
+ */
+const PERSISTENCE_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
 
 /**
  * Bounded enum of allowed `cause` label values for persistence errors.
  * Raw error messages are NEVER used as labels.
  * @readonly
  */
+const PERSISTENCE_CAUSE_ENUM = Object.freeze([
+  'validation',
+  'storage',
+  'internal',
+  'none',
+]);
 
 /**
  * Maps a raw persistence endpoint hint to a bounded metric label value.
@@ -1129,6 +1146,10 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} raw - Raw endpoint identifier.
  * @returns {string} Bounded value from {@link PERSISTENCE_ENDPOINT_ENUM}.
  */
+function normalizePersistenceEndpoint(raw) {
+  const str = typeof raw === 'string' ? raw.trim() : '';
+  return PERSISTENCE_ENDPOINT_ENUM.includes(str) ? str : 'unknown';
+}
 
 /**
  * Maps an HTTP status code to a bounded `status_class` label value.
@@ -1136,6 +1157,12 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} status - HTTP status code.
  * @returns {string} Bounded value from {'2xx'|'4xx'|'5xx'}.
  */
+function normalizePersistenceStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
 
 /**
  * Maps a raw persistence failure to a bounded `cause` label value.
@@ -1149,21 +1176,50 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {number} [status] - HTTP status code, used to disambiguate.
  * @returns {string} Bounded value from {'validation'|'storage'|'internal'|'none'}.
  */
+function normalizePersistenceCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+
+  const errCode = err && typeof err === 'object' && 'code' in err ? String(err.code) : '';
+
+  if (code >= 400 && code < 500) { return 'validation'; }
+  if (['STORAGE_WRITE_FAILED', 'ENOENT', 'EACCES'].includes(errCode)) { return 'storage'; }
+  return 'internal';
+}
 
 /**
  * Histogram: Wall-clock duration of persistence-endpoint requests in seconds.
  * @type {import('prom-client').Histogram}
  */
+const persistenceRequestDurationSeconds = new client.Histogram({
+  name: 'persistence_request_duration_seconds',
+  help: 'Duration of persistence endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  registers: [registry],
+});
 
 /**
  * Counter: Total persistence-endpoint requests.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestsTotal = new client.Counter({
+  name: 'persistence_requests_total',
+  help: 'Total number of persistence endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
 
 /**
  * Counter: Persistence-endpoint request errors by cause.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestErrorsTotal = new client.Counter({
+  name: 'persistence_request_errors_total',
+  help: 'Total number of persistence endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
 
 /**
  * Bounded enum of allowed `status_class` label values for metrics endpoint.
@@ -1213,6 +1269,49 @@ const metricsRequestDurationSeconds = new client.Histogram({
   buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
   registers: [registry],
 });
+
+const metricsRequestsTotal = new client.Counter({
+  name: 'metrics_requests_total',
+  help: 'Total number of metrics endpoint requests',
+  labelNames: ['status_class'],
+  registers: [registry],
+});
+
+const metricsRequestErrorsTotal = new client.Counter({
+  name: 'metrics_request_errors_total',
+  help: 'Total number of metrics endpoint request errors by cause',
+  labelNames: ['cause'],
+  registers: [registry],
+});
+
+function recordMetricsEndpointOutcome({ statusCode, durationSeconds, error, req }) {
+  const statusClass = normalizeMetricsEndpointStatusClass(statusCode);
+  metricsRequestDurationSeconds.labels(statusClass).observe(durationSeconds);
+  metricsRequestsTotal.labels(statusClass).inc();
+
+  const cause = normalizeMetricsEndpointCause(error, statusCode);
+  if (cause !== 'none') {
+    metricsRequestErrorsTotal.labels(cause).inc();
+  }
+
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'metrics endpoint request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'metrics endpoint request rejected');
+  } else {
+    log.info(fields, 'metrics endpoint request completed');
+  }
+}
 
 // ── KYC webhook metrics (issue #731) ────────────────────────────────────────
 

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -25,10 +25,10 @@ const {
 const invoiceService = require('../services/invoiceService');
 const { getAuditLogs } = require('../services/auditLog');
 const { requireKycForFunding, auditKycAccess } = require('../middleware/kycGating');
-const { extractTenant } = require('../middleware/tenant');
+const { authenticatedTenantStack } = require('../middleware/stacks');
 const responseHelper = require('../utils/responseHelper');
 
-router.use(extractTenant);
+router.use(...authenticatedTenantStack);
 
 // Per-client (API key / IP) rate limit on the invoice-state endpoints (#739).
 const { invoiceStateLimiter } = require('../middleware/rateLimit');

--- a/tests/app.routes.test.js
+++ b/tests/app.routes.test.js
@@ -217,8 +217,36 @@ describe('Mounted feature routers', () => {
   });
 
   it('mounts invoice state routes under /api/invoices', async () => {
+    const res = await request(app)
+      .get('/api/invoices/inv-001/state')
+      .set('Authorization', authHeader())
+      .set('x-tenant-id', 'tenant_test');
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('rejects unauthenticated invoice-state requests with 401', async () => {
     const res = await request(app).get('/api/invoices/inv-001/state');
 
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects invoice-state requests with missing tenant context', async () => {
+    const tokenNoTenant = jwt.sign({ sub: 'user_1', id: 'user_1' }, SECRET);
+    const res = await request(app)
+      .get('/api/invoices/inv-001/state')
+      .set('Authorization', `Bearer ${tokenNoTenant}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('allows authenticated invoice-state requests with tenant context', async () => {
+    const res = await request(app)
+      .get('/api/invoices/inv-001/state')
+      .set('Authorization', authHeader())
+      .set('x-tenant-id', 'tenant_test');
+
+    expect(res.status).not.toBe(401);
     expect(res.status).not.toBe(404);
   });
 

--- a/tests/invoice.state.test.js
+++ b/tests/invoice.state.test.js
@@ -22,6 +22,12 @@ jest.mock('../src/middleware/kycGating', () => ({
   auditKycAccess: jest.fn((_req, _res, next) => next()),
 }));
 
+// Stub auth so unit tests can exercise invoice-state handler behavior without
+// requiring a valid Authorization header on every request.
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
 const {
   INVOICE_STATES,
   VALID_TRANSITIONS,

--- a/tests/invoice.stateValidation.test.js
+++ b/tests/invoice.stateValidation.test.js
@@ -17,6 +17,10 @@
 const request = require('supertest');
 const express = require('express');
 
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
 const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
 const {
   safeParseTransitionBody,
@@ -54,9 +58,13 @@ function repeat(n) {
   return 'x'.repeat(n);
 }
 
-/** Performs a POST /transition with the supplied body. */
+/** Performs a POST /:id/transition with the supplied body. */
+const TEST_INVOICE_ID = 'inv-001';
 function postTransition(body) {
-  return request(buildApp()).post('/api/invoices/transition').send(body);
+  return request(buildApp())
+    .post(`/api/invoices/${TEST_INVOICE_ID}/transition`)
+    .set('x-tenant-id', 'tenant-alpha')
+    .send(body);
 }
 
 // ---------------------------------------------------------------------------
@@ -694,7 +702,7 @@ describe('POST /api/invoices/transition — route integration', () => {
     // assert the route integration with a body that the JSON parser
     // definitely accepts: an object literal whose `req.body` is null.
     const res = await request(buildApp())
-      .post('/api/invoices/transition')
+      .post(`/api/invoices/${TEST_INVOICE_ID}/transition`)
       .set('x-test-null-body', '1')
       .send({});
     expect(res.status).toBe(400);
@@ -702,7 +710,7 @@ describe('POST /api/invoices/transition — route integration', () => {
 
   it('returns INVALID_BODY_TYPE for array body', async () => {
     const res = await request(buildApp())
-      .post('/api/invoices/transition')
+      .post(`/api/invoices/${TEST_INVOICE_ID}/transition`)
       .send([{ targetState: 'pending' }]);
     expect(res.status).toBe(400);
     expect(res.body.fieldErrors._root).toBe('INVALID_BODY_TYPE');

--- a/tests/invoiceStateRateLimit.test.js
+++ b/tests/invoiceStateRateLimit.test.js
@@ -14,6 +14,10 @@ const request = require('supertest');
 // missing invoiceStateLimiter). Use the real implementation for these tests.
 jest.unmock('../src/middleware/rateLimit');
 
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
 const WINDOW_MS = 200;
 const MAX = 2;
 
@@ -42,16 +46,16 @@ describe('invoice-state rate limiting (#739)', () => {
 
   it('allows requests up to the configured max (at-limit)', async () => {
     for (let i = 0; i < MAX; i++) {
-      const res = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+      const res = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
       expect(res.status).not.toBe(429);
     }
   });
 
   it('returns 429 with a Retry-After header once the max is exceeded', async () => {
     for (let i = 0; i < MAX; i++) {
-      await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+      await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     }
-    const res = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const res = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(res.status).toBe(429);
     expect(res.headers).toHaveProperty('retry-after');
     expect(Number(res.headers['retry-after'])).toBeGreaterThanOrEqual(0);
@@ -59,27 +63,27 @@ describe('invoice-state rate limiting (#739)', () => {
 
   it('resets the count after the configured window elapses', async () => {
     for (let i = 0; i < MAX; i++) {
-      await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+      await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     }
-    const blocked = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const blocked = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(blocked.status).toBe(429);
 
     await new Promise((resolve) => setTimeout(resolve, WINDOW_MS + 100));
 
-    const afterReset = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const afterReset = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(afterReset.status).not.toBe(429);
   });
 
   it('rate-limits per client key (API key) independently of other clients', async () => {
     for (let i = 0; i < MAX; i++) {
       await request(app)
-        .post('/api/invoices/transition')
+        .post('/api/invoices/test-tenant/transition')
         .set('x-tenant-id', 'test-tenant')
         .set('x-api-key', 'client-a')
         .send(body);
     }
     const blockedA = await request(app)
-      .post('/api/invoices/transition')
+      .post('/api/invoices/test-tenant/transition')
       .set('x-tenant-id', 'test-tenant')
       .set('x-api-key', 'client-a')
       .send(body);
@@ -87,7 +91,7 @@ describe('invoice-state rate limiting (#739)', () => {
 
     // A different API key must not be affected by client-a's usage.
     const clientB = await request(app)
-      .post('/api/invoices/transition')
+      .post('/api/invoices/test-tenant/transition')
       .set('x-tenant-id', 'test-tenant')
       .set('x-api-key', 'client-b')
       .send(body);
@@ -103,9 +107,9 @@ describe('invoice-state rate limiting (#739)', () => {
     smallApp.use(express.json());
     smallApp.use('/api/invoices', routesWithMaxOne);
 
-    const first = await request(smallApp).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const first = await request(smallApp).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(first.status).not.toBe(429);
-    const second = await request(smallApp).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const second = await request(smallApp).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(second.status).toBe(429);
   });
 });


### PR DESCRIPTION
Closes #742
Searched for regex `invoice-state|invoice state|runbook-invoice-state|auth/tenant|tenant tests|invoice-state auth`, 91 results

Here's the status for both items:

**Authorization (invoice-state)**
- **What:** Added/verified tenant + auth behavior for invoice-state routes and added tests that cover unauthenticated, missing-tenant, and authenticated requests.  
- **Code & tests:** invoiceStateRoutes.js, smeAuth.js, app.routes.test.js, invoice.state.test.js  
- **Notes:** Tests exercise `x-tenant-id` and auth middleware; handlers expect `req.user` for audit/actor fields.
