### PR TITLE
Add rate limiting to kyc-webhooks endpoints (#729)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -44,6 +44,7 @@ const { validateHealthQuery, rejectBodyOnGet } = require('./schemas/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
+const { metricsLimiter } = require('./middleware/rateLimit');
 const { instrumentHealth } = require('./middleware/healthMetrics');
 const smeRoutes = require('./routes/sme');
 const invoiceFileRoutes = require('./routes/invoiceFile');

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1214,6 +1214,191 @@ const metricsRequestDurationSeconds = new client.Histogram({
   registers: [registry],
 });
 
+/**
+ * Counter: Total number of /metrics endpoint requests, by status class.
+ * @type {import('prom-client').Counter}
+ */
+const metricsRequestsTotal = new client.Counter({
+  name: 'metrics_requests_total',
+  help: 'Total number of metrics endpoint requests',
+  labelNames: ['status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: /metrics endpoint request errors by bounded cause.
+ * @type {import('prom-client').Counter}
+ */
+const metricsRequestErrorsTotal = new client.Counter({
+  name: 'metrics_request_errors_total',
+  help: 'Total number of metrics endpoint request errors by cause',
+  labelNames: ['cause'],
+  registers: [registry],
+});
+
+/**
+ * Records metrics and a structured log for one completed /metrics request.
+ *
+ * Mirrors {@link module:middleware/healthMetrics.recordHealthOutcome} but
+ * without an `endpoint` label dimension, since there is only one metrics
+ * endpoint.
+ *
+ * @param {object} params
+ * @param {number} params.statusCode - Final HTTP status code.
+ * @param {number} params.durationSeconds - Wall-clock duration in seconds.
+ * @param {unknown} [params.error] - Error thrown/observed, if any.
+ * @param {import('express').Request} [params.req] - Request, for a scoped logger.
+ * @returns {void}
+ */
+function recordMetricsEndpointOutcome({ statusCode, durationSeconds, error, req }) {
+  const statusClass = normalizeMetricsEndpointStatusClass(statusCode);
+
+  metricsRequestDurationSeconds.labels(statusClass).observe(durationSeconds);
+  metricsRequestsTotal.labels(statusClass).inc();
+
+  const cause = normalizeMetricsEndpointCause(error, statusCode);
+  if (cause !== 'none') {
+    metricsRequestErrorsTotal.labels(cause).inc();
+  }
+
+  // Structured log — safe fields only. Never log PII or raw error messages
+  // that could contain sensitive data.
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'metrics endpoint request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'metrics endpoint request rejected');
+  } else {
+    log.info(fields, 'metrics endpoint request completed');
+  }
+}
+
+// ── Persistence metrics (src/middleware/persistenceMetrics.js) ─────────────
+//
+// persistenceMetrics.js already implements recordPersistenceOutcome /
+// instrumentPersistence correctly and imports these identifiers from this
+// module — they were missing here, breaking every module that transitively
+// requires metrics.js. Restored to match the pre-existing contract in
+// tests/persistenceMetrics.test.js and the two call sites in
+// src/routes/sme/index.js ('sme_invoice_presigned_url', 'sme_invoice_upload').
+
+/**
+ * Bounded enum of allowed `endpoint` label values for persistence metrics.
+ * @readonly
+ */
+const PERSISTENCE_ENDPOINT_ENUM = Object.freeze([
+  'sme_invoice_presigned_url',
+  'sme_invoice_upload',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `status_class` label values for persistence metrics.
+ * @readonly
+ */
+const PERSISTENCE_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
+
+/**
+ * Bounded enum of allowed `cause` label values for persistence error metrics.
+ * @readonly
+ */
+const PERSISTENCE_CAUSE_ENUM = Object.freeze(['none', 'validation', 'storage', 'internal']);
+
+/** Storage-service error codes that indicate a storage-layer failure rather than a generic internal error. */
+const PERSISTENCE_STORAGE_ERROR_CODES = new Set([
+  'STORAGE_WRITE_FAILED',
+  'ENOENT',
+  'EACCES',
+  'ENOSPC',
+  'EEXIST',
+]);
+
+/**
+ * Histogram: Wall-clock duration of persistence endpoint requests in seconds.
+ * @type {import('prom-client').Histogram}
+ */
+const persistenceRequestDurationSeconds = new client.Histogram({
+  name: 'persistence_request_duration_seconds',
+  help: 'Duration of persistence endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5],
+  registers: [registry],
+});
+
+/**
+ * Counter: Total number of persistence endpoint requests, by endpoint + status class.
+ * @type {import('prom-client').Counter}
+ */
+const persistenceRequestsTotal = new client.Counter({
+  name: 'persistence_requests_total',
+  help: 'Total number of persistence endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: Persistence endpoint request errors by endpoint + bounded cause.
+ * @type {import('prom-client').Counter}
+ */
+const persistenceRequestErrorsTotal = new client.Counter({
+  name: 'persistence_request_errors_total',
+  help: 'Total number of persistence endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
+
+/**
+ * Maps a raw endpoint hint to a bounded label value.
+ *
+ * @param {unknown} raw - Raw endpoint hint.
+ * @returns {string} Bounded value from {@link PERSISTENCE_ENDPOINT_ENUM}.
+ */
+function normalizePersistenceEndpoint(raw) {
+  const str = typeof raw === 'string' ? raw.trim() : '';
+  return PERSISTENCE_ENDPOINT_ENUM.includes(str) ? str : 'unknown';
+}
+
+/**
+ * Maps an HTTP status code to a bounded `status_class` label value.
+ *
+ * @param {unknown} status - HTTP status code.
+ * @returns {string} Bounded value from {@link PERSISTENCE_STATUS_CLASS_ENUM}.
+ */
+function normalizePersistenceStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
+
+/**
+ * Maps a persistence-endpoint outcome to a bounded `cause` label value.
+ *
+ * @param {unknown} err - Raw error object, if any.
+ * @param {number} [status] - HTTP status code.
+ * @returns {string} Bounded value from {@link PERSISTENCE_CAUSE_ENUM}.
+ */
+function normalizePersistenceCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+  if (code >= 400 && code < 500) { return 'validation'; }
+  if (code >= 500) {
+    const errorCode = err && typeof err === 'object' ? err.code : undefined;
+    if (errorCode && PERSISTENCE_STORAGE_ERROR_CODES.has(errorCode)) { return 'storage'; }
+    return 'internal';
+  }
+  return 'none';
+}
+
 // ── KYC webhook metrics (issue #731) ────────────────────────────────────────
 
 /**

--- a/src/middleware/rateLimit.js
+++ b/src/middleware/rateLimit.js
@@ -328,6 +328,156 @@ function createConfigRateLimiter() {
   });
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// metricsLimiter (issue #744)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 429 response body for {@link metricsLimiter}.
+ *
+ * @param {import('express').Request} _req - Express request (unused).
+ * @param {import('express').Response} res - Express response.
+ * @param {import('express').NextFunction} _next - Express next (unused).
+ * @param {{ statusCode: number, windowMs: number }} options - RateLimit options.
+ * @returns {void}
+ */
+function metricsRateLimitHandler(_req, res, _next, options) {
+  res.status(options.statusCode).json({
+    type: 'https://liquifact.com/probs/too-many-requests',
+    title: 'Too Many Requests',
+    status: options.statusCode,
+    code: 'RATE_LIMITED',
+    retryable: true,
+    retry_hint: 'Wait for the rate-limit window to reset before retrying.',
+    scope: 'metrics',
+    error: 'Too many requests.',
+    message: 'Rate limit threshold breached for /metrics. Please try again later.',
+  });
+}
+
+/**
+ * Per-client rate limiter for /metrics (issue #744).
+ *
+ * Mounted BEFORE metricsAuth in app.js so unauthenticated attempts still
+ * consume quota, defending against brute-force token guessing on the
+ * metrics surface.
+ *
+ * Env vars:
+ *   - `METRICS_RATE_LIMIT_WINDOW_MS` (default 60 000)
+ *   - `METRICS_RATE_LIMIT_MAX`       (default 30)
+ *
+ * @type {import('express').RequestHandler}
+ */
+const metricsLimiter = rateLimit({
+  windowMs: METRICS_RATE_LIMIT_WINDOW_MS,
+  limit: METRICS_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: resolveRateLimitStore('metrics'),
+  keyGenerator: adminConfigKeyGenerator,
+  validate: {
+    xForwardedForHeader: false,
+  },
+  handler: metricsRateLimitHandler,
+});
+
+/**
+ * Factory variant of {@link metricsLimiter} for callers (mostly tests) that
+ * need to construct a fresh limiter with different bounds.
+ *
+ * @returns {import('express').RequestHandler}
+ */
+function createMetricsRateLimiter() {
+  return rateLimit({
+    windowMs: METRICS_RATE_LIMIT_WINDOW_MS,
+    limit: METRICS_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: resolveRateLimitStore('metrics'),
+    keyGenerator: adminConfigKeyGenerator,
+    validate: {
+      xForwardedForHeader: false,
+    },
+    handler: metricsRateLimitHandler,
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// kycWebhookLimiter (issue #729)
+// ────────────────────────────────────────────────────────────────────────────
+
+const KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS = parseRateLimitEnv('KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS', 60 * 1000);
+const KYC_WEBHOOK_RATE_LIMIT_MAX = parseRateLimitEnv('KYC_WEBHOOK_RATE_LIMIT_MAX', 30);
+
+/**
+ * 429 response body for {@link kycWebhookLimiter}.
+ *
+ * @param {import('express').Request} _req - Express request (unused).
+ * @param {import('express').Response} res - Express response.
+ * @param {import('express').NextFunction} _next - Express next (unused).
+ * @param {{ statusCode: number, windowMs: number }} options - RateLimit options.
+ * @returns {void}
+ */
+function kycWebhookRateLimitHandler(_req, res, _next, options) {
+  res.status(options.statusCode).json({
+    type: 'https://liquifact.com/probs/too-many-requests',
+    title: 'Too Many Requests',
+    status: options.statusCode,
+    code: 'RATE_LIMITED',
+    retryable: true,
+    retry_hint: 'Wait for the rate-limit window to reset before retrying.',
+    scope: 'kyc-webhooks',
+    error: 'Too many requests.',
+    message: 'Rate limit threshold breached for /api/kyc webhook endpoints. Please try again later.',
+  });
+}
+
+/**
+ * Per-client (API key / IP) rate limiter for the kyc-webhooks endpoints
+ * (issue #729): POST /api/kyc/webhook (provider ingestion) and
+ * GET /api/kyc/webhooks (listing).
+ *
+ * Config-driven via KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS / KYC_WEBHOOK_RATE_LIMIT_MAX.
+ * express-rate-limit sets Retry-After via standardHeaders on 429.
+ * Reuses adminConfigKeyGenerator: X-API-Key first, falling back to the
+ * socket-bound req.ip (X-Forwarded-For is never trusted).
+ *
+ * @type {import('express').RequestHandler}
+ */
+const kycWebhookLimiter = rateLimit({
+  windowMs: KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+  limit: KYC_WEBHOOK_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: resolveRateLimitStore('kyc-webhooks'),
+  keyGenerator: adminConfigKeyGenerator,
+  validate: {
+    xForwardedForHeader: false,
+  },
+  handler: kycWebhookRateLimitHandler,
+});
+
+/**
+ * Factory variant of {@link kycWebhookLimiter} for callers (mostly tests)
+ * that need to construct a fresh limiter with different bounds.
+ *
+ * @returns {import('express').RequestHandler}
+ */
+function createKycWebhookRateLimiter() {
+  return rateLimit({
+    windowMs: KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+    limit: KYC_WEBHOOK_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: resolveRateLimitStore('kyc-webhooks'),
+    keyGenerator: adminConfigKeyGenerator,
+    validate: {
+      xForwardedForHeader: false,
+    },
+    handler: kycWebhookRateLimitHandler,
+  });
+}
+
 const INVOICE_STATE_WINDOW_MS = parseRateLimitEnv('RATE_LIMIT_INVOICE_STATE_WINDOW_MS', 15 * 60 * 1000);
 const INVOICE_STATE_MAX = parseRateLimitEnv('RATE_LIMIT_INVOICE_STATE_MAX', 60);
 
@@ -370,4 +520,9 @@ module.exports = {
   metricsLimiter,
   metricsRateLimitHandler,
   createMetricsRateLimiter,
+  KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+  KYC_WEBHOOK_RATE_LIMIT_MAX,
+  kycWebhookLimiter,
+  kycWebhookRateLimitHandler,
+  createKycWebhookRateLimiter,
 };

--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -37,7 +37,6 @@ const { adminConfigLimiter } = require('../middleware/rateLimit');
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
 const logger = require('../logger');
-const idempotencyMiddleware = require('../middleware/idempotency');
 
 const router = express.Router();
 

--- a/src/routes/kyc.js
+++ b/src/routes/kyc.js
@@ -14,6 +14,10 @@ const {
 
 const router = express.Router();
 
+// Per-client (API key / IP) rate limit on the kyc-webhooks endpoints (#729).
+const { kycWebhookLimiter } = require('../middleware/rateLimit');
+router.use(kycWebhookLimiter);
+
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
 const SORT_FIELD = 'updated_at';

--- a/tests/kycWebhookRateLimit.test.js
+++ b/tests/kycWebhookRateLimit.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * Regression tests for issue #729 — rate limiting on the kyc-webhooks
+ * endpoints. Uses a tiny window/max (set via env before requiring the
+ * module, since limits are read at module-load time) so at-limit,
+ * over-limit, and window-reset behaviour can be verified quickly.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// This module is globally stubbed in tests/mocks/setup.js (no-op middleware,
+// missing kycWebhookLimiter). Use the real implementation for these tests.
+jest.unmock('../src/middleware/rateLimit');
+
+const WINDOW_MS = 200;
+const MAX = 2;
+
+describe('kyc-webhooks rate limiting (#729)', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS = String(WINDOW_MS);
+    process.env.KYC_WEBHOOK_RATE_LIMIT_MAX = String(MAX);
+
+    // Build a minimal app around just the kyc router, avoiding the full
+    // app.js dependency chain (DB, other routers).
+    const kycRoutes = require('../src/routes/kyc');
+    app = express();
+    app.use(express.json());
+    app.use('/api/kyc', kycRoutes);
+  });
+
+  afterEach(() => {
+    delete process.env.KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS;
+    delete process.env.KYC_WEBHOOK_RATE_LIMIT_MAX;
+  });
+
+  const body = { event: 'verification.completed', subjectId: 'test-subject' };
+
+  it('allows requests up to the configured max (at-limit)', async () => {
+    for (let i = 0; i < MAX; i++) {
+      const res = await request(app).post('/api/kyc/webhook').send(body);
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it('returns 429 with a Retry-After header once the max is exceeded', async () => {
+    for (let i = 0; i < MAX; i++) {
+      await request(app).post('/api/kyc/webhook').send(body);
+    }
+    const res = await request(app).post('/api/kyc/webhook').send(body);
+    expect(res.status).toBe(429);
+    expect(res.headers).toHaveProperty('retry-after');
+    expect(Number(res.headers['retry-after'])).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns a config-driven problem+json body scoped to kyc-webhooks', async () => {
+    for (let i = 0; i < MAX; i++) {
+      await request(app).post('/api/kyc/webhook').send(body);
+    }
+    const res = await request(app).post('/api/kyc/webhook').send(body);
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({
+      code: 'RATE_LIMITED',
+      scope: 'kyc-webhooks',
+      retryable: true,
+    });
+  });
+
+  it('resets the count after the configured window elapses', async () => {
+    for (let i = 0; i < MAX; i++) {
+      await request(app).post('/api/kyc/webhook').send(body);
+    }
+    const blocked = await request(app).post('/api/kyc/webhook').send(body);
+    expect(blocked.status).toBe(429);
+
+    await new Promise((resolve) => setTimeout(resolve, WINDOW_MS + 100));
+
+    const afterReset = await request(app).post('/api/kyc/webhook').send(body);
+    expect(afterReset.status).not.toBe(429);
+  });
+
+  it('rate-limits per client key (API key) independently of other clients', async () => {
+    for (let i = 0; i < MAX; i++) {
+      await request(app)
+        .post('/api/kyc/webhook')
+        .set('x-api-key', 'client-a')
+        .send(body);
+    }
+    const blockedA = await request(app)
+      .post('/api/kyc/webhook')
+      .set('x-api-key', 'client-a')
+      .send(body);
+    expect(blockedA.status).toBe(429);
+
+    // A different API key must not be affected by client-a's usage.
+    const clientB = await request(app)
+      .post('/api/kyc/webhook')
+      .set('x-api-key', 'client-b')
+      .send(body);
+    expect(clientB.status).not.toBe(429);
+  });
+
+  it('falls back to per-IP limiting when no API key is present', async () => {
+    for (let i = 0; i < MAX; i++) {
+      await request(app).post('/api/kyc/webhook').send(body);
+    }
+    const blocked = await request(app).post('/api/kyc/webhook').send(body);
+    expect(blocked.status).toBe(429);
+  });
+
+  it('is config-driven: a different env value changes the effective max', async () => {
+    jest.resetModules();
+    process.env.KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS = String(WINDOW_MS);
+    process.env.KYC_WEBHOOK_RATE_LIMIT_MAX = '1';
+    const routesWithMaxOne = require('../src/routes/kyc');
+    const smallApp = express();
+    smallApp.use(express.json());
+    smallApp.use('/api/kyc', routesWithMaxOne);
+
+    const first = await request(smallApp).post('/api/kyc/webhook').send(body);
+    expect(first.status).not.toBe(429);
+    const second = await request(smallApp).post('/api/kyc/webhook').send(body);
+    expect(second.status).toBe(429);
+  });
+});

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -299,5 +299,15 @@ jest.mock('../../src/middleware/rateLimit', () => {
     CONFIG_RATE_LIMIT_MAX: 20,
     HEALTH_RATE_LIMIT_WINDOW_MS: 15000,
     HEALTH_RATE_LIMIT_MAX: 60,
+    METRICS_RATE_LIMIT_WINDOW_MS: 60000,
+    METRICS_RATE_LIMIT_MAX: 30,
+    metricsLimiter: noopMiddleware,
+    metricsRateLimitHandler: jest.fn(),
+    createMetricsRateLimiter: jest.fn(() => noopMiddleware),
+    KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS: 60000,
+    KYC_WEBHOOK_RATE_LIMIT_MAX: 30,
+    kycWebhookLimiter: noopMiddleware,
+    kycWebhookRateLimitHandler: jest.fn(),
+    createKycWebhookRateLimiter: jest.fn(() => noopMiddleware),
   };
 }, { virtual: true });


### PR DESCRIPTION
Closes #729

## Heads up: this PR is bigger than the issue because `main` doesn't currently boot

While implementing this, I found `src/metrics.js` and `src/middleware/rateLimit.js` throw `ReferenceError`s on load — a previous merge (issue #744, metrics endpoint rate limiting) dropped the actual implementations while leaving their tests, exports, and doc comments intact. Since `src/routes/kyc.js` requires `../metrics` directly, **our own feature couldn't load without fixing this first**. I traced and fixed the full chain (see commit message for the complete list) rather than patching around it. Every restoration is verified against its own pre-existing test spec — this is mechanical restoration of designed-but-lost work, not new design decisions on my part.

## The actual feature

- `kycWebhookLimiter` in `rateLimit.js`: per-client (API key, falling back to IP) rate limit on the kyc-webhooks endpoints, config-driven via `KYC_WEBHOOK_RATE_LIMIT_WINDOW_MS` (default 60s) / `KYC_WEBHOOK_RATE_LIMIT_MAX` (default 30)
- Wired into `kyc.js` via `router.use()`, covering both `POST /api/kyc/webhook` and `GET /api/kyc/webhooks`
- 429 responses return a problem+json body (`code: RATE_LIMITED`, `scope: kyc-webhooks`) with `Retry-After` set automatically via express-rate-limit's `standardHeaders`
- Mirrors the existing `adminConfigLimiter`/`invoiceStateLimiter` pattern already established in this codebase

## Testing

`tests/kycWebhookRateLimit.test.js` — 7 tests: at-limit, over-limit (429 + Retry-After), problem+json shape, window reset, per-client-key isolation, per-IP fallback, config-driven max.

### Directly relevant suites
```
Test Suites: 7 passed, 7 total
Tests:       185 passed, 185 total
```
(`tests/kycWebhookRateLimit.test.js`, `tests/metrics.test.js`, `tests/persistenceMetrics.test.js`, `tests/unit/metrics.rateLimit.test.js`, `tests/invoiceStateRateLimit.test.js`, `tests/unit/kycWebhook.validation.test.js`, `tests/kyc.gating.test.js`)

### Lint
`59 problems (54 errors, 5 warnings)` — down from **77** on unmodified `main` (our fixes net-reduced errors). Confirmed zero new errors introduced by diffing against `HEAD` directly; our new test file lints clean.

### Build
`tsconfig.build.json(3,3): error TS5103: Invalid value for '--ignoreDeprecations'` — pre-existing, confirmed byte-identical `tsconfig.build.json` on `HEAD`, a TypeScript-version/config mismatch unrelated to this change.

## Known pre-existing issues (confirmed unrelated, left untouched)
- `tests/kyc.provider.test.js`: 5 failing tests ('missing tenant context') — reproduces identically with or without this PR's changes
- Full `npm test` run: an order-dependent open-handle crash involving `invoiceService.js` — doesn't reproduce on any individual file or combination of files this PR touches
- `GET /api/kyc/webhooks` already referenced undefined identifiers (`responseHelper`, `db`, `decodeCursor`, etc.) before this change — out of scope here

## Acceptance criteria
- [x] Per-client (API key / IP) rate limit on kyc-webhooks routes, configurable window and cap
- [x] Returns 429 with `Retry-After` header when exceeded; config-driven via env vars
- [x] Covered by tests: at-limit, over-limit 429, window reset, plus per-client isolation and config-driven max