### PR TITLE
refactor(config): add typed DTO layer

### DIFF
--- a/src/dto/config.js
+++ b/src/dto/config.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * @fileoverview Typed DTO helpers for admin config request/response boundaries.
+ *
+ * These helpers keep the route contract explicit without changing runtime
+ * behavior. They map plain objects to/from a small typed DTO envelope that is
+ * easier to evolve safely during refactors.
+ *
+ * @module dto/config
+ */
+
+/**
+ * @typedef {Object} AdminConfigRequestDto
+ * @property {string} section - Configuration section name.
+ * @property {Record<string, unknown>} config - Section-specific configuration payload.
+ */
+
+/**
+ * @typedef {Object} AdminConfigResponseDto
+ * @property {string} section - Configuration section name.
+ * @property {Record<string, unknown>} config - Accepted section payload.
+ * @property {string} message - Human-readable success message.
+ */
+
+/**
+ * @typedef {Object} ConfigSectionsResponseDto
+ * @property {string[]} sections - Valid configuration section names.
+ */
+
+/**
+ * Map a raw admin config request payload into a typed request DTO.
+ *
+ * @param {unknown} payload - Raw request payload from the route boundary.
+ * @returns {AdminConfigRequestDto} A normalized request DTO.
+ */
+function toAdminConfigRequestDto(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return { section: '', config: {} };
+  }
+
+  const section = typeof payload.section === 'string' ? payload.section : '';
+  const config = payload.config && typeof payload.config === 'object' && !Array.isArray(payload.config)
+    ? { ...payload.config }
+    : {};
+
+  return { section, config };
+}
+
+/**
+ * Convert a typed admin config request DTO back to the route shape.
+ *
+ * @param {AdminConfigRequestDto} dto - Request DTO to normalize back to plain object form.
+ * @returns {AdminConfigRequestDto} A request DTO with the same boundary shape.
+ */
+function fromAdminConfigRequestDto(dto) {
+  return toAdminConfigRequestDto(dto);
+}
+
+/**
+ * Map a raw admin config response payload into a typed response DTO.
+ *
+ * @param {unknown} payload - Raw response payload from the route boundary.
+ * @returns {AdminConfigResponseDto} A normalized response DTO.
+ */
+function toAdminConfigResponseDto(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return { section: '', config: {}, message: '' };
+  }
+
+  const section = typeof payload.section === 'string' ? payload.section : '';
+  const config = payload.config && typeof payload.config === 'object' && !Array.isArray(payload.config)
+    ? { ...payload.config }
+    : {};
+  const message = typeof payload.message === 'string' ? payload.message : '';
+
+  return { section, config, message };
+}
+
+/**
+ * Convert a typed admin config response DTO back to the route shape.
+ *
+ * @param {AdminConfigResponseDto} dto - Response DTO to normalize back to plain object form.
+ * @returns {AdminConfigResponseDto} A response DTO with the same boundary shape.
+ */
+function fromAdminConfigResponseDto(dto) {
+  return toAdminConfigResponseDto(dto);
+}
+
+/**
+ * Map a list of config sections into the typed sections response DTO.
+ *
+ * @param {unknown} sections - Raw section list from the route boundary.
+ * @returns {ConfigSectionsResponseDto} A normalized sections response DTO.
+ */
+function toConfigSectionsResponseDto(sections) {
+  if (!Array.isArray(sections)) {
+    return { sections: [] };
+  }
+
+  return { sections: sections.filter((section) => typeof section === 'string') };
+}
+
+/**
+ * Convert a typed config sections response DTO back to the route shape.
+ *
+ * @param {ConfigSectionsResponseDto} dto - Sections DTO to normalize back to plain object form.
+ * @returns {ConfigSectionsResponseDto} A sections DTO with the same boundary shape.
+ */
+function fromConfigSectionsResponseDto(dto) {
+  return toConfigSectionsResponseDto(dto && dto.sections);
+}
+
+module.exports = {
+  toAdminConfigRequestDto,
+  fromAdminConfigRequestDto,
+  toAdminConfigResponseDto,
+  fromAdminConfigResponseDto,
+  toConfigSectionsResponseDto,
+  fromConfigSectionsResponseDto,
+};

--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -37,7 +37,12 @@ const { adminConfigLimiter } = require('../middleware/rateLimit');
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
 const logger = require('../logger');
-const idempotencyMiddleware = require('../middleware/idempotency');
+const {
+  toAdminConfigRequestDto,
+  fromAdminConfigRequestDto,
+  toAdminConfigResponseDto,
+  fromConfigSectionsResponseDto,
+} = require('../dto/config');
 
 const router = express.Router();
 
@@ -193,7 +198,8 @@ const optionalIdempotency = (req, res, next) => {
  */
 router.post('/', idempotencyMiddleware, validateBody(runtimeConfigSchema), (req, res) => {
   // validateBody attaches the parsed, coerced payload to req.validated
-  const { section, config: validatedConfig } = req.validated;
+  const validatedDto = toAdminConfigRequestDto(req.validated);
+  const { section, config: validatedConfig } = fromAdminConfigRequestDto(validatedDto);
 
   // Apply runtime configuration changes for supported sections.
   if (section === 'cors') {
@@ -217,11 +223,13 @@ router.post('/', idempotencyMiddleware, validateBody(runtimeConfigSchema), (req,
     'Admin runtime config update accepted',
   );
 
-  return res.status(200).json({
+  const responseDto = toAdminConfigResponseDto({
     section,
     config: validatedConfig,
     message: `Configuration section '${section}' validated and accepted.`,
   });
+
+  return res.status(200).json(responseDto);
 });
 
 // ── GET /api/admin/config/sections ───────────────────────────────────────────
@@ -255,7 +263,8 @@ router.post('/', idempotencyMiddleware, validateBody(runtimeConfigSchema), (req,
  *         $ref: '#/components/responses/Problem403'
  */
 router.get('/sections', (req, res) => {
-  return res.status(200).json({ sections: CONFIG_SECTIONS });
+  const sectionsDto = fromConfigSectionsResponseDto({ sections: CONFIG_SECTIONS });
+  return res.status(200).json(sectionsDto);
 });
 
 module.exports = router;

--- a/tests/unit/adminConfig.dto.test.js
+++ b/tests/unit/adminConfig.dto.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const {
+  toAdminConfigRequestDto,
+  fromAdminConfigRequestDto,
+  toAdminConfigResponseDto,
+  fromAdminConfigResponseDto,
+  toConfigSectionsResponseDto,
+  fromConfigSectionsResponseDto,
+} = require('../../src/dto/config');
+
+describe('admin config DTO mapping', () => {
+  it('round-trips admin config request payloads through the request DTO layer', () => {
+    const payload = {
+      section: 'cors',
+      config: {
+        origins: ['https://app.example.com'],
+        maxAge: 600,
+      },
+    };
+
+    const dto = toAdminConfigRequestDto(payload);
+    expect(dto).toEqual(payload);
+    expect(fromAdminConfigRequestDto(dto)).toEqual(payload);
+  });
+
+  it('preserves missing optional fields when mapping request DTOs', () => {
+    const payload = {
+      section: 'webhook',
+      config: {
+        url: 'https://hooks.example.com/receive',
+        secret: '0123456789abcdef',
+        events: ['invoice.created'],
+      },
+    };
+
+    const dto = toAdminConfigRequestDto(payload);
+    expect(dto.config).toEqual(payload.config);
+    expect(dto.config.enabled).toBeUndefined();
+    expect(dto.config.maxRetries).toBeUndefined();
+    expect(fromAdminConfigRequestDto(dto)).toEqual(payload);
+  });
+
+  it('round-trips admin config response payloads through the response DTO layer', () => {
+    const payload = {
+      section: 'reconciliation',
+      config: {
+        batchSize: 25,
+        enabled: true,
+      },
+      message: 'Configuration section \'reconciliation\' validated and accepted.',
+    };
+
+    const dto = toAdminConfigResponseDto(payload);
+    expect(dto).toEqual(payload);
+    expect(fromAdminConfigResponseDto(dto)).toEqual(payload);
+  });
+
+  it('round-trips config section list payloads through the section DTO layer', () => {
+    const payload = { sections: ['webhook', 'cors'] };
+
+    const dto = toConfigSectionsResponseDto(payload.sections);
+    expect(dto).toEqual(payload);
+    expect(fromConfigSectionsResponseDto(dto)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
closes #819 

Description:
This change introduces a typed DTO layer at the admin config boundary to make request and response shapes explicit and safer for future refactors. The route now maps incoming config payloads into typed DTOs before applying runtime updates, and returns mapped DTOs for success and section-list responses. I also added unit tests covering round-trip mapping and missing optional fields to preserve behavior while tightening the boundary contract.