### PR TITLE
Rate limit

### DIFF
--- a/docs/runbook-invoice-state.md
+++ b/docs/runbook-invoice-state.md
@@ -1,0 +1,225 @@
+# Invoice-State Operations Runbook
+
+Operator runbook for the LiquiFact backend invoice-state subsystem. This document covers configuration, common failure modes, alerts/signals, and recovery procedures for the invoice-state API and the state-transition logic in `src/services/invoiceStateMachine.js`.
+
+---
+
+## Architecture Overview
+
+The invoice-state subsystem is a tenant-scoped state machine for invoice lifecycle transitions.
+
+```text
+/api/invoices/:id/*
+  |
+  +-> authenticateToken
+  +-> extractTenant
+  +-> invoiceStateLimiter
+      |
+      +-> GET /:id/state
+      +-> POST /:id/transition
+      +-> POST /:id/approve
+      +-> POST /:id/reject
+      +-> POST /:id/link-escrow
+      +-> GET /:id/history
+```
+
+Key behavior:
+
+- All invoice-state routes are mounted under `src/routes/invoiceStateRoutes.js` and require authenticated tenant context.
+- Tenant context is extracted by `src/middleware/tenant.js` from `x-tenant-id` or the authenticated JWT claim.
+- Invoice lookup and transition persistence are scoped to the tenant by `src/services/invoiceService.js`.
+- Transition rules are enforced by `src/services/invoiceStateMachine.js`; the client cannot directly set a status.
+- The `link-escrow` path is gated by KYC checks in `src/middleware/kycGating.js`.
+
+---
+
+## Invoice-State Endpoints
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `GET /api/invoices/:id/state` | Returns current state + allowed transitions | Uses `resolveInvoiceForTenant` to enforce tenant isolation. |
+| `POST /api/invoices/:id/transition` | Executes a generic state transition | Validated by the invoice state machine. |
+| `POST /api/invoices/:id/approve` | Convenience approve action | Transitions `pending` -> `approved`. |
+| `POST /api/invoices/:id/reject` | Convenience reject action | Requires a non-empty reason. |
+| `POST /api/invoices/:id/link-escrow` | Links an approved invoice to escrow | Requires KYC gate and approved current state. |
+| `GET /api/invoices/:id/history` | Returns state transition history | Uses `getTransitionHistory` and audit logs. |
+
+---
+
+## Valid State Transitions
+
+The state machine in `src/services/invoiceStateMachine.js` defines the allowed lifecycle flow.
+
+- `pending` -> `approved`
+- `pending` -> `rejected`
+- `pending` -> `cancelled`
+- `approved` -> `linked_escrow`
+- `approved` -> `cancelled`
+
+Terminal states:
+
+- `linked_escrow`
+- `rejected`
+- `cancelled`
+
+Terminal states cannot transition again.
+
+The transitions to `rejected` and `cancelled` require a non-empty reason and enforce a maximum reason length.
+
+---
+
+## Configuration
+
+Invoice-state behavior is driven mostly by authentication, tenant scoping, and rate limiting.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RATE_LIMIT_INVOICE_STATE_WINDOW_MS` | `900000` (15 minutes) | Rate-limit bucket window for invoice-state requests. |
+| `RATE_LIMIT_INVOICE_STATE_MAX` | `60` | Maximum invoice-state requests per window per client key. |
+| `JWT_SECRET` | test/dev fallback only | Required for auth outside test/dev environments. |
+
+Note: there are no dedicated invoice-state feature flags in code beyond those rate-limit env vars. The request validator and state machine enforce transition rules entirely in code.
+
+---
+
+## Common Failure Modes
+
+### 1. Unauthorized / missing token
+
+**Symptom:** `401 Unauthorized`
+
+**Cause:** `authenticateToken` rejects the request before tenant resolution.
+
+**Check:** verify the bearer token and the configured `JWT_SECRET` / token issuer settings.
+
+**Recovery:** fix the client token or auth configuration.
+
+### 2. Missing tenant context
+
+**Symptom:** `400` with a missing tenant message.
+
+**Cause:** `x-tenant-id` is not supplied and the authenticated JWT has no `tenantId` claim.
+
+**Check:** confirm the request includes either `x-tenant-id` or a valid token-scoped tenant ID.
+
+**Recovery:** supply the tenant ID in the header or ensure the token contains `tenantId`.
+
+### 3. Cross-tenant invoice access
+
+**Symptom:** `404 INVOICE_NOT_FOUND`
+
+**Cause:** `resolveInvoiceForTenant` returns `null` when the invoice does not exist or belongs to another tenant.
+
+**Check:** verify the invoice ID and tenant are correct, and that the invoice exists under the requested tenant.
+
+**Recovery:** correct the tenant-id or use the invoice ID within the same tenant.
+
+### 4. Invalid transition input
+
+**Symptom:** `400` with one of the state-machine validation errors.
+
+**Common codes:**
+
+- `MISSING_TARGET_STATE`
+- `INVALID_TARGET_STATE`
+- `ALREADY_IN_TARGET_STATE`
+- `TERMINAL_STATE`
+- `MISSING_TRANSITION_REASON`
+- `TRANSITION_REASON_TOO_LONG`
+- `INVALID_REASON_TYPE`
+
+**Cause:** bad request body or unsupported transition.
+
+**Check:** inspect the request payload and compare to the current state and allowed transitions.
+
+**Recovery:** adjust the transition target or supply the required reason/actor fields.
+
+### 5. KYC gate rejection on link escrow
+
+**Symptom:** `400 CANNOT_LINK_TO_ESCROW` or a 403 / KYC-specific rejection from `requireKycForFunding`.
+
+**Cause:** invoice is not approved, not eligible for escrow linkage, or the caller fails the KYC gate.
+
+**Check:** confirm the invoice is in `approved` state and that the SME has verified/exempted KYC status.
+
+**Recovery:** ensure the invoice is approved, then satisfy the KYC requirements before retrying.
+
+### 6. Rate limiting
+
+**Symptom:** `429 Too Many Requests` with a `Retry-After` header.
+
+**Cause:** the client exceeded `RATE_LIMIT_INVOICE_STATE_MAX` within the configured window.
+
+**Check:** verify request patterns and client key usage.
+
+**Recovery:** back off until the retry window resets, or increase the rate-limit config only if the traffic pattern is legitimate.
+
+### 7. Internal persistence / DB errors
+
+**Symptom:** `500` or other server error while executing a transition.
+
+**Cause:** underlying DB write/read failure, schema mismatch, or tenant-scoped query failure.
+
+**Check:** inspect application logs and DB connectivity. Confirm the `invoices` table and audit log persistence are healthy.
+
+**Recovery:** restore DB connectivity, correct schema/migrations, and retry the transition.
+
+---
+
+## Alerts and Signals
+
+Watch for these signals when operating invoice-state.
+
+| Signal | Meaning |
+|---|---|
+| `INVOICE_NOT_FOUND` | The requested invoice is missing or belongs to a different tenant. |
+| `MISSING_TRANSITION_REASON` | A terminal transition was attempted without a required reason. |
+| `CANNOT_LINK_TO_ESCROW` | A non-approved invoice or a KYC gate failure blocked escrow linkage. |
+| `429` on invoice-state endpoints | Rate limiting is in effect for the request key. |
+| `500` on transition routes | Underlying persistence or state-machine errors need investigation. |
+
+Relevant code locations:
+
+- `src/routes/invoiceStateRoutes.js` — route behavior, middleware ordering, response shaping.
+- `src/services/invoiceService.js` — tenant-scoped invoice lookup and persistence.
+- `src/services/invoiceStateMachine.js` — canonical transition rules and validation.
+- `src/middleware/tenant.js` — tenant extraction and header/JWT resolution.
+- `src/middleware/rateLimit.js` — invoice-state rate limiter config and behavior.
+- `src/middleware/kycGating.js` — KYC gating for `link-escrow`.
+
+---
+
+## Recovery Steps
+
+### Recover an invoice-state transition failure
+
+1. Confirm the request was authenticated and `req.tenantId` was resolved.
+2. Confirm the invoice exists for the tenant, or verify that the invoice is not cross-tenant.
+3. Review the current state and allowed transitions returned by `GET /api/invoices/:id/state`.
+4. If the transition failed with a validation code, fix the payload and retry.
+5. If the failure is a DB error, restore the database and retry the request.
+
+### Recover from `link-escrow` KYC failures
+
+1. Confirm the invoice is in `approved` state.
+2. Confirm the caller’s tenant/SME identity has KYC approved/exempted status.
+3. Confirm the `requireKycForFunding` middleware is not rejecting for missing or invalid KYC metadata.
+4. Retry the operation once the KYC condition is satisfied.
+
+### Recover from invoice-state rate limiting
+
+1. Confirm the client key and request volume.
+2. If traffic is legitimate, increase `RATE_LIMIT_INVOICE_STATE_MAX` or `RATE_LIMIT_INVOICE_STATE_WINDOW_MS` carefully.
+3. If traffic is abusive, keep the limit and ask clients to retry after the `Retry-After` window.
+
+---
+
+## Cross-References
+
+- `src/routes/invoiceStateRoutes.js`
+- `src/services/invoiceStateMachine.js`
+- `src/services/invoiceService.js`
+- `src/middleware/tenant.js`
+- `src/middleware/rateLimit.js`
+- `src/middleware/kycGating.js`
+- `docs/configuration.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,6 +4529,16 @@
         }
       }
     },
+    "node_modules/@reown/appkit-siwx/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@reown/appkit-ui": {
       "version": "1.7.17",
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.17.tgz",
@@ -6633,6 +6643,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {

--- a/src/app.js
+++ b/src/app.js
@@ -24,6 +24,7 @@ const { createSecurityMiddleware } = require('./middleware/security');
 const { auditMiddleware } = require('./middleware/audit');
 const requestId = require('./middleware/requestId');
 const { correlationIdMiddleware } = require('./middleware/correlationId');
+const { createCorsRateLimiter } = require('./middleware/rateLimit');
 const invoiceService = require('./services/invoiceService');
 const { CursorError } = require('./utils/cursorPagination');
 const { resolveEscrowAddress } = require('./config/escrowMap');
@@ -140,6 +141,8 @@ function createApp() {
   const app = express();
 
   // ── 1. CORS ──────────────────────────────────────────────────────────────
+  // Rate limit cross-origin requests before the CORS middleware evaluates them.
+  app.use(createCorsRateLimiter());
   app.use(cors(createCorsOptions()));
 
   // ── 1.a. KYC webhook raw body parser ──────────────────────────────────────

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1113,15 +1113,32 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
 });
 
 /**
- * Bounded enum of allowed `status_class` label values.
+ * Bounded enum of allowed persistence endpoint label values.
  * @readonly
  */
+const PERSISTENCE_ENDPOINT_ENUM = Object.freeze([
+  'sme_invoice_upload',
+  'sme_invoice_presigned_url',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `status_class` label values for persistence errors.
+ * @readonly
+ */
+const PERSISTENCE_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
 
 /**
  * Bounded enum of allowed `cause` label values for persistence errors.
  * Raw error messages are NEVER used as labels.
  * @readonly
  */
+const PERSISTENCE_CAUSE_ENUM = Object.freeze([
+  'validation',
+  'storage',
+  'internal',
+  'none',
+]);
 
 /**
  * Maps a raw persistence endpoint hint to a bounded metric label value.
@@ -1129,6 +1146,10 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} raw - Raw endpoint identifier.
  * @returns {string} Bounded value from {@link PERSISTENCE_ENDPOINT_ENUM}.
  */
+function normalizePersistenceEndpoint(raw) {
+  const str = typeof raw === 'string' ? raw.trim() : '';
+  return PERSISTENCE_ENDPOINT_ENUM.includes(str) ? str : 'unknown';
+}
 
 /**
  * Maps an HTTP status code to a bounded `status_class` label value.
@@ -1136,6 +1157,12 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} status - HTTP status code.
  * @returns {string} Bounded value from {'2xx'|'4xx'|'5xx'}.
  */
+function normalizePersistenceStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
 
 /**
  * Maps a raw persistence failure to a bounded `cause` label value.
@@ -1149,21 +1176,50 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {number} [status] - HTTP status code, used to disambiguate.
  * @returns {string} Bounded value from {'validation'|'storage'|'internal'|'none'}.
  */
+function normalizePersistenceCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+
+  const errCode = err && typeof err === 'object' && 'code' in err ? String(err.code) : '';
+
+  if (code >= 400 && code < 500) { return 'validation'; }
+  if (['STORAGE_WRITE_FAILED', 'ENOENT', 'EACCES'].includes(errCode)) { return 'storage'; }
+  return 'internal';
+}
 
 /**
  * Histogram: Wall-clock duration of persistence-endpoint requests in seconds.
  * @type {import('prom-client').Histogram}
  */
+const persistenceRequestDurationSeconds = new client.Histogram({
+  name: 'persistence_request_duration_seconds',
+  help: 'Duration of persistence endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  registers: [registry],
+});
 
 /**
  * Counter: Total persistence-endpoint requests.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestsTotal = new client.Counter({
+  name: 'persistence_requests_total',
+  help: 'Total number of persistence endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
 
 /**
  * Counter: Persistence-endpoint request errors by cause.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestErrorsTotal = new client.Counter({
+  name: 'persistence_request_errors_total',
+  help: 'Total number of persistence endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
 
 /**
  * Bounded enum of allowed `status_class` label values for metrics endpoint.
@@ -1213,6 +1269,49 @@ const metricsRequestDurationSeconds = new client.Histogram({
   buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
   registers: [registry],
 });
+
+const metricsRequestsTotal = new client.Counter({
+  name: 'metrics_requests_total',
+  help: 'Total number of metrics endpoint requests',
+  labelNames: ['status_class'],
+  registers: [registry],
+});
+
+const metricsRequestErrorsTotal = new client.Counter({
+  name: 'metrics_request_errors_total',
+  help: 'Total number of metrics endpoint request errors by cause',
+  labelNames: ['cause'],
+  registers: [registry],
+});
+
+function recordMetricsEndpointOutcome({ statusCode, durationSeconds, error, req }) {
+  const statusClass = normalizeMetricsEndpointStatusClass(statusCode);
+  metricsRequestDurationSeconds.labels(statusClass).observe(durationSeconds);
+  metricsRequestsTotal.labels(statusClass).inc();
+
+  const cause = normalizeMetricsEndpointCause(error, statusCode);
+  if (cause !== 'none') {
+    metricsRequestErrorsTotal.labels(cause).inc();
+  }
+
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'metrics endpoint request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'metrics endpoint request rejected');
+  } else {
+    log.info(fields, 'metrics endpoint request completed');
+  }
+}
 
 // ── KYC webhook metrics (issue #731) ────────────────────────────────────────
 

--- a/src/middleware/rateLimit.js
+++ b/src/middleware/rateLimit.js
@@ -177,6 +177,76 @@ const CONFIG_RATE_LIMIT_MAX = parseRateLimitEnv('CONFIG_RATE_LIMIT_MAX', 20);
 // accidental tight loops or abusive reloads within one scrape cycle.
 const METRICS_RATE_LIMIT_WINDOW_MS = parseRateLimitEnv('METRICS_RATE_LIMIT_WINDOW_MS', 60 * 1000);
 const METRICS_RATE_LIMIT_MAX = parseRateLimitEnv('METRICS_RATE_LIMIT_MAX', 30);
+const CORS_RATE_LIMIT_WINDOW_MS = parseRateLimitEnv('CORS_RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000);
+const CORS_RATE_LIMIT_MAX = parseRateLimitEnv('CORS_RATE_LIMIT_MAX', 120);
+
+/**
+ * CORS request rate-limit handler.
+ * Returns a structured 429 response and preserves standard rate-limit headers.
+ *
+ * @param {import('express').Request} _req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} _next - Express next callback.
+ * @param {{ statusCode: number, windowMs: number }} options - Rate limiter options.
+ * @returns {void}
+ */
+function corsRateLimitHandler(_req, res, _next, options) {
+  res.status(options.statusCode).json({
+    type: 'https://liquifact.com/probs/too-many-requests',
+    title: 'Too Many Requests',
+    status: options.statusCode,
+    code: 'RATE_LIMITED',
+    retryable: true,
+    retry_hint: 'Wait for the rate-limit window to reset before retrying.',
+    scope: 'cors',
+    error: 'Too many requests.',
+    message: 'Rate limit threshold breached for CORS requests. Please try again later.',
+  });
+}
+
+/**
+ * Per-client rate limiter for CORS requests.
+ * Limits browser-origin requests by API key or IP and returns Retry-After on 429.
+ *
+ * Env vars:
+ *   - `CORS_RATE_LIMIT_WINDOW_MS` (default 15 min)
+ *   - `CORS_RATE_LIMIT_MAX`       (default 120)
+ *
+ * @type {import('express').RequestHandler}
+ */
+const corsLimiter = rateLimit({
+  windowMs: CORS_RATE_LIMIT_WINDOW_MS,
+  limit: CORS_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: resolveRateLimitStore('cors'),
+  keyGenerator: apiKeyKeyGenerator,
+  validate: {
+    xForwardedForHeader: false,
+  },
+  skip: (req) => !req.get('Origin'),
+  handler: corsRateLimitHandler,
+});
+
+/**
+ * Factory for creating a fresh CORS limiter instance (useful for tests/apps).
+ * Returns a new express-rate-limit middleware configured for CORS.
+ */
+function createCorsRateLimiter() {
+  return rateLimit({
+    windowMs: CORS_RATE_LIMIT_WINDOW_MS,
+    max: CORS_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: resolveRateLimitStore('cors'),
+    keyGenerator: apiKeyKeyGenerator,
+    validate: {
+      xForwardedForHeader: false,
+    },
+    skip: (req) => !req.get('Origin'),
+    handler: corsRateLimitHandler,
+  });
+}
 
 /**
  * Standard global rate limiter for all API endpoints.
@@ -352,6 +422,40 @@ const invoiceStateLimiter = rateLimit({
   },
 });
 
+/**
+ * Metrics limiter 429 handler and factory (kept local to this module).
+ */
+function metricsRateLimitHandler(_req, res, _next, options) {
+  res.status(options.statusCode).json({
+    type: 'https://liquifact.com/probs/too-many-requests',
+    title: 'Too Many Requests',
+    status: options.statusCode,
+    code: 'RATE_LIMITED',
+    retryable: true,
+    retry_hint: 'Wait for the rate-limit window to reset before retrying.',
+    scope: 'metrics',
+    error: 'Too many requests.',
+    message: 'Rate limit threshold breached for /metrics. Please try again later.',
+  });
+}
+
+function createMetricsRateLimiter() {
+  return rateLimit({
+    windowMs: METRICS_RATE_LIMIT_WINDOW_MS,
+    max: METRICS_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: resolveRateLimitStore('metrics'),
+    keyGenerator: adminConfigKeyGenerator,
+    validate: {
+      xForwardedForHeader: false,
+    },
+    handler: metricsRateLimitHandler,
+  });
+}
+
+const metricsLimiter = createMetricsRateLimiter();
+
 module.exports = {
   createRateLimiter,
   globalLimiter,
@@ -367,6 +471,11 @@ module.exports = {
   CONFIG_RATE_LIMIT_MAX,
   METRICS_RATE_LIMIT_WINDOW_MS,
   METRICS_RATE_LIMIT_MAX,
+  CORS_RATE_LIMIT_WINDOW_MS,
+  CORS_RATE_LIMIT_MAX,
+  corsLimiter,
+  corsRateLimitHandler,
+  createCorsRateLimiter,
   metricsLimiter,
   metricsRateLimitHandler,
   createMetricsRateLimiter,

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -25,10 +25,10 @@ const {
 const invoiceService = require('../services/invoiceService');
 const { getAuditLogs } = require('../services/auditLog');
 const { requireKycForFunding, auditKycAccess } = require('../middleware/kycGating');
-const { extractTenant } = require('../middleware/tenant');
+const { authenticatedTenantStack } = require('../middleware/stacks');
 const responseHelper = require('../utils/responseHelper');
 
-router.use(extractTenant);
+router.use(...authenticatedTenantStack);
 
 // Per-client (API key / IP) rate limit on the invoice-state endpoints (#739).
 const { invoiceStateLimiter } = require('../middleware/rateLimit');

--- a/tests/app.routes.test.js
+++ b/tests/app.routes.test.js
@@ -217,8 +217,36 @@ describe('Mounted feature routers', () => {
   });
 
   it('mounts invoice state routes under /api/invoices', async () => {
+    const res = await request(app)
+      .get('/api/invoices/inv-001/state')
+      .set('Authorization', authHeader())
+      .set('x-tenant-id', 'tenant_test');
+
+    expect(res.status).not.toBe(404);
+  });
+
+  it('rejects unauthenticated invoice-state requests with 401', async () => {
     const res = await request(app).get('/api/invoices/inv-001/state');
 
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects invoice-state requests with missing tenant context', async () => {
+    const tokenNoTenant = jwt.sign({ sub: 'user_1', id: 'user_1' }, SECRET);
+    const res = await request(app)
+      .get('/api/invoices/inv-001/state')
+      .set('Authorization', `Bearer ${tokenNoTenant}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('allows authenticated invoice-state requests with tenant context', async () => {
+    const res = await request(app)
+      .get('/api/invoices/inv-001/state')
+      .set('Authorization', authHeader())
+      .set('x-tenant-id', 'tenant_test');
+
+    expect(res.status).not.toBe(401);
     expect(res.status).not.toBe(404);
   });
 

--- a/tests/invoice.state.test.js
+++ b/tests/invoice.state.test.js
@@ -22,6 +22,12 @@ jest.mock('../src/middleware/kycGating', () => ({
   auditKycAccess: jest.fn((_req, _res, next) => next()),
 }));
 
+// Stub auth so unit tests can exercise invoice-state handler behavior without
+// requiring a valid Authorization header on every request.
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
 const {
   INVOICE_STATES,
   VALID_TRANSITIONS,

--- a/tests/invoice.stateValidation.test.js
+++ b/tests/invoice.stateValidation.test.js
@@ -17,6 +17,10 @@
 const request = require('supertest');
 const express = require('express');
 
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
 const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
 const {
   safeParseTransitionBody,
@@ -54,9 +58,13 @@ function repeat(n) {
   return 'x'.repeat(n);
 }
 
-/** Performs a POST /transition with the supplied body. */
+/** Performs a POST /:id/transition with the supplied body. */
+const TEST_INVOICE_ID = 'inv-001';
 function postTransition(body) {
-  return request(buildApp()).post('/api/invoices/transition').send(body);
+  return request(buildApp())
+    .post(`/api/invoices/${TEST_INVOICE_ID}/transition`)
+    .set('x-tenant-id', 'tenant-alpha')
+    .send(body);
 }
 
 // ---------------------------------------------------------------------------
@@ -694,7 +702,7 @@ describe('POST /api/invoices/transition — route integration', () => {
     // assert the route integration with a body that the JSON parser
     // definitely accepts: an object literal whose `req.body` is null.
     const res = await request(buildApp())
-      .post('/api/invoices/transition')
+      .post(`/api/invoices/${TEST_INVOICE_ID}/transition`)
       .set('x-test-null-body', '1')
       .send({});
     expect(res.status).toBe(400);
@@ -702,7 +710,7 @@ describe('POST /api/invoices/transition — route integration', () => {
 
   it('returns INVALID_BODY_TYPE for array body', async () => {
     const res = await request(buildApp())
-      .post('/api/invoices/transition')
+      .post(`/api/invoices/${TEST_INVOICE_ID}/transition`)
       .send([{ targetState: 'pending' }]);
     expect(res.status).toBe(400);
     expect(res.body.fieldErrors._root).toBe('INVALID_BODY_TYPE');

--- a/tests/invoiceStateRateLimit.test.js
+++ b/tests/invoiceStateRateLimit.test.js
@@ -14,6 +14,10 @@ const request = require('supertest');
 // missing invoiceStateLimiter). Use the real implementation for these tests.
 jest.unmock('../src/middleware/rateLimit');
 
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
 const WINDOW_MS = 200;
 const MAX = 2;
 
@@ -42,16 +46,16 @@ describe('invoice-state rate limiting (#739)', () => {
 
   it('allows requests up to the configured max (at-limit)', async () => {
     for (let i = 0; i < MAX; i++) {
-      const res = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+      const res = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
       expect(res.status).not.toBe(429);
     }
   });
 
   it('returns 429 with a Retry-After header once the max is exceeded', async () => {
     for (let i = 0; i < MAX; i++) {
-      await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+      await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     }
-    const res = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const res = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(res.status).toBe(429);
     expect(res.headers).toHaveProperty('retry-after');
     expect(Number(res.headers['retry-after'])).toBeGreaterThanOrEqual(0);
@@ -59,27 +63,27 @@ describe('invoice-state rate limiting (#739)', () => {
 
   it('resets the count after the configured window elapses', async () => {
     for (let i = 0; i < MAX; i++) {
-      await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+      await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     }
-    const blocked = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const blocked = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(blocked.status).toBe(429);
 
     await new Promise((resolve) => setTimeout(resolve, WINDOW_MS + 100));
 
-    const afterReset = await request(app).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const afterReset = await request(app).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(afterReset.status).not.toBe(429);
   });
 
   it('rate-limits per client key (API key) independently of other clients', async () => {
     for (let i = 0; i < MAX; i++) {
       await request(app)
-        .post('/api/invoices/transition')
+        .post('/api/invoices/test-tenant/transition')
         .set('x-tenant-id', 'test-tenant')
         .set('x-api-key', 'client-a')
         .send(body);
     }
     const blockedA = await request(app)
-      .post('/api/invoices/transition')
+      .post('/api/invoices/test-tenant/transition')
       .set('x-tenant-id', 'test-tenant')
       .set('x-api-key', 'client-a')
       .send(body);
@@ -87,7 +91,7 @@ describe('invoice-state rate limiting (#739)', () => {
 
     // A different API key must not be affected by client-a's usage.
     const clientB = await request(app)
-      .post('/api/invoices/transition')
+      .post('/api/invoices/test-tenant/transition')
       .set('x-tenant-id', 'test-tenant')
       .set('x-api-key', 'client-b')
       .send(body);
@@ -103,9 +107,9 @@ describe('invoice-state rate limiting (#739)', () => {
     smallApp.use(express.json());
     smallApp.use('/api/invoices', routesWithMaxOne);
 
-    const first = await request(smallApp).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const first = await request(smallApp).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(first.status).not.toBe(429);
-    const second = await request(smallApp).post('/api/invoices/transition').set('x-tenant-id', 'test-tenant').send(body);
+    const second = await request(smallApp).post('/api/invoices/test-tenant/transition').set('x-tenant-id', 'test-tenant').send(body);
     expect(second.status).toBe(429);
   });
 });

--- a/tests/unit/cors.rateLimit.test.js
+++ b/tests/unit/cors.rateLimit.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * @fileoverview Unit tests for the CORS request rate limiter.
+ *
+ * Coverage:
+ *  • `corsLimiter` module export and env-var parsing.
+ *  • 429 body shape and `Retry-After` header on over-limit.
+ *  • Browser requests with an Origin header are rate limited.
+ *  • Non-browser requests without Origin bypass the CORS limiter.
+ *  • API keys get separate buckets from IP-only clients.
+ *  • Window reset restores the bucket after the configured period.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.CORS_RATE_LIMIT_WINDOW_MS = '60000';
+process.env.CORS_RATE_LIMIT_MAX = '2';
+
+jest.unmock('../../src/middleware/rateLimit');
+
+const express = require('express');
+const request = require('supertest');
+const cors = require('cors');
+const rateLimitModule = require('../../src/middleware/rateLimit');
+const { createCorsOptions } = require('../../src/config/cors');
+
+function buildApp() {
+  const app = express();
+  app.use(rateLimitModule.createCorsRateLimiter());
+  app.use(cors(createCorsOptions({ NODE_ENV: 'production', CORS_ALLOWED_ORIGINS: 'https://app.example.com' })));
+  app.get('/hello', (req, res) => {
+    res.json({ message: 'ok' });
+  });
+  app.options('/hello', cors(createCorsOptions({ NODE_ENV: 'production', CORS_ALLOWED_ORIGINS: 'https://app.example.com' })));
+  return app;
+}
+
+let app;
+
+beforeEach(() => {
+  jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+  app = buildApp();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('corsLimiter', () => {
+  it('allows requests with an allowed origin until the limit is reached', async () => {
+    const first = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+    const second = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+    const third = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    expect(third.headers['retry-after']).toMatch(/^\d+$/);
+    expect(third.body).toMatchObject({
+      code: 'RATE_LIMITED',
+      scope: 'cors',
+      retryable: true,
+      title: 'Too Many Requests',
+    });
+  });
+
+  it('skips rate limiting for requests without an Origin header', async () => {
+    const r1 = await request(app).get('/hello');
+    const r2 = await request(app).get('/hello');
+    const r3 = await request(app).get('/hello');
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(200);
+  });
+
+  it('separates buckets by X-API-Key when present', async () => {
+    const r1 = await request(app).get('/hello').set('Origin', 'https://app.example.com').set('x-api-key', 'key-a');
+    const r2 = await request(app).get('/hello').set('Origin', 'https://app.example.com').set('x-api-key', 'key-a');
+    const r3 = await request(app).get('/hello').set('Origin', 'https://app.example.com').set('x-api-key', 'key-a');
+    const other = await request(app).get('/hello').set('Origin', 'https://app.example.com').set('x-api-key', 'key-b');
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(429);
+    expect(other.status).toBe(200);
+  });
+
+  it('resets the bucket after the configured window elapses', async () => {
+    const r1 = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+    const r2 = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+    const blocked = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(blocked.status).toBe(429);
+
+    jest.advanceTimersByTime(60_001);
+
+    const recovered = await request(app).get('/hello').set('Origin', 'https://app.example.com');
+    expect(recovered.status).toBe(200);
+  });
+
+  it('applies to CORS preflight requests as well as actual browser requests', async () => {
+    const preflight1 = await request(app)
+      .options('/hello')
+      .set('Origin', 'https://app.example.com')
+      .set('Access-Control-Request-Method', 'GET');
+    const preflight2 = await request(app)
+      .options('/hello')
+      .set('Origin', 'https://app.example.com')
+      .set('Access-Control-Request-Method', 'GET');
+    const preflight3 = await request(app)
+      .options('/hello')
+      .set('Origin', 'https://app.example.com')
+      .set('Access-Control-Request-Method', 'GET');
+
+    expect(preflight1.status).toBe(204);
+    expect(preflight2.status).toBe(204);
+    expect(preflight3.status).toBe(429);
+  });
+});


### PR DESCRIPTION
Closes #749 


**Add CORS Rate Limiting**

- **Summary:** Adds per-client rate limiting for cross-origin requests so abusive CORS traffic gets 429 + `Retry-After` and standard problem JSON.
- **What I changed:** Implemented `createCorsRateLimiter` and `corsRateLimitHandler`, mounted the limiter before CORS evaluation in app.js, and added unit tests that exercise origin checking, X-API-Key bucket separation, preflight handling, and window reset.
- **Files:** rateLimit.js, app.js, cors.rateLimit.test.js
- **Key symbols:** `createCorsRateLimiter`, `corsRateLimitHandler`, `corsLimiter`
- **Testing:** Unit tests added and run locally (cors.rateLimit.test.js) — all tests pass in CI-like local runs.
- **Notes:** Config knobs added: `CORS_RATE_LIMIT_WINDOW_MS`, `CORS_RATE_LIMIT_MAX`. No behavioral change for non-browser requests (limiter skips when no `Origin` header).

**Restore Metrics Rate Limiter Export**

- **Summary:** Fixes a ReferenceError by restoring metrics limiter exports so metrics-related rate limiting can be created and used by tests and the app.
- **What I changed:** Restored `metricsRateLimitHandler`, `createMetricsRateLimiter`, and `metricsLimiter` in the central rate-limit module.
- **Files:** rateLimit.js
- **Key symbols:** `createMetricsRateLimiter`, `metricsLimiter`, `metricsRateLimitHandler`
- **Testing:** Fixes failing tests that previously threw `ReferenceError: metricsLimiter is not defined`. Note: tests warn and fall back to MemoryStore when Redis is unavailable in the test environment.

**Add Invoice-State Runbook**

- **Summary:** Adds operational runbook for invoice-state to docs so oncall and engineers have clear run/restore/runbook steps.
- **What I changed:** Created runbook-invoice-state.md with troubleshooting, operational checks, and common remediation s