### PR TITLE
test: add invoice-state response contract coverage

### DIFF
--- a/tests/invoice.state.test.js
+++ b/tests/invoice.state.test.js
@@ -816,6 +816,40 @@ describe('Invoice State API Routes', () => {
     jest.restoreAllMocks();
   });
 
+  function expectSuccessEnvelope(body, message, expectedData) {
+    expect(body).toEqual(expect.objectContaining({
+      data: expect.any(Object),
+      meta: expect.objectContaining({
+        timestamp: expect.any(String),
+        version: '0.1.0',
+      }),
+      error: null,
+      message,
+    }));
+    expect(Object.keys(body).sort()).toEqual(['data', 'error', 'message', 'meta']);
+    expect(body.data).toEqual(expectedData);
+  }
+
+  function expectErrorEnvelope(body, expectedCode, expectedMessageMatcher, expectedDetails = undefined) {
+    expect(body).toEqual(expect.objectContaining({
+      data: null,
+      meta: expect.objectContaining({
+        timestamp: expect.any(String),
+        version: '0.1.0',
+      }),
+      error: expect.objectContaining({
+        code: expectedCode,
+        message: expectedMessageMatcher,
+      }),
+    }));
+    expect(Object.keys(body).sort()).toEqual(['data', 'error', 'meta']);
+    if (expectedDetails === undefined) {
+      expect(body.error.details).toBeNull();
+    } else {
+      expect(body.error.details).toEqual(expectedDetails);
+    }
+  }
+
   describe('GET /api/invoices/:id/state', () => {
     it('should return current state and allowed transitions', async () => {
       const res = await request(app)
@@ -823,11 +857,12 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_A);
 
       expect(res.status).toBe(200);
-      expect(res.body.data.invoiceId).toBe('inv-001');
-      expect(res.body.data.currentState).toBe('pending');
-      expect(res.body.data.allowedTransitions).toContain('approved');
-      expect(res.body.data.allowedTransitions).toContain('rejected');
-      expect(res.body.data.isTerminal).toBe(false);
+      expectSuccessEnvelope(res.body, 'Invoice state retrieved successfully', {
+        invoiceId: 'inv-001',
+        currentState: 'pending',
+        allowedTransitions: ['approved', 'rejected', 'cancelled'],
+        isTerminal: false,
+      });
     });
 
     it('should return terminal state info', async () => {
@@ -836,9 +871,12 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_A);
 
       expect(res.status).toBe(200);
-      expect(res.body.data.currentState).toBe('linked_escrow');
-      expect(res.body.data.allowedTransitions).toEqual([]);
-      expect(res.body.data.isTerminal).toBe(true);
+      expectSuccessEnvelope(res.body, 'Invoice state retrieved successfully', {
+        invoiceId: 'inv-003',
+        currentState: 'linked_escrow',
+        allowedTransitions: [],
+        isTerminal: true,
+      });
     });
 
     it('should return 404 for non-existent invoice', async () => {
@@ -847,7 +885,7 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_A);
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
 
     it('should return 404 for cross-tenant invoice access', async () => {
@@ -856,7 +894,7 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_B);
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
 
     it('should handle unexpected errors when reading state', async () => {
@@ -878,11 +916,15 @@ describe('Invoice State API Routes', () => {
         .send({ targetState: 'approved', reason: 'Invoice verified by finance team' });
 
       expect(res.status).toBe(200);
-      expect(res.body.data.previousState).toBe('pending');
-      expect(res.body.data.currentState).toBe('approved');
-      expect(res.body.data.transitionedBy).toBe('test-user-123');
-      expect(res.body.data.reason).toBe('Invoice verified by finance team');
-      expect(res.body.data.auditLogId).toBeDefined();
+      expectSuccessEnvelope(res.body, 'Invoice transitioned from pending to approved', {
+        invoiceId: 'inv-001',
+        previousState: 'pending',
+        currentState: 'approved',
+        transitionedAt: expect.any(String),
+        transitionedBy: 'test-user-123',
+        reason: 'Invoice verified by finance team',
+        auditLogId: expect.any(String),
+      });
 
       const persisted = invoiceStore.get(storeKey(TENANT_A, 'inv-001'));
       expect(persisted.status).toBe('approved');
@@ -898,8 +940,9 @@ describe('Invoice State API Routes', () => {
         .send({ targetState: 'linked_escrow', reason: 'Trying to skip approval' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('INVALID_TRANSITION');
-      expect(res.body.error.details.allowedTransitions).toContain('approved');
+      expectErrorEnvelope(res.body, 'INVALID_TRANSITION', expect.stringContaining('Invalid state transition'), {
+        allowedTransitions: ['approved', 'rejected', 'cancelled'],
+      });
 
       const persisted = invoiceStore.get(storeKey(TENANT_A, 'inv-001'));
       expect(persisted.status).toBe('pending');
@@ -912,7 +955,7 @@ describe('Invoice State API Routes', () => {
         .send({ targetState: 'approved' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('TERMINAL_STATE');
+      expectErrorEnvelope(res.body, 'TERMINAL_STATE', 'Cannot transition from terminal state: linked_escrow');
     });
 
     it('should require reason for terminal rejected transition', async () => {
@@ -922,8 +965,7 @@ describe('Invoice State API Routes', () => {
         .send({ targetState: 'rejected' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('MISSING_TRANSITION_REASON');
-      expect(res.body.error.message).toContain('Reason is required');
+      expectErrorEnvelope(res.body, 'MISSING_TRANSITION_REASON', expect.stringContaining('Reason is required'));
     });
 
     it('should reject missing target state', async () => {
@@ -933,7 +975,7 @@ describe('Invoice State API Routes', () => {
         .send({ reason: 'Missing target state' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('MISSING_TARGET_STATE');
+      expectErrorEnvelope(res.body, 'MISSING_TARGET_STATE', 'Target state is required');
     });
 
     it('should return 404 for non-existent invoice', async () => {
@@ -943,7 +985,7 @@ describe('Invoice State API Routes', () => {
         .send({ targetState: 'approved' });
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
 
     it('should return 404 for cross-tenant transition attempt', async () => {
@@ -953,7 +995,7 @@ describe('Invoice State API Routes', () => {
         .send({ targetState: 'approved', reason: 'Cross-tenant attempt' });
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
   });
 
@@ -965,9 +1007,14 @@ describe('Invoice State API Routes', () => {
         .send({ reason: 'All checks passed' });
 
       expect(res.status).toBe(200);
-      expect(res.body.data.previousState).toBe('pending');
-      expect(res.body.data.currentState).toBe('approved');
-      expect(res.body.message).toBe('Invoice approved successfully');
+      expectSuccessEnvelope(res.body, 'Invoice approved successfully', {
+        invoiceId: 'inv-001',
+        previousState: 'pending',
+        currentState: 'approved',
+        transitionedAt: expect.any(String),
+        transitionedBy: 'test-user-123',
+        auditLogId: expect.any(String),
+      });
 
       const persisted = invoiceStore.get(storeKey(TENANT_A, 'inv-001'));
       expect(persisted.status).toBe('approved');
@@ -980,7 +1027,7 @@ describe('Invoice State API Routes', () => {
         .send({ reason: 'Already approved' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('ALREADY_IN_TARGET_STATE');
+      expectErrorEnvelope(res.body, 'ALREADY_IN_TARGET_STATE', 'Invoice is already in state: approved');
     });
   });
 
@@ -992,10 +1039,15 @@ describe('Invoice State API Routes', () => {
         .send({ escrowId: 'escrow-123', reason: 'Escrow contract created' });
 
       expect(res.status).toBe(200);
-      expect(res.body.data.previousState).toBe('approved');
-      expect(res.body.data.currentState).toBe('linked_escrow');
-      expect(res.body.data.escrowId).toBe('escrow-123');
-      expect(res.body.message).toBe('Invoice linked to escrow successfully');
+      expectSuccessEnvelope(res.body, 'Invoice linked to escrow successfully', {
+        invoiceId: 'inv-002',
+        previousState: 'approved',
+        currentState: 'linked_escrow',
+        escrowId: 'escrow-123',
+        transitionedAt: expect.any(String),
+        transitionedBy: 'test-user-123',
+        auditLogId: expect.any(String),
+      });
 
       const persisted = invoiceStore.get(storeKey(TENANT_A, 'inv-002'));
       expect(persisted.status).toBe('linked_escrow');
@@ -1008,7 +1060,7 @@ describe('Invoice State API Routes', () => {
         .send({ escrowId: 'escrow-456' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('CANNOT_LINK_TO_ESCROW');
+      expectErrorEnvelope(res.body, 'CANNOT_LINK_TO_ESCROW', expect.stringContaining('approved state'));
     });
 
     it('should reject linking already linked invoice', async () => {
@@ -1018,7 +1070,7 @@ describe('Invoice State API Routes', () => {
         .send({ escrowId: 'escrow-789' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('CANNOT_LINK_TO_ESCROW');
+      expectErrorEnvelope(res.body, 'CANNOT_LINK_TO_ESCROW', expect.stringContaining('approved state'));
     });
 
     it('should return 404 for non-existent invoice', async () => {
@@ -1028,7 +1080,7 @@ describe('Invoice State API Routes', () => {
         .send({ escrowId: 'escrow-000' });
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
 
     it('should return 404 for cross-tenant link-escrow attempt', async () => {
@@ -1038,7 +1090,7 @@ describe('Invoice State API Routes', () => {
         .send({ escrowId: 'escrow-000' });
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
 
     it('should surface coded transition errors from the state machine', async () => {
@@ -1054,7 +1106,7 @@ describe('Invoice State API Routes', () => {
         .send({ escrowId: 'escrow-123' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('ALREADY_IN_TARGET_STATE');
+      expectErrorEnvelope(res.body, 'ALREADY_IN_TARGET_STATE', 'Invoice is already in state: linked_escrow');
 
       invoiceService.transitionInvoice.mockRestore();
     });
@@ -1068,9 +1120,15 @@ describe('Invoice State API Routes', () => {
         .send({ reason: 'Invalid documentation' });
 
       expect(res.status).toBe(200);
-      expect(res.body.data.previousState).toBe('pending');
-      expect(res.body.data.currentState).toBe('rejected');
-      expect(res.body.data.reason).toBe('Invalid documentation');
+      expectSuccessEnvelope(res.body, 'Invoice rejected successfully', {
+        invoiceId: 'inv-001',
+        previousState: 'pending',
+        currentState: 'rejected',
+        reason: 'Invalid documentation',
+        transitionedAt: expect.any(String),
+        transitionedBy: 'test-user-123',
+        auditLogId: expect.any(String),
+      });
 
       const persisted = invoiceStore.get(storeKey(TENANT_A, 'inv-001'));
       expect(persisted.status).toBe('rejected');
@@ -1083,7 +1141,7 @@ describe('Invoice State API Routes', () => {
         .send({});
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('MISSING_TRANSITION_REASON');
+      expectErrorEnvelope(res.body, 'MISSING_TRANSITION_REASON', expect.stringContaining('Reason is required'));
     });
 
     it('should not allow rejecting approved invoice', async () => {
@@ -1093,7 +1151,9 @@ describe('Invoice State API Routes', () => {
         .send({ reason: 'Cannot reject approved invoice' });
 
       expect(res.status).toBe(400);
-      expect(res.body.error.code).toBe('INVALID_TRANSITION');
+      expectErrorEnvelope(res.body, 'INVALID_TRANSITION', expect.stringContaining('Invalid state transition'), {
+        allowedTransitions: ['linked_escrow', 'cancelled'],
+      });
     });
   });
 
@@ -1114,10 +1174,13 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_A);
 
       expect(res.status).toBe(200);
-      expect(res.body.data.invoiceId).toBe('inv-001');
-      expect(res.body.data.currentState).toBe('linked_escrow');
+      expectSuccessEnvelope(res.body, 'Invoice transition history retrieved successfully', {
+        invoiceId: 'inv-001',
+        currentState: 'linked_escrow',
+        transitions: expect.any(Array),
+        totalTransitions: 2,
+      });
       expect(res.body.data.transitions).toHaveLength(2);
-      expect(res.body.data.totalTransitions).toBe(2);
     });
 
     it('should return empty history for invoice with no transitions', async () => {
@@ -1126,8 +1189,12 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_A);
 
       expect(res.status).toBe(200);
-      expect(res.body.data.transitions).toEqual([]);
-      expect(res.body.data.totalTransitions).toBe(0);
+      expectSuccessEnvelope(res.body, 'Invoice transition history retrieved successfully', {
+        invoiceId: 'inv-001',
+        currentState: 'pending',
+        transitions: [],
+        totalTransitions: 0,
+      });
     });
 
     it('should return 404 for non-existent invoice', async () => {
@@ -1136,7 +1203,7 @@ describe('Invoice State API Routes', () => {
         .set('x-tenant-id', TENANT_A);
 
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expectErrorEnvelope(res.body, 'INVOICE_NOT_FOUND', 'Invoice not found');
     });
 
     it('should handle unexpected errors when reading history', async () => {


### PR DESCRIPTION
# Invoice-state response contract tests added

The task is now completed in invoice.state.test.js with no behavior changes to the routes themselves.

### What changed
- Added contract-style assertions for the standard success/error envelope used by the invoice-state endpoints.
- Locked in the expected payload shape for:
  - GET state
  - POST transition
  - POST approve
  - POST link-escrow
  - POST reject
  - GET history
- Covered both success responses and error responses, including the expected details payload for invalid transitions.

### Verification
- Ran: `npx jest invoice.state.test.js --runInBand --forceExit`
  - Result: 168 tests passed, 0 failed
- Ran: `npm run lint:new`
  - Result: completed successfully with no lint errors for the scoped invoice-state files

Closes: #796