### PR TITLE
feat(persistence): add strict input validation for persistence endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -586,6 +586,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1134,6 +1135,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1170,34 +1172,12 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2819,6 +2799,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2840,6 +2821,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -2876,6 +2858,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -3406,6 +3389,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4199,6 +4183,7 @@
       "integrity": "sha512-SwYl64hKHE/NeO2VSSG1y/4zIm0cNepyOZtQrOpLiNRHmH2FdWBOecNzsLiXCQdFCF9MCyoPXwAbaG2iMO0A7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -5462,6 +5447,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.1.tgz",
       "integrity": "sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.101.1"
       },
@@ -5629,6 +5615,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5651,16 +5638,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/shimmer": {
@@ -6716,6 +6693,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7553,6 +7531,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -8362,8 +8341,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
@@ -8879,6 +8857,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9253,6 +9232,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9296,6 +9276,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
       "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -10164,7 +10145,8 @@
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
       "integrity": "sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -11481,6 +11463,7 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
       "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -13860,8 +13843,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-inspector": {
       "version": "2.1.0",
@@ -15059,6 +15041,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15226,6 +15209,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15525,6 +15509,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -15637,6 +15622,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -15812,6 +15798,7 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-3.5.5.tgz",
       "integrity": "sha512-JEJAwo25p9c52JwQs1WunqANPs4PjJ+eepDLXvQJ390vEXsBexYdCDmsPPcYZaGpk0Umx0w85U1ruRodXusMzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -16112,6 +16099,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
       "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -16250,6 +16238,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/routes/sme/index.js
+++ b/src/routes/sme/index.js
@@ -1,5 +1,12 @@
 /**
  * SME Routes Index
+ *
+ * Persistence write endpoints:
+ *  - POST /api/sme/invoice/presigned-url
+ *  - POST /api/sme/invoice
+ *
+ * Both routes reject unknown fields, wrong types, and out-of-range values with
+ * a structured RFC 7807 400 before any storage call runs.
  */
 
 'use strict';
@@ -13,88 +20,100 @@ const storageService = require('../../services/storage');
 const { extractTenant } = require('../../middleware/tenant');
 const idempotencyMiddleware = require('../../middleware/idempotency');
 const logger = require('../../logger');
+const {
+  presignedUploadBodySchema,
+  directUploadBodySchema,
+  validatePersistenceBody,
+  MAX_FILE_SIZE_BYTES,
+} = require('../../schemas/persistence');
 
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: {
-    fileSize: 512 * 1024,
+    fileSize: MAX_FILE_SIZE_BYTES,
   },
 });
 
 router.use('/', metricsRoutes);
 
 // POST /api/sme/invoice/presigned-url - Request a presigned upload URL
-router.post('/invoice/presigned-url', express.json(), extractTenant, idempotencyMiddleware, async (req, res) => {
-  const requestLogger = logger.createRequestLogger(req);
-  try {
-    const { fileName, mimeType, fileSize } = req.body;
+router.post(
+  '/invoice/presigned-url',
+  express.json(),
+  extractTenant,
+  idempotencyMiddleware,
+  validatePersistenceBody(presignedUploadBodySchema),
+  async (req, res) => {
+    const requestLogger = logger.createRequestLogger(req);
+    try {
+      const { fileName, mimeType, fileSize, invoiceId: bodyInvoiceId } = req.validated;
+      const tenantId = req.tenantId;
+      const invoiceId = bodyInvoiceId || crypto.randomUUID();
 
-    if (!fileName || !mimeType || fileSize == null) {
-      return res.status(400).json({
-        error: 'fileName, mimeType, and fileSize are required',
+      const result = await storageService.getPresignedUploadUrl({
+        tenantId,
+        invoiceId,
+        fileName,
+        mimeType,
+        fileSize,
       });
+
+      res.json({
+        message: 'Presigned upload URL generated',
+        uploadUrl: result.url,
+        fileKey: result.key,
+        invoiceId,
+      });
+    } catch (error) {
+      if (error.code === 'INVALID_MIME_TYPE' || error.code === 'FILE_TOO_LARGE' || error.code === 'INVALID_TENANT_ID') {
+        return res.status(400).json({ error: error.message });
+      }
+      requestLogger.error({ err: error }, 'Presigned URL error');
+      res.status(500).json({ error: 'Failed to generate presigned upload URL' });
     }
-
-    const tenantId = req.tenantId;
-    const invoiceId = req.body.invoiceId || crypto.randomUUID();
-
-    const result = await storageService.getPresignedUploadUrl({
-      tenantId,
-      invoiceId,
-      fileName,
-      mimeType,
-      fileSize,
-    });
-
-    res.json({
-      message: 'Presigned upload URL generated',
-      uploadUrl: result.url,
-      fileKey: result.key,
-      invoiceId,
-    });
-  } catch (error) {
-    if (error.code === 'INVALID_MIME_TYPE' || error.code === 'FILE_TOO_LARGE' || error.code === 'INVALID_TENANT_ID') {
-      return res.status(400).json({ error: error.message });
-    }
-    requestLogger.error({ err: error }, 'Presigned URL error');
-    res.status(500).json({ error: 'Failed to generate presigned upload URL' });
   }
-});
+);
 
 // POST /api/sme/invoice - Upload PDF invoice
-router.post('/invoice', upload.single('invoice'), extractTenant, async (req, res) => {
-  const requestLogger = logger.createRequestLogger(req);
-  try {
-    if (!req.file) {
-      return res.status(400).json({ error: 'Invoice file is required' });
+router.post(
+  '/invoice',
+  upload.single('invoice'),
+  extractTenant,
+  validatePersistenceBody(directUploadBodySchema),
+  async (req, res) => {
+    const requestLogger = logger.createRequestLogger(req);
+    try {
+      if (!req.file) {
+        return res.status(400).json({ error: 'Invoice file is required' });
+      }
+
+      const tenantId = req.tenantId;
+      const invoiceId = req.validated.invoiceId || crypto.randomUUID();
+
+      const key = await storageService.uploadFile(
+        req.file.buffer,
+        req.file.originalname,
+        req.file.mimetype,
+        tenantId,
+        invoiceId
+      );
+
+      const signedUrl = await storageService.getSignedUrl(key);
+
+      res.json({
+        message: 'Invoice uploaded successfully',
+        fileKey: key,
+        signedUrl,
+        invoiceId,
+      });
+    } catch (error) {
+      if (error.code === 'INVALID_MIME_TYPE' || error.code === 'FILE_TOO_LARGE' || error.code === 'INVALID_TENANT_ID') {
+        return res.status(400).json({ error: error.message });
+      }
+      requestLogger.error({ err: error }, 'Upload error');
+      res.status(500).json({ error: 'Failed to upload invoice' });
     }
-
-    const tenantId = req.tenantId;
-    const invoiceId = req.body?.invoiceId || crypto.randomUUID();
-
-    const key = await storageService.uploadFile(
-      req.file.buffer,
-      req.file.originalname,
-      req.file.mimetype,
-      tenantId,
-      invoiceId
-    );
-
-    const signedUrl = await storageService.getSignedUrl(key);
-
-    res.json({
-      message: 'Invoice uploaded successfully',
-      fileKey: key,
-      signedUrl,
-      invoiceId,
-    });
-  } catch (error) {
-    if (error.code === 'INVALID_MIME_TYPE' || error.code === 'FILE_TOO_LARGE' || error.code === 'INVALID_TENANT_ID') {
-      return res.status(400).json({ error: error.message });
-    }
-    requestLogger.error({ err: error }, 'Upload error');
-    res.status(500).json({ error: 'Failed to upload invoice' });
   }
-});
+);
 
 module.exports = router;

--- a/src/schemas/persistence.js
+++ b/src/schemas/persistence.js
@@ -1,0 +1,230 @@
+'use strict';
+
+/**
+ * @fileoverview Strict Zod schemas for persistence write endpoints.
+ *
+ * The persistence endpoint family is:
+ *  - `POST /api/sme/invoice/presigned-url` — JSON body requesting a presigned upload
+ *  - `POST /api/sme/invoice` — multipart direct upload (optional form fields)
+ *
+ * Security guarantees applied to every schema:
+ *  - `.strict()` — unknown keys are rejected (prevents prototype-pollution payloads).
+ *  - String length bounds — prevents oversized inputs reaching the store.
+ *  - Numeric range checks — ensures fileSize is within the storage service limit.
+ *  - Enum allowlists — rejects arbitrary MIME types.
+ *
+ * Validation failures produce an RFC 7807 `application/problem+json` 400 body
+ * with a machine-readable top-level `code` and a `fieldErrors` map.
+ *
+ * @module schemas/persistence
+ */
+
+const { z } = require('zod');
+const {
+  ALLOWED_MIME_TYPES,
+  DEFAULT_MAX_FILE_SIZE,
+} = require('../services/storage');
+const { parseValidationErrors } = require('./invoice');
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Maximum length for a file name (matches storage `_sanitizeFilename` truncate). */
+const MAX_FILE_NAME_LENGTH = 255;
+
+/** Maximum length for an optional invoiceId path segment. */
+const MAX_INVOICE_ID_LENGTH = 128;
+
+/**
+ * Resolved max file size for request validation.
+ * Mirrors `StorageService.maxFileSize` / `BODY_LIMIT_INVOICE` parsing so the
+ * route rejects oversized declarations before calling the storage service.
+ *
+ * @type {number}
+ */
+const MAX_FILE_SIZE_BYTES = (() => {
+  const sizeStr = process.env.BODY_LIMIT_INVOICE || '512kb';
+  if (typeof sizeStr !== 'string' || sizeStr.trim() === '') {
+    return DEFAULT_MAX_FILE_SIZE;
+  }
+  const match = sizeStr.trim().match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?$/i);
+  if (!match) {
+    return DEFAULT_MAX_FILE_SIZE;
+  }
+  const value = parseFloat(match[1]);
+  const unit = (match[2] || 'b').toLowerCase();
+  const multipliers = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3 };
+  return Math.floor(value * multipliers[unit]);
+})();
+
+/** Machine-readable top-level error code for persistence validation failures. */
+const PERSISTENCE_VALIDATION_CODE = 'PERSISTENCE_VALIDATION_FAILED';
+
+/** Problem-details type URI for persistence validation errors. */
+const PERSISTENCE_PROBLEM_TYPE = 'https://liquifact.io/problems/validation-error';
+
+// ── Shared field schemas ─────────────────────────────────────────────────────
+
+/**
+ * Optional invoiceId: non-empty alphanumeric / `_` / `-`, max 128 chars.
+ * Matches `StorageService._validateInvoiceId`.
+ */
+const invoiceIdSchema = z
+  .string({ invalid_type_error: 'invoiceId must be a string' })
+  .min(1, { message: 'invoiceId must be a non-empty string' })
+  .max(MAX_INVOICE_ID_LENGTH, {
+    message: `invoiceId must not exceed ${MAX_INVOICE_ID_LENGTH} characters`,
+  })
+  .regex(/^[a-zA-Z0-9_-]+$/, {
+    message: 'invoiceId must contain only letters, digits, underscores, and hyphens',
+  });
+
+// ── Presigned upload body schema ─────────────────────────────────────────────
+
+/**
+ * Zod schema for `POST /api/sme/invoice/presigned-url` JSON bodies.
+ *
+ * Required: `fileName`, `mimeType`, `fileSize`.
+ * Optional: `invoiceId`.
+ * Unknown keys are rejected.
+ *
+ * @type {import('zod').ZodObject}
+ */
+const presignedUploadBodySchema = z
+  .object({
+    fileName: z
+      .string({
+        invalid_type_error: 'fileName must be a string',
+        required_error: 'fileName is required',
+      })
+      .min(1, { message: 'fileName must be a non-empty string' })
+      .max(MAX_FILE_NAME_LENGTH, {
+        message: `fileName must not exceed ${MAX_FILE_NAME_LENGTH} characters`,
+      })
+      .refine((v) => !v.includes('..') && !v.includes('/') && !v.includes('\\'), {
+        message: 'fileName must not contain path separators or traversal sequences',
+      }),
+
+    mimeType: z.enum(
+      /** @type {[string, ...string[]]} */ (ALLOWED_MIME_TYPES),
+      {
+        errorMap: () => ({
+          message: `mimeType must be one of: ${ALLOWED_MIME_TYPES.join(', ')}`,
+        }),
+        invalid_type_error: 'mimeType must be a string',
+        required_error: 'mimeType is required',
+      }
+    ),
+
+    fileSize: z
+      .number({
+        invalid_type_error: 'fileSize must be a number',
+        required_error: 'fileSize is required',
+      })
+      .int({ message: 'fileSize must be an integer' })
+      .min(1, { message: 'fileSize must be at least 1' })
+      .max(MAX_FILE_SIZE_BYTES, {
+        message: `fileSize must be at most ${MAX_FILE_SIZE_BYTES}`,
+      }),
+
+    invoiceId: invoiceIdSchema.optional(),
+  })
+  .strict();
+
+// ── Direct upload form-field schema ──────────────────────────────────────────
+
+/**
+ * Zod schema for optional form fields on `POST /api/sme/invoice` (multipart).
+ *
+ * Only `invoiceId` is accepted. Unknown keys are rejected.
+ * The binary file itself is validated separately (presence + storage service).
+ *
+ * @type {import('zod').ZodObject}
+ */
+const directUploadBodySchema = z
+  .object({
+    invoiceId: invoiceIdSchema.optional(),
+  })
+  .strict();
+
+// ── Response helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Builds an RFC 7807 problem+json body for a persistence validation failure.
+ *
+ * @param {import('express').Request} req
+ * @param {Record<string, string>} fieldErrors
+ * @param {string} [detail]
+ * @returns {object}
+ */
+function buildPersistenceValidationProblem(
+  req,
+  fieldErrors,
+  detail = 'Request body contains invalid, missing, or unknown fields.'
+) {
+  return {
+    type: PERSISTENCE_PROBLEM_TYPE,
+    title: 'Invalid persistence request body',
+    status: 400,
+    detail,
+    instance: req.originalUrl,
+    code: PERSISTENCE_VALIDATION_CODE,
+    fieldErrors,
+  };
+}
+
+/**
+ * Express middleware that validates `req.body` against a persistence Zod schema
+ * and responds with a structured 400 on failure.
+ *
+ * On success, attaches the parsed value to `req.validated`.
+ *
+ * @param {import('zod').ZodTypeAny} schema
+ * @returns {import('express').RequestHandler}
+ */
+function validatePersistenceBody(schema) {
+  return (req, res, next) => {
+    if (req.body === undefined || req.body === null) {
+      return res.status(400).json(
+        buildPersistenceValidationProblem(req, {
+          _root: 'Request body is required',
+        }, 'Request body is missing.')
+      );
+    }
+
+    if (typeof req.body !== 'object' || Array.isArray(req.body)) {
+      return res.status(400).json(
+        buildPersistenceValidationProblem(req, {
+          _root: 'Request body must be a JSON object',
+        }, 'Request body must be a plain object.')
+      );
+    }
+
+    const result = schema.safeParse(req.body);
+    if (result.success) {
+      req.validated = result.data;
+      return next();
+    }
+
+    const fieldErrors = parseValidationErrors(result.error);
+    return res
+      .status(400)
+      .type('application/problem+json')
+      .json(buildPersistenceValidationProblem(req, fieldErrors));
+  };
+}
+
+// ── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  presignedUploadBodySchema,
+  directUploadBodySchema,
+  validatePersistenceBody,
+  buildPersistenceValidationProblem,
+  parseValidationErrors,
+  MAX_FILE_NAME_LENGTH,
+  MAX_INVOICE_ID_LENGTH,
+  MAX_FILE_SIZE_BYTES,
+  PERSISTENCE_VALIDATION_CODE,
+  PERSISTENCE_PROBLEM_TYPE,
+  ALLOWED_MIME_TYPES,
+};

--- a/tests/persistence.validation.test.js
+++ b/tests/persistence.validation.test.js
@@ -1,0 +1,480 @@
+'use strict';
+
+/**
+ * @fileoverview Tests for persistence write input validation.
+ *
+ * Covers:
+ *  - Unit: `presignedUploadBodySchema` / `directUploadBodySchema` edge cases
+ *  - HTTP: structured 400 on POST /api/sme/invoice/presigned-url and POST /api/sme/invoice
+ *
+ * Edge cases required by #683: missing field, wrong type, oversized string,
+ * boundary numbers, unknown fields.
+ */
+
+const request = require('supertest');
+const { createApp } = require('../src/index');
+const storageService = require('../src/services/storage');
+const {
+  presignedUploadBodySchema,
+  directUploadBodySchema,
+  MAX_FILE_NAME_LENGTH,
+  MAX_INVOICE_ID_LENGTH,
+  MAX_FILE_SIZE_BYTES,
+  PERSISTENCE_VALIDATION_CODE,
+  PERSISTENCE_PROBLEM_TYPE,
+  ALLOWED_MIME_TYPES,
+} = require('../src/schemas/persistence');
+
+jest.mock('../src/services/storage', () => {
+  const actual = jest.requireActual('../src/services/storage');
+  return {
+    ...actual,
+    uploadFile: jest.fn(),
+    getSignedUrl: jest.fn(),
+    getPresignedUploadUrl: jest.fn(),
+  };
+});
+
+const app = createApp();
+
+const VALID_PDF = 'application/pdf';
+
+function validPresignedBody(overrides = {}) {
+  return {
+    fileName: 'invoice.pdf',
+    mimeType: VALID_PDF,
+    fileSize: 50_000,
+    ...overrides,
+  };
+}
+
+function expectValidationProblem(res) {
+  expect(res.status).toBe(400);
+  expect(res.body.type).toBe(PERSISTENCE_PROBLEM_TYPE);
+  expect(res.body.title).toBe('Invalid persistence request body');
+  expect(res.body.status).toBe(400);
+  expect(res.body.code).toBe(PERSISTENCE_VALIDATION_CODE);
+  expect(res.body.fieldErrors).toEqual(expect.any(Object));
+}
+
+// ── Schema unit tests ────────────────────────────────────────────────────────
+
+describe('presignedUploadBodySchema', () => {
+  describe('valid payloads', () => {
+    it('accepts a minimal valid body', () => {
+      const result = presignedUploadBodySchema.safeParse(validPresignedBody());
+      expect(result.success).toBe(true);
+      expect(result.data.fileName).toBe('invoice.pdf');
+      expect(result.data.fileSize).toBe(50_000);
+    });
+
+    it('accepts optional invoiceId', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ invoiceId: 'inv-42' })
+      );
+      expect(result.success).toBe(true);
+      expect(result.data.invoiceId).toBe('inv-42');
+    });
+
+    it('accepts every allowlisted mimeType', () => {
+      for (const mimeType of ALLOWED_MIME_TYPES) {
+        const result = presignedUploadBodySchema.safeParse(
+          validPresignedBody({ mimeType })
+        );
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('accepts fileSize at lower boundary (1)', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: 1 })
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts fileSize at upper boundary (MAX_FILE_SIZE_BYTES)', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: MAX_FILE_SIZE_BYTES })
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts fileName at max length', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: `${'a'.repeat(MAX_FILE_NAME_LENGTH - 4)}.pdf` })
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('missing fields', () => {
+    it('rejects missing fileName', () => {
+      const { fileName: _omit, ...body } = validPresignedBody();
+      const result = presignedUploadBodySchema.safeParse(body);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing mimeType', () => {
+      const { mimeType: _omit, ...body } = validPresignedBody();
+      const result = presignedUploadBodySchema.safeParse(body);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing fileSize', () => {
+      const { fileSize: _omit, ...body } = validPresignedBody();
+      const result = presignedUploadBodySchema.safeParse(body);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty object', () => {
+      const result = presignedUploadBodySchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('wrong types', () => {
+    it('rejects fileName as number', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: 123 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects mimeType as number', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ mimeType: 1 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects fileSize as string', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: '50000' })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects fileSize as boolean', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: true })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invoiceId as number', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ invoiceId: 99 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects null body fields', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: null })
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('oversized strings and out-of-range numbers', () => {
+    it('rejects oversized fileName', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: `${'a'.repeat(MAX_FILE_NAME_LENGTH + 1)}.pdf` })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty fileName', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: '' })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects path traversal in fileName', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: '../etc/passwd.pdf' })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects slash in fileName', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileName: 'dir/invoice.pdf' })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects fileSize of 0', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: 0 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects negative fileSize', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: -1 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-integer fileSize', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: 1.5 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects fileSize just above max', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ fileSize: MAX_FILE_SIZE_BYTES + 1 })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects disallowed mimeType', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ mimeType: 'text/html' })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects oversized invoiceId', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ invoiceId: 'a'.repeat(MAX_INVOICE_ID_LENGTH + 1) })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invoiceId with path characters', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ invoiceId: '../../admin' })
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('unknown fields', () => {
+    it('rejects an unknown top-level key', () => {
+      const result = presignedUploadBodySchema.safeParse(
+        validPresignedBody({ extra: 'nope' })
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects constructor / prototype-pollution keys', () => {
+      const body = Object.assign(Object.create(null), validPresignedBody(), {
+        constructor: { name: 'evil' },
+      });
+      const result = presignedUploadBodySchema.safeParse(body);
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe('directUploadBodySchema', () => {
+  it('accepts empty object (invoiceId optional)', () => {
+    expect(directUploadBodySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts valid invoiceId', () => {
+    const result = directUploadBodySchema.safeParse({ invoiceId: 'inv-1' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown fields', () => {
+    const result = directUploadBodySchema.safeParse({ foo: 'bar' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects wrong-type invoiceId', () => {
+    const result = directUploadBodySchema.safeParse({ invoiceId: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects oversized invoiceId', () => {
+    const result = directUploadBodySchema.safeParse({
+      invoiceId: 'x'.repeat(MAX_INVOICE_ID_LENGTH + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── HTTP integration tests ───────────────────────────────────────────────────
+
+describe('POST /api/sme/invoice/presigned-url validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storageService.getPresignedUploadUrl.mockResolvedValue({
+      url: 'https://s3.example.com/upload',
+      key: 'tenants/t/invoices/i/file.pdf',
+    });
+  });
+
+  it('returns 200 for a valid body', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_valid-body-001')
+      .send(validPresignedBody({ invoiceId: 'custom-1' }));
+
+    expect(res.status).toBe(200);
+    expect(storageService.getPresignedUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'invoice.pdf',
+        mimeType: VALID_PDF,
+        fileSize: 50_000,
+        invoiceId: 'custom-1',
+      })
+    );
+  });
+
+  it('returns structured 400 when required fields are missing', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_missing-fields-001')
+      .send({ fileName: 'test.pdf' });
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.mimeType || res.body.fieldErrors.fileSize).toBeDefined();
+    expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for wrong type (fileSize string)', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_wrong-type-001')
+      .send(validPresignedBody({ fileSize: '50000' }));
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.fileSize).toBeDefined();
+    expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for oversized fileName', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_oversized-name-001')
+      .send(validPresignedBody({ fileName: `${'a'.repeat(MAX_FILE_NAME_LENGTH + 1)}.pdf` }));
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.fileName).toMatch(/exceed/);
+    expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for fileSize above max', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_oversized-size-001')
+      .send(validPresignedBody({ fileSize: MAX_FILE_SIZE_BYTES + 1 }));
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.fileSize).toBeDefined();
+    expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for fileSize at zero boundary', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_zero-size-001')
+      .send(validPresignedBody({ fileSize: 0 }));
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.fileSize).toBeDefined();
+  });
+
+  it('accepts fileSize at max boundary without calling with invalid size', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_max-boundary-001')
+      .send(validPresignedBody({ fileSize: MAX_FILE_SIZE_BYTES }));
+
+    expect(res.status).toBe(200);
+    expect(storageService.getPresignedUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ fileSize: MAX_FILE_SIZE_BYTES })
+    );
+  });
+
+  it('returns structured 400 for unknown fields', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_unknown-field-001')
+      .send(validPresignedBody({ unexpected: true }));
+
+    expectValidationProblem(res);
+    expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for disallowed mimeType', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice/presigned-url')
+      .set('X-Tenant-Id', 'test-tenant')
+      .set('Idempotency-Key', 'ik_bad-mime-001')
+      .send(validPresignedBody({ mimeType: 'text/html' }));
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.mimeType).toBeDefined();
+    expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/sme/invoice validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storageService.uploadFile.mockResolvedValue('tenants/t/invoices/i/file.pdf');
+    storageService.getSignedUrl.mockResolvedValue('https://signed.example.com/x');
+  });
+
+  it('returns 200 for a valid multipart upload', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice')
+      .set('X-Tenant-Id', 'test-tenant')
+      .attach('invoice', Buffer.from('%PDF-1.4'), 'test.pdf')
+      .field('invoiceId', 'test-inv');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns structured 400 for unknown form fields', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice')
+      .set('X-Tenant-Id', 'test-tenant')
+      .attach('invoice', Buffer.from('%PDF-1.4'), 'test.pdf')
+      .field('invoiceId', 'test-inv')
+      .field('extraField', 'nope');
+
+    expectValidationProblem(res);
+    expect(storageService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for oversized invoiceId', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice')
+      .set('X-Tenant-Id', 'test-tenant')
+      .attach('invoice', Buffer.from('%PDF-1.4'), 'test.pdf')
+      .field('invoiceId', 'x'.repeat(MAX_INVOICE_ID_LENGTH + 1));
+
+    expectValidationProblem(res);
+    expect(res.body.fieldErrors.invoiceId).toBeDefined();
+    expect(storageService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns structured 400 for invalid invoiceId characters', async () => {
+    const res = await request(app)
+      .post('/api/sme/invoice')
+      .set('X-Tenant-Id', 'test-tenant')
+      .attach('invoice', Buffer.from('%PDF-1.4'), 'test.pdf')
+      .field('invoiceId', '../../evil');
+
+    expectValidationProblem(res);
+    expect(storageService.uploadFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sme.upload.test.js
+++ b/tests/sme.upload.test.js
@@ -268,14 +268,14 @@ describe('SME Invoice Upload - Security Hardening', () => {
         .send({ fileName: 'test.pdf' });
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toBe('fileName, mimeType, and fileSize are required');
+      expect(response.body.code).toBe('PERSISTENCE_VALIDATION_FAILED');
+      expect(response.body.fieldErrors).toBeDefined();
+      expect(
+        response.body.fieldErrors.mimeType || response.body.fieldErrors.fileSize
+      ).toBeDefined();
     });
 
     it('should return 400 for invalid MIME type', async () => {
-      const error = new Error('Invalid MIME type: "text/html"');
-      error.code = 'INVALID_MIME_TYPE';
-      storageService.getPresignedUploadUrl.mockRejectedValue(error);
-
       const response = await request(app)
         .post('/api/sme/invoice/presigned-url')
         .set('X-Tenant-Id', 'test-tenant')
@@ -287,14 +287,12 @@ describe('SME Invoice Upload - Security Hardening', () => {
         });
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toContain('Invalid MIME type');
+      expect(response.body.code).toBe('PERSISTENCE_VALIDATION_FAILED');
+      expect(response.body.fieldErrors.mimeType).toBeDefined();
+      expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
     });
 
     it('should return 400 for oversized file', async () => {
-      const error = new Error('File size 1048576 exceeds maximum');
-      error.code = 'FILE_TOO_LARGE';
-      storageService.getPresignedUploadUrl.mockRejectedValue(error);
-
       const response = await request(app)
         .post('/api/sme/invoice/presigned-url')
         .set('X-Tenant-Id', 'test-tenant')
@@ -306,7 +304,9 @@ describe('SME Invoice Upload - Security Hardening', () => {
         });
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toContain('File size exceeds maximum');
+      expect(response.body.code).toBe('PERSISTENCE_VALIDATION_FAILED');
+      expect(response.body.fieldErrors.fileSize).toBeDefined();
+      expect(storageService.getPresignedUploadUrl).not.toHaveBeenCalled();
     });
 
     it('should never expose AWS credentials in response', async () => {


### PR DESCRIPTION
closes #683 

- Add Zod schemas for presigned upload and direct upload endpoints
- Reject unknown fields with .strict() to prevent prototype pollution
- Bound string lengths (fileName: 255 chars, invoiceId: 128 chars)
- Bound numeric ranges (fileSize: 1 to MAX_FILE_SIZE_BYTES)
- Enum allowlist for MIME types (application/pdf, image/jpeg, image/png, image/tiff)
- Return RFC 7807 problem+json 400 responses with machine-readable error codes
- Update SME routes to use validatePersistenceBody middleware
- Add comprehensive tests covering missing fields, wrong types, oversized strings, boundary numbers, and unknown fields