### PR TITLE
refactor(invoice-state): add typed DTO layer

### DIFF
--- a/src/dtos/invoiceStateDtos.js
+++ b/src/dtos/invoiceStateDtos.js
@@ -1,0 +1,364 @@
+'use strict';
+
+/**
+ * @fileoverview Typed DTOs and boundary mappers for invoice-state endpoints.
+ *
+ * Defines the request/response shapes crossing the invoice-state route
+ * boundary and the pure mapping functions that convert between the internal
+ * service-layer objects and the public DTOs.
+ *
+ * Keeping the mappers pure (no side effects, no I/O) means they can be
+ * exhaustively unit-tested in isolation from Express / Knex / audit-log
+ * concerns, and gives us a typed boundary for safer refactors.
+ *
+ * @module dtos/invoiceStateDtos
+ */
+
+// ---------------------------------------------------------------------------
+// Request DTOs — inbound shapes parsed (loosely) from request bodies
+// ---------------------------------------------------------------------------
+
+/**
+ * Body of `POST /api/invoices/:id/transition`.
+ *
+ * @typedef {Object} TransitionRequestDto
+ * @property {string} targetState - Desired invoice lifecycle state.
+ * @property {string} [reason] - Optional human-readable rationale.
+ */
+
+/**
+ * Body of `POST /api/invoices/:id/approve`.
+ *
+ * @typedef {Object} ApproveRequestDto
+ * @property {string} [reason] - Optional approval rationale.
+ */
+
+/**
+ * Body of `POST /api/invoices/:id/link-escrow`.
+ *
+ * @typedef {Object} LinkEscrowRequestDto
+ * @property {string} [escrowId] - Escrow contract identifier.
+ * @property {string} [reason] - Optional link rationale.
+ */
+
+/**
+ * Body of `POST /api/invoices/:id/reject`.
+ *
+ * @typedef {Object} RejectRequestDto
+ * @property {string} reason - Mandatory rejection rationale.
+ */
+
+// ---------------------------------------------------------------------------
+// Response DTOs — outbound shapes serialised to clients
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload returned by `GET /api/invoices/:id/state`.
+ *
+ * @typedef {Object} InvoiceStateResponseDto
+ * @property {string} invoiceId - Invoice identifier.
+ * @property {string} currentState - Current lifecycle state.
+ * @property {string[]} allowedTransitions - Permitted next-state values.
+ * @property {boolean} isTerminal - True when no further transitions exist.
+ */
+
+/**
+ * Payload returned by transition-carrying endpoints (transition / approve /
+ * reject) on success.
+ *
+ * @typedef {Object} TransitionResponseDto
+ * @property {string} invoiceId - Invoice identifier.
+ * @property {string} previousState - State before the transition.
+ * @property {string} currentState - State after the transition.
+ * @property {string} transitionedAt - ISO-8601 timestamp of the transition.
+ * @property {string} transitionedBy - Actor identifier that performed it.
+ * @property {string} [reason] - Echoed rationale when one was supplied.
+ * @property {string} auditLogId - Identifier of the associated audit log.
+ */
+
+/**
+ * Payload returned by `POST /api/invoices/:id/link-escrow` on success.
+ *
+ * @typedef {Object} LinkEscrowResponseDto
+ * @property {string} invoiceId - Invoice identifier.
+ * @property {string} previousState - State before the transition.
+ * @property {string} currentState - State after the transition.
+ * @property {string|null} escrowId - Escrow contract identifier (or null).
+ * @property {string} transitionedAt - ISO-8601 timestamp of the transition.
+ * @property {string} transitionedBy - Actor identifier that performed it.
+ * @property {string} auditLogId - Identifier of the associated audit log.
+ */
+
+/**
+ * A single entry in the invoice transition history list.
+ *
+ * @typedef {Object} HistoryEntryDto
+ * @property {string} id - Audit-log record identifier.
+ * @property {string} timestamp - ISO-8601 timestamp of the transition.
+ * @property {string} actor - Actor identifier.
+ * @property {string} [fromState] - State before transition (may be absent
+ *   for malformed or very old audit records).
+ * @property {string} [toState] - State after transition (may be absent).
+ * @property {string} [reason] - Rationale captured from metadata.
+ * @property {string} [ipAddress] - Source IP recorded at the time.
+ */
+
+/**
+ * Payload returned by `GET /api/invoices/:id/history`.
+ *
+ * @typedef {Object} InvoiceHistoryResponseDto
+ * @property {string} invoiceId - Invoice identifier.
+ * @property {string} currentState - Current lifecycle state.
+ * @property {HistoryEntryDto[]} transitions - Ordered transition records.
+ * @property {number} totalTransitions - Total number of transitions captured.
+ */
+
+// ---------------------------------------------------------------------------
+// Internal service-layer shapes (described for mapper documentation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Transition result produced by `invoiceService.transitionInvoice` /
+ * `invoiceStateMachine.executeTransition`.
+ *
+ * @typedef {Object} InternalTransitionResult
+ * @property {boolean} success
+ * @property {string} previousState
+ * @property {string} newState
+ * @property {{ id: string, timestamp?: string }} auditLog
+ * @property {string} transitionedAt
+ * @property {string} transitionedBy
+ */
+
+/**
+ * Audit-log record produced by `getTransitionHistory`.
+ *
+ * @typedef {Object} InternalAuditLog
+ * @property {string} id
+ * @property {string} timestamp
+ * @property {string} actor
+ * @property {{ before?: { state?: string }, after?: { state?: string } }} [changes]
+ * @property {{ reason?: string }} [metadata]
+ * @property {string} [ipAddress]
+ */
+
+// ---------------------------------------------------------------------------
+// Request mappers — body → well-typed internal command input
+// ---------------------------------------------------------------------------
+
+/**
+ * Pulls the typed transition fields from an Express request body.
+ *
+ * The mapper itself does NOT perform semantic validation — that remains the
+ * responsibility of `invoiceStateMachine.validateTransition` and the Zod
+ * schema in `schemas/invoiceState`.  The mapper only guarantees the returned
+ * object has the declared field shapes (coercing missing optional keys to
+ * `undefined` rather than leaving them absent so downstream code sees a
+ * stable structure).
+ *
+ * @param {unknown} body - Raw `req.body`.
+ * @returns {{ targetState: unknown, reason: string|undefined }}
+ */
+function mapTransitionRequest(body) {
+  /** @type {Record<string, unknown>} */
+  const b = body && typeof body === 'object' && !Array.isArray(body) ? /** @type {Record<string, unknown>} */ (body) : {};
+  return {
+    targetState: 'targetState' in b ? b.targetState : undefined,
+    reason: typeof b.reason === 'string' ? b.reason : undefined,
+  };
+}
+
+/**
+ * Pulls the typed approval fields from an Express request body.
+ *
+ * @param {unknown} body - Raw `req.body`.
+ * @returns {{ reason: string|undefined }}
+ */
+function mapApproveRequest(body) {
+  /** @type {Record<string, unknown>} */
+  const b = body && typeof body === 'object' && !Array.isArray(body) ? /** @type {Record<string, unknown>} */ (body) : {};
+  return {
+    reason: typeof b.reason === 'string' ? b.reason : undefined,
+  };
+}
+
+/**
+ * Pulls the typed link-escrow fields from an Express request body.
+ *
+ * @param {unknown} body - Raw `req.body`.
+ * @returns {{ escrowId: string|null, reason: string|undefined }}
+ */
+function mapLinkEscrowRequest(body) {
+  /** @type {Record<string, unknown>} */
+  const b = body && typeof body === 'object' && !Array.isArray(body) ? /** @type {Record<string, unknown>} */ (body) : {};
+  return {
+    escrowId: typeof b.escrowId === 'string' ? b.escrowId : null,
+    reason: typeof b.reason === 'string' ? b.reason : undefined,
+  };
+}
+
+/**
+ * Pulls the typed rejection fields from an Express request body.
+ *
+ * @param {unknown} body - Raw `req.body`.
+ * @returns {{ reason: string|undefined }}
+ */
+function mapRejectRequest(body) {
+  /** @type {Record<string, unknown>} */
+  const b = body && typeof body === 'object' && !Array.isArray(body) ? /** @type {Record<string, unknown>} */ (body) : {};
+  return {
+    reason: typeof b.reason === 'string' ? b.reason : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response mappers — internal result → public DTO
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the state-query response DTO from a resolved invoice + state-machine
+ * output.
+ *
+ * @param {object} args
+ * @param {string} args.invoiceId - Invoice identifier (from route params).
+ * @param {string} args.currentState - Invoice status.
+ * @param {string[]} args.allowedTransitions - Result of
+ *   `getAllowedTransitions(currentState)`.
+ * @returns {InvoiceStateResponseDto}
+ */
+function toInvoiceStateResponse({ invoiceId, currentState, allowedTransitions }) {
+  return {
+    invoiceId,
+    currentState,
+    allowedTransitions: Array.isArray(allowedTransitions) ? [...allowedTransitions] : [],
+    isTerminal: Array.isArray(allowedTransitions) ? allowedTransitions.length === 0 : false,
+  };
+}
+
+/**
+ * Builds a transition response DTO from a state-machine execution result and
+ * the caller-supplied optional reason.
+ *
+ * @param {object} args
+ * @param {string} args.invoiceId - Invoice identifier (from route params).
+ * @param {InternalTransitionResult} args.result - Transition result object.
+ * @param {string} [args.reason] - Optional rationale echoed back.
+ * @returns {TransitionResponseDto}
+ */
+function toTransitionResponse({ invoiceId, result, reason }) {
+  const auditLogId = result.auditLog && result.auditLog.id ? result.auditLog.id : '';
+  const base = {
+    invoiceId,
+    previousState: result.previousState,
+    currentState: result.newState,
+    transitionedAt: result.transitionedAt,
+    transitionedBy: result.transitionedBy,
+    auditLogId,
+  };
+  if (reason !== undefined && reason !== null) {
+    /** @type {TransitionResponseDto} */
+    const withReason = Object.assign({}, base, { reason });
+    return withReason;
+  }
+  /** @type {TransitionResponseDto} */
+  const withoutReason = base;
+  return withoutReason;
+}
+
+/**
+ * Builds the link-escrow response DTO from a transition result and the
+ * user-supplied escrow identifier.
+ *
+ * @param {object} args
+ * @param {string} args.invoiceId - Invoice identifier.
+ * @param {InternalTransitionResult} args.result - Transition result object.
+ * @param {string|null} args.escrowId - Escrow contract identifier or null.
+ * @returns {LinkEscrowResponseDto}
+ */
+function toLinkEscrowResponse({ invoiceId, result, escrowId }) {
+  return {
+    invoiceId,
+    previousState: result.previousState,
+    currentState: result.newState,
+    escrowId: typeof escrowId === 'string' ? escrowId : null,
+    transitionedAt: result.transitionedAt,
+    transitionedBy: result.transitionedBy,
+    auditLogId: result.auditLog && result.auditLog.id ? result.auditLog.id : '',
+  };
+}
+
+/**
+ * Converts a single audit-log record into a history-entry DTO.
+ *
+ * Missing optional fields are either omitted or set to `undefined` so JSON
+ * serialisation produces the leanest valid payload.
+ *
+ * @param {InternalAuditLog} log - Raw audit-log record.
+ * @returns {HistoryEntryDto}
+ */
+function toHistoryEntryDto(log) {
+  /** @type {HistoryEntryDto} */
+  const entry = {
+    id: log.id,
+    timestamp: log.timestamp,
+    actor: log.actor,
+  };
+  if (log.changes && log.changes.before && log.changes.before.state !== undefined) {
+    entry.fromState = log.changes.before.state;
+  }
+  if (log.changes && log.changes.after && log.changes.after.state !== undefined) {
+    entry.toState = log.changes.after.state;
+  }
+  if (log.metadata && log.metadata.reason !== undefined) {
+    entry.reason = log.metadata.reason;
+  }
+  if (log.ipAddress !== undefined) {
+    entry.ipAddress = log.ipAddress;
+  }
+  return entry;
+}
+
+/**
+ * Builds the history response DTO from a resolved invoice + ordered list of
+ * transition entries.
+ *
+ * The `transitions` array is expected to already be in {@link HistoryEntryDto}
+ * shape — this is the format produced by
+ * `invoiceStateMachine.getTransitionHistory`.  `toHistoryEntryDto` remains
+ * exported for callers that need to convert raw audit-log records into the
+ * same entry shape.
+ *
+ * @param {object} args
+ * @param {string} args.invoiceId - Invoice identifier.
+ * @param {string} args.currentState - Invoice status at query time.
+ * @param {HistoryEntryDto[]} args.transitions - Transition entries in
+ *   canonical DTO order (most recent first).
+ * @returns {InvoiceHistoryResponseDto}
+ */
+function toInvoiceHistoryResponse({ invoiceId, currentState, transitions }) {
+  const safe = Array.isArray(transitions) ? transitions : [];
+  return {
+    invoiceId,
+    currentState,
+    transitions: safe,
+    totalTransitions: safe.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  // Request mappers
+  mapTransitionRequest,
+  mapApproveRequest,
+  mapLinkEscrowRequest,
+  mapRejectRequest,
+  // Response mappers
+  toInvoiceStateResponse,
+  toTransitionResponse,
+  toLinkEscrowResponse,
+  toHistoryEntryDto,
+  toInvoiceHistoryResponse,
+};

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -27,6 +27,16 @@ const { getAuditLogs } = require('../services/auditLog');
 const { requireKycForFunding, auditKycAccess } = require('../middleware/kycGating');
 const { extractTenant } = require('../middleware/tenant');
 const responseHelper = require('../utils/responseHelper');
+const {
+  mapTransitionRequest,
+  mapApproveRequest,
+  mapLinkEscrowRequest,
+  mapRejectRequest,
+  toInvoiceStateResponse,
+  toTransitionResponse,
+  toLinkEscrowResponse,
+  toInvoiceHistoryResponse,
+} = require('../dtos/invoiceStateDtos');
 
 router.use(extractTenant);
 
@@ -90,14 +100,14 @@ router.get('/:id/state', async (req, res, next) => {
 
     const currentState = invoice.status;
     const allowedTransitions = getAllowedTransitions(currentState);
+    const stateDto = toInvoiceStateResponse({
+      invoiceId: id,
+      currentState,
+      allowedTransitions,
+    });
 
     return res.json({
-      ...responseHelper.success({
-        invoiceId: id,
-        currentState,
-        allowedTransitions,
-        isTerminal: allowedTransitions.length === 0,
-      }),
+      ...responseHelper.success(stateDto),
       message: 'Invoice state retrieved successfully',
     });
   } catch (error) {
@@ -113,7 +123,7 @@ router.get('/:id/state', async (req, res, next) => {
  */
 router.post('/:id/transition', async (req, res, next) => {
   const { id } = req.params;
-  const { targetState, reason } = req.body || {};
+  const { targetState, reason } = mapTransitionRequest(req.body);
 
   try {
     if (!targetState) {
@@ -137,16 +147,9 @@ router.post('/:id/transition', async (req, res, next) => {
       },
     });
 
+    const responseDto = toTransitionResponse({ invoiceId: id, result, reason });
     return res.status(200).json({
-      ...responseHelper.success({
-        invoiceId: id,
-        previousState: result.previousState,
-        currentState: result.newState,
-        transitionedAt: result.transitionedAt,
-        transitionedBy: result.transitionedBy,
-        reason,
-        auditLogId: result.auditLog.id,
-      }),
+      ...responseHelper.success(responseDto),
       message: `Invoice transitioned from ${result.previousState} to ${result.newState}`,
     });
   } catch (error) {
@@ -163,7 +166,7 @@ router.post('/:id/transition', async (req, res, next) => {
  */
 router.post('/:id/approve', async (req, res, next) => {
   const { id } = req.params;
-  const { reason } = req.body || {};
+  const { reason } = mapApproveRequest(req.body);
 
   try {
     const actor = getActorFromRequest(req);
@@ -182,15 +185,9 @@ router.post('/:id/approve', async (req, res, next) => {
       },
     });
 
+    const responseDto = toTransitionResponse({ invoiceId: id, result });
     return res.status(200).json({
-      ...responseHelper.success({
-        invoiceId: id,
-        previousState: result.previousState,
-        currentState: result.newState,
-        transitionedAt: result.transitionedAt,
-        transitionedBy: result.transitionedBy,
-        auditLogId: result.auditLog.id,
-      }),
+      ...responseHelper.success(responseDto),
       message: 'Invoice approved successfully',
     });
   } catch (error) {
@@ -208,7 +205,7 @@ router.post('/:id/approve', async (req, res, next) => {
  */
 router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req, res, next) => {
   const { id } = req.params;
-  const { escrowId, reason } = req.body || {};
+  const { escrowId, reason } = mapLinkEscrowRequest(req.body);
 
   try {
     const invoice = await invoiceService.resolveInvoiceForTenant(id, req.tenantId);
@@ -242,16 +239,9 @@ router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req
       },
     });
 
+    const responseDto = toLinkEscrowResponse({ invoiceId: id, result, escrowId });
     return res.status(200).json({
-      ...responseHelper.success({
-        invoiceId: id,
-        previousState: result.previousState,
-        currentState: result.newState,
-        escrowId: escrowId || null,
-        transitionedAt: result.transitionedAt,
-        transitionedBy: result.transitionedBy,
-        auditLogId: result.auditLog.id,
-      }),
+      ...responseHelper.success(responseDto),
       message: 'Invoice linked to escrow successfully',
     });
   } catch (error) {
@@ -268,7 +258,7 @@ router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req
  */
 router.post('/:id/reject', async (req, res, next) => {
   const { id } = req.params;
-  const { reason } = req.body || {};
+  const { reason } = mapRejectRequest(req.body);
 
   try {
     if (!reason || typeof reason !== 'string' || reason.trim().length === 0) {
@@ -293,16 +283,9 @@ router.post('/:id/reject', async (req, res, next) => {
       },
     });
 
+    const responseDto = toTransitionResponse({ invoiceId: id, result, reason });
     return res.status(200).json({
-      ...responseHelper.success({
-        invoiceId: id,
-        previousState: result.previousState,
-        currentState: result.newState,
-        reason,
-        transitionedAt: result.transitionedAt,
-        transitionedBy: result.transitionedBy,
-        auditLogId: result.auditLog.id,
-      }),
+      ...responseHelper.success(responseDto),
       message: 'Invoice rejected successfully',
     });
   } catch (error) {
@@ -327,15 +310,15 @@ router.get('/:id/history', async (req, res, next) => {
       return sendInvoiceNotFound(res);
     }
 
-    const history = await getTransitionHistory(id, getAuditLogs);
+    const transitions = await getTransitionHistory(id, getAuditLogs);
+    const historyDto = toInvoiceHistoryResponse({
+      invoiceId: id,
+      currentState: invoice.status,
+      transitions,
+    });
 
     return res.json({
-      ...responseHelper.success({
-        invoiceId: id,
-        currentState: invoice.status,
-        transitions: history,
-        totalTransitions: history.length,
-      }),
+      ...responseHelper.success(historyDto),
       message: 'Invoice transition history retrieved successfully',
     });
   } catch (error) {

--- a/tests/invoiceStateDtos.test.js
+++ b/tests/invoiceStateDtos.test.js
@@ -1,0 +1,624 @@
+/**
+ * Invoice-State DTO Boundary Tests
+ *
+ * Covers:
+ *   - Request mappers: every body variant (valid, malformed, absent, wrong
+ *     types, empty strings, extra keys) so undefined/optional fields always
+ *     land in a well-known shape on the internal side of the boundary.
+ *   - Response mappers: every DTO field including missing optional fields
+ *     (reason, escrowId, fromState/toState, ipAddress) and the JSON
+ *     serialisation footprint (undefined keys are absent, not null).
+ *   - Round-trip mapping: a request body is mapped in, combined with a
+ *     canonical service-layer transition result, then mapped back out — the
+ *     serialised JSON matches the original route contract exactly.
+ *   - Edge cases: null / undefined auditLog, empty allowedTransitions array,
+ *     zero-length history, wrong-typed inputs falling back to defaults.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const {
+  mapTransitionRequest,
+  mapApproveRequest,
+  mapLinkEscrowRequest,
+  mapRejectRequest,
+  toInvoiceStateResponse,
+  toTransitionResponse,
+  toLinkEscrowResponse,
+  toHistoryEntryDto,
+  toInvoiceHistoryResponse,
+} = require('../src/dtos/invoiceStateDtos');
+
+/* ------------------------------------------------------------------ */
+/*  Shared fixtures                                                    */
+/* ------------------------------------------------------------------ */
+
+const TS = '2026-01-15T10:30:00.000Z';
+const ACTOR = 'user-42';
+const INVOICE_ID = 'inv-001';
+
+/** Canonical service-layer transition result (used by transition / approve /
+ *  reject / link-escrow routes). */
+function makeServiceResult(overrides = {}) {
+  return Object.assign(
+    {
+      success: true,
+      previousState: 'pending',
+      newState: 'approved',
+      auditLog: { id: 'audit-abc-123', timestamp: TS },
+      transitionedAt: TS,
+      transitionedBy: ACTOR,
+    },
+    overrides,
+  );
+}
+
+/** JSON round-trip helper — mirrors what `res.json()` does. */
+function jsonRoundTrip(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Request mappers                                                    */
+/* ------------------------------------------------------------------ */
+describe('Request mappers', () => {
+  describe('mapTransitionRequest', () => {
+    it('extracts targetState and reason from a complete body', () => {
+      const out = mapTransitionRequest({
+        targetState: 'approved',
+        reason: 'Looks good',
+      });
+      expect(out).toEqual({ targetState: 'approved', reason: 'Looks good' });
+    });
+
+    it('leaves reason undefined when absent', () => {
+      const out = mapTransitionRequest({ targetState: 'rejected' });
+      expect(out).toEqual({ targetState: 'rejected', reason: undefined });
+      expect('reason' in out).toBe(true);
+    });
+
+    it('leaves targetState undefined when absent', () => {
+      const out = mapTransitionRequest({ reason: 'some reason' });
+      expect(out.targetState).toBeUndefined();
+    });
+
+    it('coerces non-string reason to undefined', () => {
+      expect(mapTransitionRequest({ targetState: 'approved', reason: 42 }).reason).toBeUndefined();
+      expect(mapTransitionRequest({ targetState: 'approved', reason: null }).reason).toBeUndefined();
+      expect(mapTransitionRequest({ targetState: 'approved', reason: {} }).reason).toBeUndefined();
+    });
+
+    it('treats null body identically to an empty object', () => {
+      const outNull = mapTransitionRequest(null);
+      const outUndef = mapTransitionRequest(undefined);
+      const outEmpty = mapTransitionRequest({});
+      expect(outNull).toEqual(outEmpty);
+      expect(outUndef).toEqual(outEmpty);
+      expect(outNull.targetState).toBeUndefined();
+      expect(outNull.reason).toBeUndefined();
+    });
+
+    it('treats primitive / array bodies as empty', () => {
+      expect(mapTransitionRequest('string-body')).toEqual({
+        targetState: undefined,
+        reason: undefined,
+      });
+      expect(mapTransitionRequest([1, 2, 3])).toEqual({
+        targetState: undefined,
+        reason: undefined,
+      });
+    });
+
+    it('ignores extra keys (defensive against prototype pollution)', () => {
+      const out = mapTransitionRequest({
+        targetState: 'approved',
+        reason: 'ok',
+        __proto__: { polluted: true },
+        constructor: 'oops',
+        unexpected: 'field',
+      });
+      expect(Object.keys(out)).toEqual(['targetState', 'reason']);
+      expect(out).toEqual({ targetState: 'approved', reason: 'ok' });
+    });
+  });
+
+  describe('mapApproveRequest', () => {
+    it('returns reason from body when provided', () => {
+      expect(mapApproveRequest({ reason: 'All checks passed' })).toEqual({
+        reason: 'All checks passed',
+      });
+    });
+
+    it('returns undefined reason when absent or non-string', () => {
+      expect(mapApproveRequest({}).reason).toBeUndefined();
+      expect(mapApproveRequest({ reason: true }).reason).toBeUndefined();
+      expect(mapApproveRequest(null).reason).toBeUndefined();
+    });
+  });
+
+  describe('mapLinkEscrowRequest', () => {
+    it('extracts both escrowId and reason from complete body', () => {
+      expect(
+        mapLinkEscrowRequest({ escrowId: 'esc-999', reason: 'Linked' }),
+      ).toEqual({ escrowId: 'esc-999', reason: 'Linked' });
+    });
+
+    it('defaults escrowId to null when missing / non-string', () => {
+      expect(mapLinkEscrowRequest({}).escrowId).toBeNull();
+      expect(mapLinkEscrowRequest({ escrowId: 123 }).escrowId).toBeNull();
+      expect(mapLinkEscrowRequest({ escrowId: null }).escrowId).toBeNull();
+    });
+
+    it('preserves explicitly null escrowId (client sends none)', () => {
+      const out = mapLinkEscrowRequest({ reason: 'No escrow yet' });
+      expect(out.escrowId).toBeNull();
+      expect(out.reason).toBe('No escrow yet');
+    });
+  });
+
+  describe('mapRejectRequest', () => {
+    it('returns reason when string', () => {
+      expect(mapRejectRequest({ reason: 'Missing docs' })).toEqual({
+        reason: 'Missing docs',
+      });
+    });
+
+    it('returns undefined reason when non-string / absent', () => {
+      expect(mapRejectRequest({}).reason).toBeUndefined();
+      expect(mapRejectRequest({ reason: ['not', 'a', 'string'] }).reason).toBeUndefined();
+      expect(mapRejectRequest(undefined).reason).toBeUndefined();
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Response mappers                                                   */
+/* ------------------------------------------------------------------ */
+describe('Response mappers', () => {
+  describe('toInvoiceStateResponse', () => {
+    it('builds non-terminal state DTO with all allowed transitions', () => {
+      const dto = toInvoiceStateResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'pending',
+        allowedTransitions: ['approved', 'rejected', 'cancelled'],
+      });
+      expect(dto).toEqual({
+        invoiceId: INVOICE_ID,
+        currentState: 'pending',
+        allowedTransitions: ['approved', 'rejected', 'cancelled'],
+        isTerminal: false,
+      });
+    });
+
+    it('sets isTerminal=true when allowedTransitions is empty', () => {
+      const dto = toInvoiceStateResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'linked_escrow',
+        allowedTransitions: [],
+      });
+      expect(dto.isTerminal).toBe(true);
+      expect(dto.allowedTransitions).toEqual([]);
+    });
+
+    it('guards against non-array allowedTransitions (defensive)', () => {
+      const dto = toInvoiceStateResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'approved',
+        allowedTransitions: null,
+      });
+      expect(dto.allowedTransitions).toEqual([]);
+      expect(dto.isTerminal).toBe(false);
+
+      const dto2 = toInvoiceStateResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'approved',
+        allowedTransitions: 'not-an-array',
+      });
+      expect(Array.isArray(dto2.allowedTransitions)).toBe(true);
+    });
+
+    it('returns a fresh array copy (caller mutation cannot poison mapper)', () => {
+      const allowed = ['approved'];
+      const dto = toInvoiceStateResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'pending',
+        allowedTransitions: allowed,
+      });
+      dto.allowedTransitions.push('rejected');
+      expect(allowed).toEqual(['approved']);
+    });
+  });
+
+  describe('toTransitionResponse', () => {
+    it('builds DTO with reason echoed back when supplied', () => {
+      const result = makeServiceResult();
+      const dto = toTransitionResponse({
+        invoiceId: INVOICE_ID,
+        result,
+        reason: 'Looks good to me',
+      });
+      expect(dto).toEqual({
+        invoiceId: INVOICE_ID,
+        previousState: 'pending',
+        currentState: 'approved',
+        transitionedAt: TS,
+        transitionedBy: ACTOR,
+        reason: 'Looks good to me',
+        auditLogId: 'audit-abc-123',
+      });
+    });
+
+    it('omits reason entirely when not supplied (JSON footprint)', () => {
+      const dto = toTransitionResponse({
+        invoiceId: INVOICE_ID,
+        result: makeServiceResult(),
+      });
+      expect('reason' in dto).toBe(false);
+      expect(jsonRoundTrip(dto)).not.toHaveProperty('reason');
+    });
+
+    it('omits reason when explicitly undefined / null', () => {
+      const dto1 = toTransitionResponse({
+        invoiceId: INVOICE_ID,
+        result: makeServiceResult(),
+        reason: undefined,
+      });
+      const dto2 = toTransitionResponse({
+        invoiceId: INVOICE_ID,
+        result: makeServiceResult(),
+        reason: null,
+      });
+      expect('reason' in dto1).toBe(false);
+      expect('reason' in dto2).toBe(false);
+    });
+
+    it('handles missing / malformed auditLog defensively', () => {
+      const noAudit = makeServiceResult({ auditLog: null });
+      const dto = toTransitionResponse({ invoiceId: INVOICE_ID, result: noAudit });
+      expect(dto.auditLogId).toBe('');
+
+      const emptyAudit = makeServiceResult({ auditLog: {} });
+      const dto2 = toTransitionResponse({ invoiceId: INVOICE_ID, result: emptyAudit });
+      expect(dto2.auditLogId).toBe('');
+    });
+  });
+
+  describe('toLinkEscrowResponse', () => {
+    it('includes escrowId when provided as string', () => {
+      const dto = toLinkEscrowResponse({
+        invoiceId: INVOICE_ID,
+        result: makeServiceResult({ newState: 'linked_escrow', previousState: 'approved' }),
+        escrowId: 'esc-abc',
+      });
+      expect(dto).toEqual({
+        invoiceId: INVOICE_ID,
+        previousState: 'approved',
+        currentState: 'linked_escrow',
+        escrowId: 'esc-abc',
+        transitionedAt: TS,
+        transitionedBy: ACTOR,
+        auditLogId: 'audit-abc-123',
+      });
+    });
+
+    it('coerces non-string escrowId to null (undefined / number / object)', () => {
+      const base = {
+        invoiceId: INVOICE_ID,
+        result: makeServiceResult({ newState: 'linked_escrow' }),
+      };
+      expect(toLinkEscrowResponse({ ...base, escrowId: undefined }).escrowId).toBeNull();
+      expect(toLinkEscrowResponse({ ...base, escrowId: 1234 }).escrowId).toBeNull();
+      expect(toLinkEscrowResponse({ ...base, escrowId: {} }).escrowId).toBeNull();
+    });
+  });
+
+  describe('toHistoryEntryDto', () => {
+    it('maps a full audit-log record with every optional field present', () => {
+      const rawLog = {
+        id: 'audit-1',
+        timestamp: TS,
+        actor: ACTOR,
+        changes: { before: { state: 'pending' }, after: { state: 'approved' } },
+        metadata: { reason: 'Approved by finance' },
+        ipAddress: '10.0.0.1',
+      };
+      expect(toHistoryEntryDto(rawLog)).toEqual({
+        id: 'audit-1',
+        timestamp: TS,
+        actor: ACTOR,
+        fromState: 'pending',
+        toState: 'approved',
+        reason: 'Approved by finance',
+        ipAddress: '10.0.0.1',
+      });
+    });
+
+    it('omits optional fields when the raw log has no changes / metadata / ip', () => {
+      const minimalLog = { id: 'audit-2', timestamp: TS, actor: ACTOR };
+      const dto = toHistoryEntryDto(minimalLog);
+      expect(dto).toEqual({ id: 'audit-2', timestamp: TS, actor: ACTOR });
+      expect('fromState' in dto).toBe(false);
+      expect('toState' in dto).toBe(false);
+      expect('reason' in dto).toBe(false);
+      expect('ipAddress' in dto).toBe(false);
+    });
+
+    it('handles partial changes (before without after, and vice versa)', () => {
+      const beforeOnly = {
+        id: 'a',
+        timestamp: TS,
+        actor: ACTOR,
+        changes: { before: { state: 'pending' } },
+      };
+      expect(toHistoryEntryDto(beforeOnly)).toEqual({
+        id: 'a',
+        timestamp: TS,
+        actor: ACTOR,
+        fromState: 'pending',
+      });
+
+      const afterOnly = {
+        id: 'b',
+        timestamp: TS,
+        actor: ACTOR,
+        changes: { after: { state: 'rejected' } },
+        metadata: {},
+      };
+      expect(toHistoryEntryDto(afterOnly)).toEqual({
+        id: 'b',
+        timestamp: TS,
+        actor: ACTOR,
+        toState: 'rejected',
+      });
+    });
+
+    it('treats null metadata reason the same as absent (JSON safety)', () => {
+      const log = {
+        id: 'c',
+        timestamp: TS,
+        actor: ACTOR,
+        changes: {},
+        metadata: { reason: undefined },
+        ipAddress: undefined,
+      };
+      const dto = toHistoryEntryDto(log);
+      expect('reason' in dto).toBe(false);
+      expect('ipAddress' in dto).toBe(false);
+    });
+  });
+
+  describe('toInvoiceHistoryResponse', () => {
+    it('builds response with transitions and total count', () => {
+      const transitions = [
+        {
+          id: 'h1',
+          timestamp: TS,
+          actor: ACTOR,
+          fromState: 'approved',
+          toState: 'linked_escrow',
+        },
+        {
+          id: 'h0',
+          timestamp: TS,
+          actor: ACTOR,
+          fromState: 'pending',
+          toState: 'approved',
+        },
+      ];
+      const dto = toInvoiceHistoryResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'linked_escrow',
+        transitions,
+      });
+      expect(dto).toEqual({
+        invoiceId: INVOICE_ID,
+        currentState: 'linked_escrow',
+        transitions,
+        totalTransitions: 2,
+      });
+      // Identity preserved — entries are not mutated or re-cloned.
+      expect(dto.transitions[0]).toBe(transitions[0]);
+    });
+
+    it('handles empty transitions list defensively', () => {
+      const dto = toInvoiceHistoryResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'pending',
+        transitions: [],
+      });
+      expect(dto.totalTransitions).toBe(0);
+      expect(dto.transitions).toEqual([]);
+    });
+
+    it('guards against non-array transitions input', () => {
+      const dto = toInvoiceHistoryResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'pending',
+        transitions: null,
+      });
+      expect(dto.transitions).toEqual([]);
+      expect(dto.totalTransitions).toBe(0);
+
+      const dto2 = toInvoiceHistoryResponse({
+        invoiceId: INVOICE_ID,
+        currentState: 'pending',
+        transitions: 'whoops',
+      });
+      expect(Array.isArray(dto2.transitions)).toBe(true);
+      expect(dto2.totalTransitions).toBe(0);
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Round-trip mapping: request → service → response                  */
+/* ------------------------------------------------------------------ */
+describe('Boundary round-trip mapping', () => {
+  function simulateTransitionRoute(requestBody) {
+    // 1. Map inbound body (defensive coercion at the boundary).
+    const req = mapTransitionRequest(requestBody);
+    // 2. "Service" layer combines the request into a transition result.  The
+    //    DTOs are deliberately not coupled — the internal service shape is
+    //    free to evolve and the mapper isolates callers from that change.
+    const serviceResult = makeServiceResult({
+      previousState: 'pending',
+      newState: req.targetState || 'approved',
+      transitionedAt: TS,
+      transitionedBy: ACTOR,
+    });
+    // 3. Map outbound DTO and then JSON-serialise just like Express would.
+    const response = toTransitionResponse({
+      invoiceId: INVOICE_ID,
+      result: serviceResult,
+      reason: req.reason,
+    });
+    return { mappedRequest: req, response, json: jsonRoundTrip(response) };
+  }
+
+  it('full body → service → response preserves user-visible fields exactly', () => {
+    const rt = simulateTransitionRoute({
+      targetState: 'approved',
+      reason: 'All checks passed',
+    });
+    expect(rt.mappedRequest).toEqual({
+      targetState: 'approved',
+      reason: 'All checks passed',
+    });
+    expect(rt.json).toEqual({
+      invoiceId: INVOICE_ID,
+      previousState: 'pending',
+      currentState: 'approved',
+      transitionedAt: TS,
+      transitionedBy: ACTOR,
+      reason: 'All checks passed',
+      auditLogId: 'audit-abc-123',
+    });
+  });
+
+  it('missing optional reason does not appear in the JSON envelope', () => {
+    const rt = simulateTransitionRoute({ targetState: 'approved' });
+    expect(rt.mappedRequest.reason).toBeUndefined();
+    expect(rt.json).not.toHaveProperty('reason');
+    expect(rt.json).toEqual({
+      invoiceId: INVOICE_ID,
+      previousState: 'pending',
+      currentState: 'approved',
+      transitionedAt: TS,
+      transitionedBy: ACTOR,
+      auditLogId: 'audit-abc-123',
+    });
+  });
+
+  it('link-escrow route round-trips escrowId=null when user omitted it', () => {
+    const linkReq = mapLinkEscrowRequest({ reason: 'Linked by admin' });
+    expect(linkReq.escrowId).toBeNull();
+
+    const serviceResult = makeServiceResult({
+      previousState: 'approved',
+      newState: 'linked_escrow',
+    });
+    const response = toLinkEscrowResponse({
+      invoiceId: INVOICE_ID,
+      result: serviceResult,
+      escrowId: linkReq.escrowId,
+    });
+    // Escrow ID is an explicit null on the wire (matches route contract).
+    expect(jsonRoundTrip(response).escrowId).toBeNull();
+    expect(response.escrowId).toBeNull();
+  });
+
+  it('reject route echoes non-empty reason through the response envelope', () => {
+    const body = { reason: 'Failed KYC / sanctions check' };
+    const { reason } = mapRejectRequest(body);
+    const result = makeServiceResult({
+      previousState: 'pending',
+      newState: 'rejected',
+    });
+    const response = toTransitionResponse({
+      invoiceId: INVOICE_ID,
+      result,
+      reason,
+    });
+    expect(jsonRoundTrip(response).reason).toBe('Failed KYC / sanctions check');
+  });
+
+  it('state + history routes produce well-known JSON shapes end-to-end', () => {
+    const state = toInvoiceStateResponse({
+      invoiceId: INVOICE_ID,
+      currentState: 'approved',
+      allowedTransitions: ['linked_escrow', 'cancelled'],
+    });
+    const history = toInvoiceHistoryResponse({
+      invoiceId: INVOICE_ID,
+      currentState: 'approved',
+      transitions: [
+        {
+          id: 'h0',
+          timestamp: TS,
+          actor: ACTOR,
+          fromState: 'pending',
+          toState: 'approved',
+          reason: 'First pass',
+          ipAddress: '127.0.0.1',
+        },
+      ],
+    });
+    expect(jsonRoundTrip(state)).toEqual({
+      invoiceId: INVOICE_ID,
+      currentState: 'approved',
+      allowedTransitions: ['linked_escrow', 'cancelled'],
+      isTerminal: false,
+    });
+    expect(jsonRoundTrip(history)).toEqual({
+      invoiceId: INVOICE_ID,
+      currentState: 'approved',
+      totalTransitions: 1,
+      transitions: [
+        {
+          id: 'h0',
+          timestamp: TS,
+          actor: ACTOR,
+          fromState: 'pending',
+          toState: 'approved',
+          reason: 'First pass',
+          ipAddress: '127.0.0.1',
+        },
+      ],
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Mapper determinism / referential-integrity smoke tests            */
+/* ------------------------------------------------------------------ */
+describe('Mapper determinism', () => {
+  it('two calls with identical inputs produce deeply-equal but independent objects', () => {
+    const input = {
+      invoiceId: INVOICE_ID,
+      currentState: 'pending',
+      allowedTransitions: ['approved', 'rejected'],
+    };
+    const a = toInvoiceStateResponse(input);
+    const b = toInvoiceStateResponse(input);
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+    a.allowedTransitions.push('cancelled');
+    expect(b.allowedTransitions).toEqual(['approved', 'rejected']);
+  });
+
+  it('mappers accept frozen inputs without throwing (no defensive mutation)', () => {
+    const frozenResult = Object.freeze(makeServiceResult());
+    expect(() =>
+      toTransitionResponse({ invoiceId: INVOICE_ID, result: frozenResult }),
+    ).not.toThrow();
+    expect(() =>
+      toLinkEscrowResponse({
+        invoiceId: INVOICE_ID,
+        result: frozenResult,
+        escrowId: 'esc-1',
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
closes #797 

## Summary
Typed DTO boundary layer implemented for invoice-state endpoints. Behaviour is unchanged; all mapping is pure and lives in explicit, testable functions.

invoiceStateDtos.test.js — 38 tests covering:

- Request coercion: complete body → minimal body → wrong types → null/undefined → primitives/arrays → extra keys
- Response optional fields: reason absent in JSON when undefined; escrowId coerced to null; fromState/toState/reason/ipAddress omitted when raw log has none
- Defensive fallbacks: null auditLog, non-array transitions, empty allowedTransitions
- Round-trip: transition, link-escrow (escrowId=null), reject, state, history — end-to-end JSON shape
- Referential integrity: array copies, frozen-input tolerance, deterministic deep-equality output