### PR TITLE
docs(kyc-webhooks): add API changelog

### DIFF
--- a/docs/changelog-kyc-webhooks.md
+++ b/docs/changelog-kyc-webhooks.md
@@ -1,0 +1,52 @@
+# KYC Webhooks API Changelog
+
+Tracks notable, consumer-facing changes to the KYC webhooks API surface:
+
+- `POST /api/kyc/webhook` — inbound webhook ingestion from the external KYC provider.
+- `GET /api/kyc/webhooks` — cursor-paginated listing of ingested KYC records.
+
+See also: [runbook-kyc-webhooks.md](./runbook-kyc-webhooks.md) for operational/failure-mode detail, [webhooks.md](./webhooks.md) for the signature-verification contract, and [configuration.md](./configuration.md) for the full environment-variable reference.
+
+## Policy — keep this current
+
+Any PR that changes either endpoint's request/response shape, status codes, headers, auth/tenant requirements, or signature scheme **must** add an entry here in the same PR, written from the perspective of a consumer integrating with the API (not internal implementation detail), linking the commit/PR that made the change.
+
+---
+
+## Known issues
+
+### `GET /api/kyc/webhooks` is currently non-functional
+
+The cursor-pagination change (`0c756431`, 2026-07-25, "feat(kyc-webhooks): add cursor pagination") references `responseHelper`, `db`, `decodeCursor`, `encodeCursor`, and `CursorError` in `src/routes/kyc.js`, but none of them are imported in that file — every request to this route throws a `ReferenceError` before it can respond. Separately, `'updated_at'` (the field the route sorts and paginates by) is not present in `ALLOWED_SORT_FIELDS` in `src/utils/cursorPagination.js`, so `encodeCursor`/`decodeCursor` would still reject it once the imports are fixed. There is no automated test coverage for this route today, which is why this shipped without being caught.
+
+Do not treat this endpoint as available to consumers until a fix lands. This entry should be replaced with a normal dated entry (below) once it is.
+
+---
+
+## 2026-07-25 — Structured request validation on webhook ingestion
+
+`50cc354f` (#852). `POST /api/kyc/webhook` now validates the parsed JSON body against a strict Zod schema (`src/schemas/kycWebhook.js`, `.strict()`) before processing: unknown fields are rejected, `smeId` must be 1–128 characters matching `^[A-Za-z0-9_-]+$`, `status` must be 1–50 characters, and `recordId` is capped at 255 characters. Previously, any payload with the right field names was accepted with no bounds. Consumers sending malformed or oversized payloads will now receive a `400` earlier and with a more specific error.
+
+## 2026-07-24 — Metrics and structured logging on webhook ingestion
+
+`aba066ba`. The webhook route now emits `kyc_webhook_request_duration_seconds`, `kyc_webhook_requests_total`, and `kyc_webhook_errors_total` (labelled by status class and failure cause) and logs structured success/reject events. No change to the request/response contract — flagged here because consumers running their own alerting on this integration can now scrape these directly.
+
+## 2026-06-27 — Unmapped provider statuses are rejected, not silently normalized
+
+`faa65a8c`. A webhook payload whose `status` value is not present in the provider-status map (`kycService.PROVIDER_STATUS_MAP`) is now rejected with `400 Unknown provider status: <value>` instead of being silently persisted as `unknown`. This is an intentional fail-closed change (issue #592): integrations that previously relied on unrecognized status strings being accepted and normalized will now get a `400`. See [runbook-kyc-webhooks.md § 3](./runbook-kyc-webhooks.md#3-webhook-is-rejected-with-400-unknown-provider-status).
+
+## 2026-05-27 — Timestamped, replay-resistant webhook signatures
+
+`20460278` (#238). The `X-Signature` header format changed to `t=<timestamp>,v1=<hmac>`, signing `HMAC-SHA256(secret, "<timestamp>.<rawBody>")` with a 5-minute tolerance window and verified with a constant-time comparison. This replaced an earlier signature scheme with no replay protection. Any provider or consumer generating this header must send the current `t=,v1=` format — see [webhooks.md](./webhooks.md) for the full receiver-side verification contract.
+
+## 2026-05-28 — KYC gating enforced across all capital-movement routes
+
+`173b703d`. KYC gating (blocking capital-movement actions for SMEs without an approved KYC status) was extended to routes that had previously bypassed the check. Does not change the webhook ingestion contract itself, but changes which downstream actions become available once a webhook is processed.
+
+## 2026-04-25 — Initial KYC status model
+
+`29822056`. Introduced the KYC status model and funding gate that the webhook ingestion endpoint (added shortly after) writes to. Starting point for this changelog's history.
+
+---
+
+Entries above are backfilled from `git log` against `src/routes/kyc.js`, `src/services/kycService.js`, and `src/services/webhooks.js`. Commit hashes are abbreviated; run `git log <hash>` in this repository for full detail.

--- a/docs/runbook-kyc-webhooks.md
+++ b/docs/runbook-kyc-webhooks.md
@@ -195,3 +195,4 @@ The KYC circuit breaker is implemented in [src/utils/circuitBreaker.js](../src/u
 - [src/services/webhooks.js](../src/services/webhooks.js) — signature creation and verification helpers.
 - [src/utils/circuitBreaker.js](../src/utils/circuitBreaker.js) — breaker state machine and recovery semantics.
 - [docs/configuration.md](./configuration.md) — full environment-variable reference.
+- [docs/changelog-kyc-webhooks.md](./changelog-kyc-webhooks.md) — notable, consumer-facing API changes to this subsystem over time.


### PR DESCRIPTION
Closes #860.

## What this adds
`docs/changelog-kyc-webhooks.md`, documenting notable, consumer-facing changes to `POST /api/kyc/webhook` and `GET /api/kyc/webhooks`. Every entry is backfilled from real `git log` history against `src/routes/kyc.js`, `src/services/kycService.js`, and `src/services/webhooks.js` and cites its commit hash — nothing invented. Includes the requested policy note (PRs changing either endpoint's contract must update this file in the same PR), and is cross-linked from `docs/runbook-kyc-webhooks.md`'s existing "Cross-References" section.

## Important: a real bug found while verifying history
The issue asked me to "verify entries against history" and "keep it accurate." While doing that for the cursor-pagination commit (`0c756431`), I found **`GET /api/kyc/webhooks` is currently non-functional**:
- It references `responseHelper`, `db`, `decodeCursor`, `encodeCursor`, and `CursorError` in `src/routes/kyc.js`, but none of them are imported in that file. Confirmed independently — `npm run lint` reports `no-undef` errors on those exact five names at those exact lines.
- Separately, `'updated_at'` (the field the route sorts/paginates by) is not present in `ALLOWED_SORT_FIELDS` in `src/utils/cursorPagination.js`, so `encodeCursor`/`decodeCursor` would still reject it even once the imports are fixed.
- There is no test coverage for this route at all, which is presumably why this shipped without being caught.

I did **not** fix this here — it's a multi-part code bug, not a docs change, and this issue is explicitly scoped to `type:docs`. Silently smuggling a code fix into a documentation-only PR felt like the wrong call, and so did writing a changelog entry that describes a broken endpoint as a working, shipped feature. Instead I added a **"Known issues"** section at the top of the changelog documenting exactly what's broken and why, to be replaced with a normal dated entry once a real fix lands. Happy to open that as a separate fix PR if wanted — just say the word.

(Separately, for context/reassurance this isn't a fluke: the same missing-imports pattern also exists in `src/routes/adminWebhooks.js`, and the full test suite currently has 112/178 suites failing on `main` due to an unrelated `recordMetricsEndpointOutcome is not defined` bug in `src/metrics.js` that cascades through `cacheStore.js` into most of the service layer. Neither is something I touched or am fixing here — flagging only so the failing counts below aren't a surprise.)

## Testing
- `npm run lint` — pre-existing failures only (confirmed via `git status`/`git diff` showing zero source changes in this PR — only the two `docs/*.md` files). No lint rule applies to Markdown here, so nothing to report for the new file itself.
- `npm test` (full suite) — **112 suites / 276 tests failing on `main` before this change**, all pre-existing and cascading from the unrelated `src/metrics.js` bug noted above; this PR touches zero `.js`/`.ts` files so it cannot have changed that count.
- `npm run build` — fails on `tsconfig.build.json(3,3): error TS5103: Invalid value for '--ignoreDeprecations'`, confirmed pre-existing (this PR doesn't touch `tsconfig.build.json`).

Per the issue's own instruction ("Cover edge cases: n/a — verify entries against history"), no new test file was expected or added — the verification work is the git-log cross-referencing described above.