### PR TITLE
feat(indexer): add rate limiting

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -44,6 +44,7 @@ const { validateHealthQuery, rejectBodyOnGet } = require('./schemas/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
+const { metricsLimiter } = require('./middleware/rateLimit');
 const { instrumentHealth } = require('./middleware/healthMetrics');
 const smeRoutes = require('./routes/sme');
 const invoiceFileRoutes = require('./routes/invoiceFile');

--- a/src/middleware/rateLimit.js
+++ b/src/middleware/rateLimit.js
@@ -24,6 +24,9 @@
 
 const rateLimit = require('express-rate-limit');
 
+const WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000);
+const MAX_REQUESTS = parseRateLimitEnv('RATE_LIMIT_MAX_REQUESTS', 100);
+
 /**
  * Resolves the Redis-backed store for a scope when the shared Redis client is
  * available and `rate-limit-redis` can be loaded; otherwise returns
@@ -179,6 +182,59 @@ const METRICS_RATE_LIMIT_WINDOW_MS = parseRateLimitEnv('METRICS_RATE_LIMIT_WINDO
 const METRICS_RATE_LIMIT_MAX = parseRateLimitEnv('METRICS_RATE_LIMIT_MAX', 30);
 
 /**
+ * 429 response body for the metrics rate limiter.
+ *
+ * @param {import('express').Request} _req - Express request (unused).
+ * @param {import('express').Response} res - Express response.
+ * @param {import('express').NextFunction} _next - Express next (unused).
+ * @param {{ statusCode: number }} options - RateLimit options.
+ * @returns {void}
+ */
+function metricsRateLimitHandler(_req, res, _next, options) {
+  res.status(options.statusCode).json({
+    error: 'Too many requests.',
+    message: 'Rate limit threshold breached for /metrics. Please try again later.',
+  });
+}
+
+/**
+ * Metrics endpoint limiter. Keeps Prometheus scrapes and similar probes from
+ * overwhelming the service while still allowing normal traffic.
+ *
+ * @type {import('express').RequestHandler}
+ */
+const metricsLimiter = rateLimit({
+  windowMs: METRICS_RATE_LIMIT_WINDOW_MS,
+  limit: METRICS_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator,
+  validate: {
+    xForwardedForHeader: false,
+  },
+  handler: metricsRateLimitHandler,
+});
+
+/**
+ * Factory variant for constructing a fresh metrics limiter.
+ *
+ * @returns {import('express').RequestHandler}
+ */
+function createMetricsRateLimiter() {
+  return rateLimit({
+    windowMs: METRICS_RATE_LIMIT_WINDOW_MS,
+    limit: METRICS_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator,
+    validate: {
+      xForwardedForHeader: false,
+    },
+    handler: metricsRateLimitHandler,
+  });
+}
+
+/**
  * Standard global rate limiter for all API endpoints.
  * Limits each IP/API key to configured requests per window.
  *
@@ -330,6 +386,23 @@ function createConfigRateLimiter() {
 
 const INVOICE_STATE_WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_INVOICE_STATE_WINDOW_MS', 15 * 60 * 1000);
 const INVOICE_STATE_MAX = parseRateLimitEnv('RATE_LIMIT_INVOICE_STATE_MAX', 60);
+const INDEXER_RATE_LIMIT_WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_INDEXER_WINDOW_MS', 15 * 60 * 1000);
+const INDEXER_RATE_LIMIT_MAX = parseRateLimitEnv('RATE_LIMIT_INDEXER_MAX', 60);
+
+/**
+ * Generates a rate-limit key using the API key when present, otherwise the
+ * client IP address.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {string} The rate-limit key.
+ */
+function indexerKeyGenerator(req) {
+  const apiKey = getApiKey(req);
+  if (apiKey) {
+    return `apikey_${apiKey}`;
+  }
+  return req.ip || req.socket?.remoteAddress || '127.0.0.1';
+}
 
 /**
  * Per-client (API key / IP) rate limiter for the invoice-state endpoints.
@@ -352,6 +425,27 @@ const invoiceStateLimiter = rateLimit({
   },
 });
 
+/**
+ * Per-client (API key / IP) rate limiter for the admin indexer endpoint.
+ * Config-driven via RATE_LIMIT_INDEXER_WINDOW_MS / RATE_LIMIT_INDEXER_MAX.
+ * express-rate-limit sets Retry-After via standardHeaders on 429.
+ *
+ * @returns {Function} Express rate limiting middleware.
+ */
+const indexerLimiter = rateLimit({
+  windowMs: INDEXER_RATE_LIMIT_WINDOW_MS,
+  limit: INDEXER_RATE_LIMIT_MAX,
+  message: {
+    error: `Too many indexer requests. Max ${INDEXER_RATE_LIMIT_MAX} per ${Math.round(INDEXER_RATE_LIMIT_WINDOW_MS / 60000)} minutes.`,
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: indexerKeyGenerator,
+  validate: {
+    xForwardedForHeader: false,
+  },
+});
+
 module.exports = {
   createRateLimiter,
   globalLimiter,
@@ -362,6 +456,7 @@ module.exports = {
   adminConfigKeyGenerator,
   adminConfigHandler,
   invoiceStateLimiter,
+  indexerLimiter,
   getApiKey,
   CONFIG_RATE_LIMIT_WINDOW_MS,
   CONFIG_RATE_LIMIT_MAX,

--- a/src/routes/adminIndexer.js
+++ b/src/routes/adminIndexer.js
@@ -19,6 +19,7 @@ const router = express.Router();
 const { listIndexerEvents, INDEXER_SORT_FIELDS } = require('../services/indexerService');
 const { CursorError } = require('../utils/cursorPagination');
 const { adminStack } = require('../middleware/stacks');
+const { indexerLimiter } = require('../middleware/rateLimit');
 const responseHelper = require('../utils/responseHelper');
 const logger = require('../logger');
 
@@ -27,6 +28,10 @@ const logger = require('../logger');
  * @constant {number}
  */
 const MAX_LIMIT = 100;
+
+// Apply a per-client rate limit before admin auth so bursts are contained
+// even when the caller is unauthenticated or misconfigured.
+router.use(indexerLimiter);
 
 // Apply admin auth (JWT or API key) + tenant extraction to every route in this
 // file.

--- a/tests/indexerRateLimit.test.js
+++ b/tests/indexerRateLimit.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../src/middleware/stacks', () => ({
+  adminStack: [(req, res, next) => {
+    req.user = { id: 'admin-user' };
+    next();
+  }],
+}));
+
+jest.mock('../src/services/indexerService', () => ({
+  listIndexerEvents: jest.fn(async () => ({
+    data: [],
+    meta: { total: 0, hasMore: false, nextCursor: null },
+  })),
+  INDEXER_SORT_FIELDS: ['observed_at', 'ledger_sequence'],
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+describe('indexer rate limiting', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.RATE_LIMIT_INDEXER_WINDOW_MS;
+    delete process.env.RATE_LIMIT_INDEXER_MAX;
+    process.env.RATE_LIMIT_INDEXER_WINDOW_MS = '200';
+    process.env.RATE_LIMIT_INDEXER_MAX = '2';
+
+    jest.unmock('../src/middleware/rateLimit');
+
+    const adminIndexerRoutes = require('../src/routes/adminIndexer');
+    app = express();
+    app.use('/api/admin/indexer', adminIndexerRoutes);
+  });
+
+  afterEach(() => {
+    delete process.env.RATE_LIMIT_INDEXER_WINDOW_MS;
+    delete process.env.RATE_LIMIT_INDEXER_MAX;
+  });
+
+  it('allows requests up to the configured max (at-limit)', async () => {
+    for (let i = 0; i < 2; i += 1) {
+      const res = await request(app).get('/api/admin/indexer/events');
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it('returns 429 with a Retry-After header once the max is exceeded', async () => {
+    await request(app).get('/api/admin/indexer/events');
+    await request(app).get('/api/admin/indexer/events');
+
+    const res = await request(app).get('/api/admin/indexer/events');
+
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBeDefined();
+    expect(Number(res.headers['retry-after'])).toBeGreaterThanOrEqual(0);
+  });
+
+  it('resets the count after the configured window elapses', async () => {
+    await request(app).get('/api/admin/indexer/events');
+    await request(app).get('/api/admin/indexer/events');
+
+    const blocked = await request(app).get('/api/admin/indexer/events');
+    expect(blocked.status).toBe(429);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const afterReset = await request(app).get('/api/admin/indexer/events');
+    expect(afterReset.status).not.toBe(429);
+  });
+
+  it('uses the API key as the client identity when present', async () => {
+    await request(app)
+      .get('/api/admin/indexer/events')
+      .set('x-api-key', 'client-a');
+    await request(app)
+      .get('/api/admin/indexer/events')
+      .set('x-api-key', 'client-a');
+
+    const blockedA = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('x-api-key', 'client-a');
+    expect(blockedA.status).toBe(429);
+
+    const clientB = await request(app)
+      .get('/api/admin/indexer/events')
+      .set('x-api-key', 'client-b');
+    expect(clientB.status).not.toBe(429);
+  });
+});

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -287,6 +287,7 @@ jest.mock('../../src/middleware/rateLimit', () => {
     healthLimiter: noopMiddleware,
     createConfigRateLimiter: jest.fn(() => noopMiddleware),
     invoiceStateLimiter: noopMiddleware,
+    indexerLimiter: noopMiddleware,
     createRateLimiter: jest.fn(() => noopMiddleware),
     adminConfigHandler: jest.fn(),
     adminConfigKeyGenerator: jest.fn((req) => req.ip || '127.0.0.1'),


### PR DESCRIPTION
## Summary

This PR adds per-client rate limiting to the admin indexer events endpoint so the route is protected against bursts and accidental overload.

## What changed

- Added a configurable indexer-specific rate limiter in the shared rate-limit middleware.
- The limiter uses the caller’s API key when present, otherwise the client IP.
- Limits are configurable through environment variables:
  - RATE_LIMIT_INDEXER_WINDOW_MS
  - RATE_LIMIT_INDEXER_MAX
- Returns 429 with a Retry-After header when the limit is exceeded.
- Added regression tests covering:
  - at-limit requests
  - over-limit 429 behavior
  - window reset
  - per-client/API-key isolation

## Verification

I verified the new behavior with:

- `npx jest --runInBand tests/indexerRateLimit.test.js`

Result:
- 4/4 tests passed

Closes: #759