### PR TITLE
feat(kyc-webhooks): add outbound webhook callbacks for KYC events

### DIFF
--- a/migrations/20260727000000_create_kyc_webhook_dead_letters.sql
+++ b/migrations/20260727000000_create_kyc_webhook_dead_letters.sql
@@ -1,0 +1,19 @@
+-- Create table to persist exhausted KYC webhook deliveries (dead-letter queue).
+-- KYC events are scoped to an SME (not an invoice), so this table uses sme_id
+-- rather than invoice_id as the primary correlation identifier.
+CREATE TABLE IF NOT EXISTS kyc_webhook_dead_letters (
+  id           BIGSERIAL    PRIMARY KEY,
+  tenant_id    VARCHAR(255) NOT NULL,
+  sme_id       VARCHAR(255) NOT NULL,
+  event        VARCHAR(128) NOT NULL,
+  payload      JSONB        NOT NULL,
+  last_error   TEXT,
+  attempts     INTEGER      NOT NULL DEFAULT 0,
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kyc_webhook_dead_letters_tenant_created_at
+  ON kyc_webhook_dead_letters (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_kyc_webhook_dead_letters_sme_id
+  ON kyc_webhook_dead_letters (sme_id);

--- a/src/jobs/kycWebhookDelivery.js
+++ b/src/jobs/kycWebhookDelivery.js
@@ -1,0 +1,376 @@
+'use strict';
+
+/**
+ * @fileoverview KYC webhook delivery job handler.
+ *
+ * This module exports a factory that produces a job handler suitable for
+ * registration with BackgroundWorker under the type `kyc_webhook_delivery`.
+ *
+ * Each job payload carries everything needed to perform a signed HTTP POST to
+ * the tenant's configured webhook endpoint:
+ *
+ * ```jsonc
+ * {
+ *   "smeId":        "sme_123",       // subject SME
+ *   "tenantId":     "tenant_abc",    // owning tenant
+ *   "webhookUrl":   "https://...",   // delivery target  (never logged at info)
+ *   "webhookSecret":"<secret>",      // HMAC-SHA256 signing key (never logged)
+ *   "event":        "kyc.verified",  // KYC event type
+ *   "kycData": {                     // KYC state snapshot
+ *     "status":     "verified",
+ *     "recordId":   "rec_xyz",
+ *     "verifiedAt": "2025-01-01T00:00:00.000Z"
+ *   }
+ * }
+ * ```
+ *
+ * Security:
+ * - Secrets and full target URLs are never logged at info level.
+ * - Signatures use the v1 HMAC-SHA256 scheme from `src/services/webhooks.js`.
+ * - Timestamp tolerance replay-protection is enforced on the receiving side.
+ * - Constant-time signature comparison is used in `verifySignature`.
+ * - Payload size is bounded by `KYC_WEBHOOK_MAX_PAYLOAD_BYTES` (default 64 KB).
+ *
+ * @module jobs/kycWebhookDelivery
+ */
+
+const logger = require('../logger');
+const { sortKeys } = require('../services/webhooks');
+const { sendWebhookRequest } = require('./webhookDelivery');
+const { withRetry } = require('../utils/retry');
+const db = require('../db/knex');
+
+let promClient;
+try {
+  promClient = require('prom-client');
+} catch (_e) {
+  promClient = {
+    Counter: class {
+      /** No-op constructor shim for test environments without prom-client. */
+      constructor() {}
+      /** No-op increment shim for test environments without prom-client. */
+      inc() {}
+    },
+  };
+}
+
+const { registry } = require('../metrics');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default maximum serialised payload size in bytes (64 KB). */
+const DEFAULT_MAX_PAYLOAD_BYTES = 64 * 1024;
+
+// ---------------------------------------------------------------------------
+// Metrics (lazily initialised to avoid duplicate-registration errors in tests)
+// ---------------------------------------------------------------------------
+
+let _kycDeliveryAttemptsTotal;
+let _kycDeliverySuccessTotal;
+let _kycDeadLetterTotal;
+
+/**
+ * Returns (creating on first call) the KYC delivery-attempts Prometheus counter.
+ * Lazy initialisation avoids duplicate-registration errors across test suites.
+ * @returns {import('prom-client').Counter}
+ */
+function kycDeliveryAttemptsCounter() {
+  if (!_kycDeliveryAttemptsTotal) {
+    _kycDeliveryAttemptsTotal = new promClient.Counter({
+      name: 'kyc_webhook_delivery_attempts_total',
+      help: 'Total KYC webhook delivery attempts (each try counts)',
+      registers: [registry],
+    });
+  }
+  return _kycDeliveryAttemptsTotal;
+}
+
+/**
+ * Returns (creating on first call) the KYC delivery-success Prometheus counter.
+ * Lazy initialisation avoids duplicate-registration errors across test suites.
+ * @returns {import('prom-client').Counter}
+ */
+function kycDeliverySuccessCounter() {
+  if (!_kycDeliverySuccessTotal) {
+    _kycDeliverySuccessTotal = new promClient.Counter({
+      name: 'kyc_webhook_delivery_success_total',
+      help: 'Total KYC webhook deliveries that completed successfully',
+      registers: [registry],
+    });
+  }
+  return _kycDeliverySuccessTotal;
+}
+
+/**
+ * Returns (creating on first call) the KYC dead-letter Prometheus counter.
+ * Lazy initialisation avoids duplicate-registration errors across test suites.
+ * @returns {import('prom-client').Counter}
+ */
+function kycDeadLetterCounter() {
+  if (!_kycDeadLetterTotal) {
+    _kycDeadLetterTotal = new promClient.Counter({
+      name: 'kyc_webhook_delivery_dead_letter_total',
+      help: 'Total KYC webhook deliveries that exhausted retries and were dead-lettered',
+      registers: [registry],
+    });
+  }
+  return _kycDeadLetterTotal;
+}
+
+// ---------------------------------------------------------------------------
+// Retry policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Determines whether a KYC delivery error is transient and eligible for retry.
+ * Only network/socket errors and HTTP 5xx responses are retried; 4xx is permanent.
+ *
+ * @param {Error} err
+ * @returns {boolean}
+ */
+function shouldRetry(err) {
+  if (!err) {return false;}
+  if (err.name === 'AbortError') {return true;}
+  if (err.code) {
+    return ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN'].includes(err.code);
+  }
+  if (err.status) {
+    const s = Number(err.status);
+    return s >= 500 && s < 600;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Dead-letter helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes a dead-letter record to `kyc_webhook_dead_letters` for an exhausted job.
+ *
+ * @param {Object} params
+ * @param {string} params.tenantId  - Tenant identifier.
+ * @param {string} params.smeId     - SME identifier.
+ * @param {string} params.event     - KYC event type string.
+ * @param {Object} params.payload   - Payload object that failed delivery.
+ * @param {string} params.lastError - Error message from final attempt.
+ * @param {number} params.attempts  - Total attempts made.
+ * @returns {Promise<void>}
+ */
+async function writeKycDeadLetter({ tenantId, smeId, event, payload, lastError, attempts }) {
+  try {
+    await db('kyc_webhook_dead_letters').insert({
+      tenant_id: tenantId,
+      sme_id: smeId,
+      event,
+      payload: JSON.stringify(payload),
+      last_error: lastError,
+      attempts,
+      created_at: new Date(),
+    });
+  } catch (dbErr) {
+    logger.warn({ err: dbErr.message }, 'kyc_webhook_delivery: failed to persist dead-letter record');
+  }
+
+  try {
+    kycDeadLetterCounter().inc();
+  } catch (_) {
+    // ignore metric errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Payload size guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the maximum allowed KYC webhook payload size in bytes.
+ * Reads from `KYC_WEBHOOK_MAX_PAYLOAD_BYTES` env var; falls back to 64 KB.
+ *
+ * @returns {number}
+ */
+function getMaxPayloadBytes() {
+  const raw = Number(process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PAYLOAD_BYTES;
+}
+
+// ---------------------------------------------------------------------------
+// Job handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a job handler for `kyc_webhook_delivery` jobs.
+ *
+ * The returned handler is an `async function(job)` satisfying the
+ * BackgroundWorker handler contract. Retry configuration is read from
+ * environment variables:
+ *
+ * | Variable                       | Default | Description                           |
+ * |--------------------------------|---------|---------------------------------------|
+ * | `WEBHOOK_MAX_RETRIES`          | 3       | Max delivery attempts (excluding 1st) |
+ * | `WEBHOOK_BASE_DELAY`           | 500     | Base exponential-backoff delay (ms)   |
+ * | `WEBHOOK_MAX_DELAY`            | 10000   | Backoff cap (ms)                      |
+ * | `WEBHOOK_TIMEOUT_MS`           | 5000    | Per-request HTTP timeout (ms)         |
+ * | `KYC_WEBHOOK_MAX_PAYLOAD_BYTES`| 65536   | Maximum serialised payload size       |
+ *
+ * @param {Object} [deps={}] - Optional dependency overrides (for testing).
+ * @param {Function} [deps.send] - Override for `sendWebhookRequest`.
+ * @param {Function} [deps.dead] - Override for `writeKycDeadLetter`.
+ * @returns {Function} Async job handler: `async (job) => void`.
+ */
+function createKycWebhookDeliveryHandler(deps = {}) {
+  const send = deps.send || sendWebhookRequest;
+  const dead = deps.dead || writeKycDeadLetter;
+
+  /**
+   * Processes a `kyc_webhook_delivery` job.
+   *
+   * @param {Object} job              - Job object from JobQueue.
+   * @param {string} job.id           - Unique job identifier.
+   * @param {Object} job.payload      - Delivery payload (see module JSDoc above).
+   * @param {number} job.attempts     - Current attempt count (1-based).
+   * @returns {Promise<void>}
+   */
+  return async function kycWebhookDeliveryHandler(job) {
+    const {
+      smeId,
+      tenantId,
+      webhookUrl,
+      webhookSecret,
+      event,
+      kycData = {},
+    } = job.payload;
+
+    const maxRetries = Number(process.env.WEBHOOK_MAX_RETRIES || 3);
+    const baseDelay = Number(process.env.WEBHOOK_BASE_DELAY || 500);
+    const maxDelay = Number(process.env.WEBHOOK_MAX_DELAY || 10000);
+    const timeoutMs = Number(process.env.WEBHOOK_TIMEOUT_MS || 5000);
+    const maxPayloadBytes = getMaxPayloadBytes();
+
+    // Build deterministically-sorted payload
+    const payload = sortKeys({
+      event,
+      smeId,
+      tenantId,
+      timestamp: new Date().toISOString(),
+      kyc: {
+        status: kycData.status || null,
+        recordId: kycData.recordId || null,
+        verifiedAt: kycData.verifiedAt || null,
+      },
+    });
+
+    const rawBody = JSON.stringify(payload);
+
+    // Enforce payload size bound
+    const payloadBytes = Buffer.byteLength(rawBody, 'utf8');
+    if (payloadBytes > maxPayloadBytes) {
+      const sizeError = new Error(
+        `KYC webhook payload exceeds size limit: ${payloadBytes} > ${maxPayloadBytes} bytes`
+      );
+      sizeError.code = 'PAYLOAD_TOO_LARGE';
+      logger.error(
+        { smeId, tenantId, event, payloadBytes, maxPayloadBytes },
+        'kyc_webhook_delivery: payload too large, dead-lettering without retry'
+      );
+      await dead({
+        tenantId,
+        smeId,
+        event,
+        payload,
+        lastError: sizeError.message,
+        attempts: 1,
+      });
+      throw sizeError;
+    }
+
+    logger.info(
+      { smeId, tenantId, event, jobId: job.id, attempt: job.attempts },
+      'kyc_webhook_delivery: starting delivery attempt'
+    );
+
+    let attemptCount = 0;
+
+    const operation = async () => {
+      attemptCount += 1;
+      try {
+        kycDeliveryAttemptsCounter().inc();
+      } catch (_) { /* ignore */ }
+
+      return send({ webhookUrl, webhookSecret, rawBody, timeoutMs });
+    };
+
+    try {
+      await withRetry(operation, {
+        maxRetries,
+        baseDelay,
+        maxDelay,
+        shouldRetry,
+        onRetry: ({ attempt, error }) => {
+          logger.warn(
+            {
+              smeId,
+              tenantId,
+              event,
+              jobId: job.id,
+              attempt,
+              errorCode: error && error.code ? error.code : undefined,
+              errorMessage: error && error.message ? error.message : String(error),
+            },
+            'kyc_webhook_delivery: transient failure, will retry'
+          );
+        },
+      });
+
+      // Success
+      try {
+        kycDeliverySuccessCounter().inc();
+      } catch (_) { /* ignore */ }
+
+      logger.info(
+        { smeId, tenantId, event, jobId: job.id, totalAttempts: attemptCount },
+        'kyc_webhook_delivery: delivered successfully'
+      );
+    } catch (finalErr) {
+      // Exhausted retries → dead-letter
+      logger.error(
+        {
+          smeId,
+          tenantId,
+          event,
+          jobId: job.id,
+          totalAttempts: attemptCount,
+          error: finalErr && finalErr.message ? finalErr.message : String(finalErr),
+        },
+        'kyc_webhook_delivery: exhausted retries, dead-lettering'
+      );
+
+      try {
+        await dead({
+          tenantId,
+          smeId,
+          event,
+          payload,
+          lastError: finalErr && finalErr.message ? finalErr.message : String(finalErr),
+          attempts: attemptCount,
+        });
+      } catch (_deadErr) {
+        // dead() failures must not shadow the original delivery error
+      }
+
+      // Re-throw so BackgroundWorker can mark the job as failed
+      throw finalErr;
+    }
+  };
+}
+
+module.exports = {
+  createKycWebhookDeliveryHandler,
+  // Exported for unit testing
+  shouldRetry,
+  writeKycDeadLetter,
+  getMaxPayloadBytes,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+};

--- a/src/services/kycService.js
+++ b/src/services/kycService.js
@@ -10,6 +10,7 @@
 
 const db = require('../db/knex');
 const logger = require('../logger');
+const { emitKycWebhookForSme } = require('./kycWebhookEmitter');
 
 const KYC_STATUSES = {
   PENDING: 'pending',
@@ -134,13 +135,30 @@ async function persistKycRecord({ smeId, status, providerRecordId = null, verifi
     await db('kyc_records').insert(record);
   }
 
-  return {
+  const result = {
     smeId,
     status: normalizedStatus,
     recordId: providerRecordId || null,
     verifiedAt: verifiedAt || null,
     updatedAt: updatedAt.toISOString(),
   };
+
+  // Fire-and-forget: emit outbound webhook for the KYC status change.
+  // Errors are suppressed inside emitKycWebhookForSme so they can never
+  // prevent the KYC record from being persisted.
+  emitKycWebhookForSme({
+    smeId,
+    status: normalizedStatus,
+    recordId: providerRecordId || null,
+    verifiedAt: verifiedAt || null,
+  }).catch((err) => {
+    logger.error(
+      { smeId, error: err && err.message ? err.message : String(err) },
+      'persistKycRecord: unexpected error from webhook emitter (suppressed)'
+    );
+  });
+
+  return result;
 }
 
 /**

--- a/src/services/kycWebhookEmitter.js
+++ b/src/services/kycWebhookEmitter.js
@@ -1,0 +1,321 @@
+'use strict';
+
+/**
+ * @fileoverview KYC webhook emitter service.
+ *
+ * Responsible for enqueueing signed outbound webhook delivery jobs whenever an
+ * SME's KYC status changes. Works in conjunction with `kycWebhookDelivery.js`
+ * (the job handler) and the shared `BackgroundWorker`.
+ *
+ * ## Tenant lookup strategy
+ * KYC records are SME-scoped, not invoice-scoped. To find which tenants should
+ * receive a KYC event for a given SME we query the `invoices` table for any
+ * invoice that belongs to the SME, then retrieve webhook configuration from the
+ * `tenants` table for each distinct tenant found. This is consistent with the
+ * existing invoice-centric data model and avoids adding a direct SME→tenant
+ * foreign key.
+ *
+ * ## Payload size bounding
+ * The serialised JSON payload is checked against `KYC_WEBHOOK_MAX_PAYLOAD_BYTES`
+ * (default 64 KB) before enqueueing. Oversized payloads are rejected with a
+ * logged warning; they are never enqueued.
+ *
+ * ## Fire-and-forget safety
+ * `emitKycWebhookForSme` is designed to be called as fire-and-forget from
+ * `kycService.persistKycRecord`. It never throws — all errors are caught
+ * internally and logged. This ensures that webhook emission can never prevent a
+ * KYC status update from completing.
+ *
+ * @module services/kycWebhookEmitter
+ */
+
+const db = require('../db/knex');
+const logger = require('../logger');
+const { sortKeys } = require('./webhooks');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default maximum serialised payload size in bytes (64 KB). */
+const DEFAULT_MAX_PAYLOAD_BYTES = 64 * 1024;
+
+/**
+ * Canonical KYC event names emitted on status transitions.
+ *
+ * @readonly
+ * @enum {string}
+ */
+const KYC_WEBHOOK_EVENTS = {
+  VERIFIED: 'kyc.verified',
+  REJECTED: 'kyc.rejected',
+  EXEMPTED: 'kyc.exempted',
+  PENDING: 'kyc.pending',
+};
+
+/**
+ * Maps a normalised KYC status string to its corresponding webhook event name.
+ *
+ * @param {string} status - Normalised KYC status (e.g. `'verified'`).
+ * @returns {string|null} The event name, or `null` for unknown statuses.
+ */
+function statusToEvent(status) {
+  const map = {
+    verified: KYC_WEBHOOK_EVENTS.VERIFIED,
+    rejected: KYC_WEBHOOK_EVENTS.REJECTED,
+    exempted: KYC_WEBHOOK_EVENTS.EXEMPTED,
+    pending: KYC_WEBHOOK_EVENTS.PENDING,
+  };
+  return map[status] || null;
+}
+
+// ---------------------------------------------------------------------------
+// Shared worker reference (injected at startup, same pattern as webhooks.js)
+// ---------------------------------------------------------------------------
+
+let _sharedWorker = null;
+
+/**
+ * Injects the BackgroundWorker instance used by `enqueueKycWebhookDelivery`.
+ * Call this once at application startup after the worker has been created and
+ * the `kyc_webhook_delivery` handler has been registered.
+ *
+ * @param {import('../workers/worker')} worker - Configured BackgroundWorker.
+ * @returns {void}
+ */
+function setSharedWorker(worker) {
+  _sharedWorker = worker;
+}
+
+// ---------------------------------------------------------------------------
+// Payload size guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the maximum allowed KYC webhook payload size in bytes.
+ * Reads from `KYC_WEBHOOK_MAX_PAYLOAD_BYTES`; falls back to 64 KB.
+ *
+ * @returns {number}
+ */
+function getMaxPayloadBytes() {
+  const raw = Number(process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PAYLOAD_BYTES;
+}
+
+// ---------------------------------------------------------------------------
+// Tenant lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds all tenants that have webhook configuration and are associated with the
+ * given SME (via the `invoices` table). Returns an array of objects containing
+ * `tenantId`, `webhookUrl`, and `webhookSecret`.
+ *
+ * Returns an empty array (never throws) if the lookup fails.
+ *
+ * @param {string} smeId - SME identifier.
+ * @returns {Promise<Array<{tenantId: string, webhookUrl: string, webhookSecret: string}>>}
+ */
+async function findTenantsForSme(smeId) {
+  try {
+    // Fetch distinct tenant IDs that have at least one invoice for this SME
+    const rows = await db('invoices')
+      .select('tenant_id')
+      .where('sme_id', smeId)
+      .distinct('tenant_id');
+
+    if (!rows || rows.length === 0) {
+      return [];
+    }
+
+    const tenantIds = rows.map((r) => r.tenant_id);
+
+    // Fetch webhook settings for those tenants
+    const tenants = await db('tenants')
+      .select('id', 'settings')
+      .whereIn('id', tenantIds);
+
+    const result = [];
+    for (const tenant of tenants) {
+      if (!tenant.settings) {continue;}
+      const { webhook_url: webhookUrl, webhook_secret: webhookSecret } = tenant.settings;
+      if (!webhookUrl || !webhookSecret) {continue;}
+      result.push({
+        tenantId: tenant.id,
+        webhookUrl,
+        webhookSecret,
+      });
+    }
+
+    return result;
+  } catch (err) {
+    logger.error(
+      { smeId, error: err && err.message ? err.message : String(err) },
+      'kycWebhookEmitter: failed to look up tenants for SME'
+    );
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueues a `kyc_webhook_delivery` job for a KYC status change.
+ *
+ * Looks up all tenants associated with the SME and enqueues one job per
+ * tenant that has a configured webhook. Returns an array of enqueued job IDs.
+ *
+ * Returns `[]` (and never throws) when:
+ *  - The shared worker has not been initialised.
+ *  - No tenants are associated with the SME.
+ *  - No tenant has a configured webhook.
+ *  - The serialised payload exceeds `KYC_WEBHOOK_MAX_PAYLOAD_BYTES`.
+ *  - Any other unexpected error occurs.
+ *
+ * @param {Object} options
+ * @param {string} options.smeId      - SME identifier.
+ * @param {string} options.event      - KYC event name (use `KYC_WEBHOOK_EVENTS`).
+ * @param {Object} [options.kycData]  - KYC state snapshot included in the payload.
+ * @param {string} [options.kycData.status]     - Normalised KYC status.
+ * @param {string|null} [options.kycData.recordId]   - Provider record ID.
+ * @param {string|null} [options.kycData.verifiedAt] - ISO timestamp when verified.
+ * @returns {Promise<string[]>} Enqueued job IDs.
+ */
+async function enqueueKycWebhookDelivery({ smeId, event, kycData = {} }) {
+  if (!_sharedWorker) {
+    logger.info({ smeId, event }, 'kycWebhookEmitter: shared worker not set, skipping enqueue');
+    return [];
+  }
+
+  const maxPayloadBytes = getMaxPayloadBytes();
+
+  // Pre-validate payload size using a representative payload
+  const samplePayload = sortKeys({
+    event,
+    smeId,
+    tenantId: '',
+    timestamp: new Date().toISOString(),
+    kyc: {
+      status: kycData.status || null,
+      recordId: kycData.recordId || null,
+      verifiedAt: kycData.verifiedAt || null,
+    },
+  });
+  const sampleBody = JSON.stringify(samplePayload);
+  const payloadBytes = Buffer.byteLength(sampleBody, 'utf8');
+
+  if (payloadBytes > maxPayloadBytes) {
+    logger.warn(
+      { smeId, event, payloadBytes, maxPayloadBytes },
+      'kycWebhookEmitter: payload too large, skipping enqueue'
+    );
+    return [];
+  }
+
+  const tenants = await findTenantsForSme(smeId);
+
+  if (tenants.length === 0) {
+    logger.info({ smeId, event }, 'kycWebhookEmitter: no tenants with webhooks configured for SME');
+    return [];
+  }
+
+  const jobIds = [];
+  for (const { tenantId, webhookUrl, webhookSecret } of tenants) {
+    try {
+      const jobId = _sharedWorker.enqueue('kyc_webhook_delivery', {
+        smeId,
+        tenantId,
+        webhookUrl,
+        webhookSecret,
+        event,
+        kycData,
+      });
+
+      logger.info(
+        { smeId, tenantId, event, jobId },
+        'kycWebhookEmitter: delivery job enqueued'
+      );
+
+      jobIds.push(jobId);
+    } catch (err) {
+      logger.error(
+        {
+          smeId,
+          tenantId,
+          event,
+          error: err && err.message ? err.message : String(err),
+        },
+        'kycWebhookEmitter: failed to enqueue delivery job for tenant'
+      );
+    }
+  }
+
+  return jobIds;
+}
+
+// ---------------------------------------------------------------------------
+// Fire-and-forget top-level emitter
+// ---------------------------------------------------------------------------
+
+/**
+ * Emits KYC webhook events for all tenants associated with the given SME,
+ * based on the new KYC status. This is the primary integration point called
+ * from `kycService.persistKycRecord`.
+ *
+ * This function is **fire-and-forget**: it never throws. All errors are caught
+ * internally so that a webhook failure can never prevent a KYC status update.
+ *
+ * @param {Object} params
+ * @param {string} params.smeId                  - SME identifier.
+ * @param {string} params.status                 - Normalised KYC status.
+ * @param {string|null} [params.recordId]        - Provider record ID.
+ * @param {string|null} [params.verifiedAt]      - ISO timestamp when verified.
+ * @returns {Promise<void>}
+ */
+async function emitKycWebhookForSme({ smeId, status, recordId = null, verifiedAt = null }) {
+  try {
+    if (!smeId || typeof smeId !== 'string') {
+      logger.warn({ smeId }, 'kycWebhookEmitter: invalid smeId, skipping emission');
+      return;
+    }
+
+    const event = statusToEvent(status);
+    if (!event) {
+      logger.warn({ smeId, status }, 'kycWebhookEmitter: unknown status, skipping emission');
+      return;
+    }
+
+    await enqueueKycWebhookDelivery({
+      smeId,
+      event,
+      kycData: {
+        status,
+        recordId,
+        verifiedAt,
+      },
+    });
+  } catch (err) {
+    // Must never propagate — KYC persistence must not be blocked by webhook errors
+    logger.error(
+      {
+        smeId,
+        status,
+        error: err && err.message ? err.message : String(err),
+      },
+      'kycWebhookEmitter: unexpected error during webhook emission (suppressed)'
+    );
+  }
+}
+
+module.exports = {
+  KYC_WEBHOOK_EVENTS,
+  statusToEvent,
+  setSharedWorker,
+  findTenantsForSme,
+  enqueueKycWebhookDelivery,
+  emitKycWebhookForSme,
+  getMaxPayloadBytes,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+};

--- a/tests/kycWebhook.test.js
+++ b/tests/kycWebhook.test.js
@@ -1,0 +1,776 @@
+'use strict';
+
+/**
+ * @fileoverview Comprehensive tests for KYC outbound webhook callbacks.
+ *
+ * Coverage:
+ *  1. kycWebhookEmitter – statusToEvent mapping, tenant lookup, enqueue,
+ *     payload-size guard, fire-and-forget error suppression
+ *  2. kycWebhookDelivery job handler – happy path, retry/backoff, dead-letter,
+ *     payload-too-large, metrics, shouldRetry predicate
+ *  3. kycService.persistKycRecord → webhook emission integration
+ *  4. Edge cases: missing worker, missing tenants, DB errors, metric failures
+ */
+
+process.env.NODE_ENV = 'test';
+
+// ─── Module mocks (must precede requires) ────────────────────────────────────
+
+jest.mock('../src/db/knex', () => jest.fn());
+jest.mock('../src/logger', () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+
+jest.mock('prom-client', () => ({
+  Counter: class { constructor() {} inc() {} },
+  Gauge:   class { constructor() {} set() {} },
+  Registry: class {
+    constructor() { this.contentType = 'text/plain'; }
+    metrics() { return ''; }
+  },
+  collectDefaultMetrics: () => {},
+}), { virtual: true });
+
+jest.mock('../src/metrics', () => ({
+  registry: { contentType: 'text/plain', metrics: jest.fn().mockResolvedValue('') },
+  escrowIndexerEventsProcessedTotal: { inc: jest.fn() },
+  escrowIndexerEventsSkippedTotal:   { inc: jest.fn() },
+  escrowIndexerCycleFailuresTotal:   { inc: jest.fn() },
+  escrowIndexerLastCursorAdvanceTimestampSeconds: { set: jest.fn() },
+  metricsAuth:    jest.fn(),
+  metricsHandler: jest.fn(),
+}));
+
+// ─── Imports ─────────────────────────────────────────────────────────────────
+
+const db     = require('../src/db/knex');
+const logger = require('../src/logger');
+
+const {
+  KYC_WEBHOOK_EVENTS,
+  statusToEvent,
+  setSharedWorker,
+  findTenantsForSme,
+  enqueueKycWebhookDelivery,
+  emitKycWebhookForSme,
+  getMaxPayloadBytes,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+} = require('../src/services/kycWebhookEmitter');
+
+const {
+  createKycWebhookDeliveryHandler,
+  shouldRetry,
+  writeKycDeadLetter,
+} = require('../src/jobs/kycWebhookDelivery');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Builds a minimal mock DB chain for the invoices+tenants lookup path. */
+function mockTenantsForSme(invoiceRows, tenantRows) {
+  // invoices query: select + where + distinct
+  db.mockReturnValueOnce({
+    select: jest.fn().mockReturnThis(),
+    where:  jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockResolvedValue(invoiceRows),
+  });
+  // tenants query: only queued when invoices returns rows (code returns early otherwise)
+  if (invoiceRows.length > 0) {
+    db.mockReturnValueOnce({
+      select:  jest.fn().mockReturnThis(),
+      whereIn: jest.fn().mockResolvedValue(tenantRows),
+    });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. statusToEvent
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('statusToEvent', () => {
+  it('maps verified  → kyc.verified',  () => expect(statusToEvent('verified')).toBe(KYC_WEBHOOK_EVENTS.VERIFIED));
+  it('maps rejected  → kyc.rejected',  () => expect(statusToEvent('rejected')).toBe(KYC_WEBHOOK_EVENTS.REJECTED));
+  it('maps exempted  → kyc.exempted',  () => expect(statusToEvent('exempted')).toBe(KYC_WEBHOOK_EVENTS.EXEMPTED));
+  it('maps pending   → kyc.pending',   () => expect(statusToEvent('pending')).toBe(KYC_WEBHOOK_EVENTS.PENDING));
+  it('returns null for unknown status', () => expect(statusToEvent('mystery')).toBeNull());
+  it('returns null for empty string',   () => expect(statusToEvent('')).toBeNull());
+  it('returns null for undefined',      () => expect(statusToEvent(undefined)).toBeNull());
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. getMaxPayloadBytes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getMaxPayloadBytes', () => {
+  afterEach(() => { delete process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES; });
+
+  it('returns DEFAULT_MAX_PAYLOAD_BYTES when env var is unset', () => {
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+
+  it('returns custom value from env var', () => {
+    process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES = '1024';
+    expect(getMaxPayloadBytes()).toBe(1024);
+  });
+
+  it('falls back to default for non-numeric env var', () => {
+    process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES = 'abc';
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+
+  it('falls back to default for zero', () => {
+    process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES = '0';
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+
+  it('falls back to default for negative value', () => {
+    process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES = '-100';
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. findTenantsForSme
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('findTenantsForSme', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('returns tenants that have webhook configured', async () => {
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-1' }],
+      [{ id: 'tenant-1', settings: { webhook_url: 'https://cb.example.com', webhook_secret: 'sec' } }],
+    );
+
+    const result = await findTenantsForSme('sme-001');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ tenantId: 'tenant-1', webhookUrl: 'https://cb.example.com' });
+  });
+
+  it('excludes tenants with no webhook_url', async () => {
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-2' }],
+      [{ id: 'tenant-2', settings: { webhook_secret: 'sec' } }],
+    );
+
+    const result = await findTenantsForSme('sme-002');
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes tenants with no webhook_secret', async () => {
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-3' }],
+      [{ id: 'tenant-3', settings: { webhook_url: 'https://x' } }],
+    );
+
+    const result = await findTenantsForSme('sme-003');
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes tenants with null settings', async () => {
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-4' }],
+      [{ id: 'tenant-4', settings: null }],
+    );
+
+    const result = await findTenantsForSme('sme-004');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when SME has no invoices', async () => {
+    db.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      where:  jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockResolvedValue([]),
+    });
+
+    const result = await findTenantsForSme('sme-no-invoices');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns multiple tenants when SME has invoices under multiple tenants', async () => {
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-a' }, { tenant_id: 'tenant-b' }],
+      [
+        { id: 'tenant-a', settings: { webhook_url: 'https://a', webhook_secret: 'sa' } },
+        { id: 'tenant-b', settings: { webhook_url: 'https://b', webhook_secret: 'sb' } },
+      ],
+    );
+
+    const result = await findTenantsForSme('sme-multi');
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array and logs error when DB throws', async () => {
+    db.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      where:  jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockRejectedValue(new Error('db boom')),
+    });
+
+    const result = await findTenantsForSme('sme-dberr');
+    expect(result).toEqual([]);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. enqueueKycWebhookDelivery
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('enqueueKycWebhookDelivery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES;
+  });
+
+  afterEach(() => {
+    setSharedWorker(null);
+  });
+
+  it('returns [] when shared worker is not set', async () => {
+    setSharedWorker(null);
+    const result = await enqueueKycWebhookDelivery({ smeId: 'sme-1', event: 'kyc.verified', kycData: {} });
+    expect(result).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ smeId: 'sme-1' }),
+      expect.stringContaining('shared worker not set'),
+    );
+  });
+
+  it('returns [] when no tenants have webhooks configured', async () => {
+    setSharedWorker({ enqueue: jest.fn() });
+    mockTenantsForSme([], []);
+
+    const result = await enqueueKycWebhookDelivery({ smeId: 'sme-none', event: 'kyc.verified', kycData: {} });
+    expect(result).toEqual([]);
+  });
+
+  it('enqueues one job per tenant and returns job IDs', async () => {
+    const mockEnqueue = jest.fn().mockReturnValue('job-001');
+    setSharedWorker({ enqueue: mockEnqueue });
+
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-x' }],
+      [{ id: 'tenant-x', settings: { webhook_url: 'https://x', webhook_secret: 'sx' } }],
+    );
+
+    const result = await enqueueKycWebhookDelivery({
+      smeId: 'sme-5',
+      event: KYC_WEBHOOK_EVENTS.VERIFIED,
+      kycData: { status: 'verified', recordId: 'rec_1', verifiedAt: '2026-01-01T00:00:00Z' },
+    });
+
+    expect(result).toEqual(['job-001']);
+    expect(mockEnqueue).toHaveBeenCalledWith('kyc_webhook_delivery', expect.objectContaining({
+      smeId: 'sme-5',
+      tenantId: 'tenant-x',
+      event: 'kyc.verified',
+    }));
+  });
+
+  it('returns [] and logs warning when payload exceeds size limit', async () => {
+    process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES = '10';
+    const mockEnqueue = jest.fn();
+    setSharedWorker({ enqueue: mockEnqueue });
+
+    const result = await enqueueKycWebhookDelivery({
+      smeId: 'sme-big',
+      event: 'kyc.verified',
+      kycData: { status: 'verified', recordId: 'rec_big', verifiedAt: '2026-01-01T00:00:00Z' },
+    });
+
+    expect(result).toEqual([]);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ smeId: 'sme-big' }),
+      expect.stringContaining('payload too large'),
+    );
+  });
+
+  it('continues enqueueing remaining tenants if one enqueue throws', async () => {
+    const mockEnqueue = jest.fn()
+      .mockImplementationOnce(() => { throw new Error('enqueue failed'); })
+      .mockReturnValueOnce('job-002');
+    setSharedWorker({ enqueue: mockEnqueue });
+
+    mockTenantsForSme(
+      [{ tenant_id: 'tenant-a' }, { tenant_id: 'tenant-b' }],
+      [
+        { id: 'tenant-a', settings: { webhook_url: 'https://a', webhook_secret: 'sa' } },
+        { id: 'tenant-b', settings: { webhook_url: 'https://b', webhook_secret: 'sb' } },
+      ],
+    );
+
+    const result = await enqueueKycWebhookDelivery({ smeId: 'sme-partial', event: 'kyc.verified', kycData: {} });
+    expect(result).toEqual(['job-002']);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. emitKycWebhookForSme (fire-and-forget wrapper)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('emitKycWebhookForSme', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setSharedWorker(null);
+  });
+
+  it('never throws even when inner logic errors', async () => {
+    // worker not set → enqueueKycWebhookDelivery returns []
+    setSharedWorker(null);
+    await expect(emitKycWebhookForSme({ smeId: 'sme-1', status: 'verified' })).resolves.toBeUndefined();
+  });
+
+  it('skips emission and logs warn for invalid smeId', async () => {
+    await emitKycWebhookForSme({ smeId: '', status: 'verified' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ smeId: '' }),
+      expect.stringContaining('invalid smeId'),
+    );
+  });
+
+  it('skips emission and logs warn for unknown status', async () => {
+    await emitKycWebhookForSme({ smeId: 'sme-1', status: 'bogus' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'bogus' }),
+      expect.stringContaining('unknown status'),
+    );
+  });
+
+  it('emits for all four valid statuses without throwing', async () => {
+    for (const status of ['verified', 'rejected', 'exempted', 'pending']) {
+      setSharedWorker(null); // worker not set → graceful skip
+      await expect(
+        emitKycWebhookForSme({ smeId: 'sme-x', status })
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it('suppresses unexpected errors from enqueueKycWebhookDelivery', async () => {
+    // Cause findTenantsForSme to throw unexpectedly via DB mock
+    db.mockReturnValueOnce({
+      select:   jest.fn().mockReturnThis(),
+      where:    jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockRejectedValue(new Error('unexpected')),
+    });
+
+    const mockWorker = { enqueue: jest.fn() };
+    setSharedWorker(mockWorker);
+
+    await expect(
+      emitKycWebhookForSme({ smeId: 'sme-err', status: 'verified' })
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. shouldRetry predicate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('shouldRetry (kycWebhookDelivery)', () => {
+  it('retries on ECONNRESET', () => {
+    const e = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on ETIMEDOUT', () => {
+    const e = Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on ECONNREFUSED', () => {
+    const e = Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on ENOTFOUND', () => {
+    const e = Object.assign(new Error('notfound'), { code: 'ENOTFOUND' });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on EAI_AGAIN', () => {
+    const e = Object.assign(new Error('again'), { code: 'EAI_AGAIN' });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on AbortError', () => {
+    const e = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on HTTP 500', () => {
+    const e = Object.assign(new Error('500'), { status: 500 });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('retries on HTTP 503', () => {
+    const e = Object.assign(new Error('503'), { status: 503 });
+    expect(shouldRetry(e)).toBe(true);
+  });
+  it('does NOT retry on HTTP 400', () => {
+    const e = Object.assign(new Error('400'), { status: 400 });
+    expect(shouldRetry(e)).toBe(false);
+  });
+  it('does NOT retry on HTTP 401', () => {
+    const e = Object.assign(new Error('401'), { status: 401 });
+    expect(shouldRetry(e)).toBe(false);
+  });
+  it('does NOT retry on generic error with no code/status', () => {
+    expect(shouldRetry(new Error('generic'))).toBe(false);
+  });
+  it('returns false for null/undefined', () => {
+    expect(shouldRetry(null)).toBe(false);
+    expect(shouldRetry(undefined)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. writeKycDeadLetter
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('writeKycDeadLetter', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('inserts a record into kyc_webhook_dead_letters', async () => {
+    const insertMock = jest.fn().mockResolvedValue([1]);
+    db.mockReturnValueOnce({ insert: insertMock });
+
+    await writeKycDeadLetter({
+      tenantId: 't1', smeId: 'sme-1', event: 'kyc.verified',
+      payload: { event: 'kyc.verified' }, lastError: 'boom', attempts: 3,
+    });
+
+    expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenant_id: 't1',
+      sme_id: 'sme-1',
+      event: 'kyc.verified',
+      last_error: 'boom',
+      attempts: 3,
+    }));
+  });
+
+  it('logs a warning when DB insert fails but does not throw', async () => {
+    db.mockReturnValueOnce({ insert: jest.fn().mockRejectedValue(new Error('dbfail')) });
+
+    await expect(writeKycDeadLetter({
+      tenantId: 't1', smeId: 'sme-1', event: 'kyc.rejected',
+      payload: {}, lastError: 'err', attempts: 1,
+    })).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: 'dbfail' }),
+      expect.stringContaining('dead-letter'),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. createKycWebhookDeliveryHandler – job handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createKycWebhookDeliveryHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.WEBHOOK_MAX_RETRIES;
+    delete process.env.WEBHOOK_BASE_DELAY;
+    delete process.env.WEBHOOK_MAX_DELAY;
+    delete process.env.WEBHOOK_TIMEOUT_MS;
+    delete process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES;
+  });
+
+  /** Builds a minimal job object. */
+  function makeJob(overrides = {}) {
+    return {
+      id: 'job-test-1',
+      attempts: 1,
+      payload: {
+        smeId: 'sme-abc',
+        tenantId: 'tenant-xyz',
+        webhookUrl: 'https://cb.example.com/kyc',
+        webhookSecret: 'secret123',
+        event: 'kyc.verified',
+        kycData: { status: 'verified', recordId: 'rec_1', verifiedAt: '2026-01-01T00:00:00Z' },
+        ...overrides,
+      },
+    };
+  }
+
+  it('delivers successfully on first attempt', async () => {
+    const send = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    const dead = jest.fn();
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    await handler(makeJob());
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(dead).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'kyc.verified' }),
+      expect.stringContaining('delivered successfully'),
+    );
+  });
+
+  it('retries on transient error then succeeds', async () => {
+    process.env.WEBHOOK_MAX_RETRIES = '3';
+    process.env.WEBHOOK_BASE_DELAY = '1';
+
+    const send = jest.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }))
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const dead = jest.fn();
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    await handler(makeJob());
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(dead).not.toHaveBeenCalled();
+  });
+
+  it('dead-letters after exhausting retries', async () => {
+    process.env.WEBHOOK_MAX_RETRIES = '2';
+    process.env.WEBHOOK_BASE_DELAY = '1';
+
+    const netErr = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' });
+    const send = jest.fn().mockRejectedValue(netErr);
+    const dead = jest.fn().mockResolvedValue(undefined);
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    await expect(handler(makeJob())).rejects.toThrow('ECONNRESET');
+
+    expect(send).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    expect(dead).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-xyz',
+      smeId: 'sme-abc',
+      event: 'kyc.verified',
+      attempts: 3,
+    }));
+  });
+
+  it('does NOT retry on 4xx and dead-letters immediately', async () => {
+    process.env.WEBHOOK_MAX_RETRIES = '3';
+    process.env.WEBHOOK_BASE_DELAY = '1';
+
+    const err400 = Object.assign(new Error('Bad Request'), { status: 400 });
+    const send = jest.fn().mockRejectedValue(err400);
+    const dead = jest.fn().mockResolvedValue(undefined);
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    await expect(handler(makeJob())).rejects.toThrow('Bad Request');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(dead).toHaveBeenCalledTimes(1);
+  });
+
+  it('dead-letters immediately when payload exceeds size limit', async () => {
+    process.env.KYC_WEBHOOK_MAX_PAYLOAD_BYTES = '10';
+
+    const send = jest.fn();
+    const dead = jest.fn().mockResolvedValue(undefined);
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    await expect(handler(makeJob())).rejects.toThrow(/payload exceeds size limit/);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(dead).toHaveBeenCalledWith(expect.objectContaining({
+      smeId: 'sme-abc',
+      lastError: expect.stringContaining('payload exceeds size limit'),
+      attempts: 1,
+    }));
+  });
+
+  it('still throws after dead() itself fails', async () => {
+    process.env.WEBHOOK_MAX_RETRIES = '1';
+    process.env.WEBHOOK_BASE_DELAY = '1';
+
+    const send = jest.fn().mockRejectedValue(Object.assign(new Error('net'), { code: 'ECONNRESET' }));
+    const dead = jest.fn().mockRejectedValue(new Error('db dead fail'));
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    // Should re-throw original error, not the dead() error
+    await expect(handler(makeJob())).rejects.toThrow('net');
+  });
+
+  it('logs retry warnings with attempt number', async () => {
+    process.env.WEBHOOK_MAX_RETRIES = '2';
+    process.env.WEBHOOK_BASE_DELAY = '1';
+
+    const send = jest.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('fail'), { code: 'ECONNRESET' }))
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const dead = jest.fn();
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    await handler(makeJob());
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ attempt: 1 }),
+      expect.stringContaining('transient failure'),
+    );
+  });
+
+  it('handles kycData defaults gracefully when kycData is omitted', async () => {
+    const send = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    const dead = jest.fn();
+    const handler = createKycWebhookDeliveryHandler({ send, dead });
+
+    const job = { id: 'j2', attempts: 1, payload: {
+      smeId: 'sme-1', tenantId: 't1',
+      webhookUrl: 'https://x', webhookSecret: 'sec',
+      event: 'kyc.pending',
+      // kycData intentionally omitted
+    }};
+
+    await expect(handler(job)).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. kycService.persistKycRecord → webhook emission integration
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('kycService.persistKycRecord → webhook integration', () => {
+  let kycService;
+  let emitterModule;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+
+    // Re-mock db and logger for fresh module loads
+    jest.mock('../src/db/knex', () => jest.fn());
+    jest.mock('../src/logger', () => ({ warn: jest.fn(), error: jest.fn(), info: jest.fn() }));
+
+    // Spy on kycWebhookEmitter.emitKycWebhookForSme
+    jest.mock('../src/services/kycWebhookEmitter', () => ({
+      emitKycWebhookForSme: jest.fn().mockResolvedValue(undefined),
+      KYC_WEBHOOK_EVENTS: {
+        VERIFIED: 'kyc.verified', REJECTED: 'kyc.rejected',
+        EXEMPTED: 'kyc.exempted', PENDING:  'kyc.pending',
+      },
+      statusToEvent:             jest.fn(),
+      setSharedWorker:           jest.fn(),
+      findTenantsForSme:         jest.fn(),
+      enqueueKycWebhookDelivery: jest.fn().mockResolvedValue([]),
+      getMaxPayloadBytes:        jest.fn().mockReturnValue(65536),
+      DEFAULT_MAX_PAYLOAD_BYTES: 65536,
+    }));
+
+    kycService   = require('../src/services/kycService');
+    emitterModule = require('../src/services/kycWebhookEmitter');
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  function setupDb(existingRow) {
+    const freshDb = require('../src/db/knex');
+    freshDb.mockImplementation(() => ({
+      where:  jest.fn().mockReturnThis(),
+      first:  jest.fn().mockResolvedValue(existingRow),
+      insert: jest.fn().mockResolvedValue([1]),
+      update: jest.fn().mockResolvedValue(1),
+    }));
+  }
+
+  it('calls emitKycWebhookForSme after insert (new record)', async () => {
+    setupDb(null); // no existing row → insert path
+    await kycService.persistKycRecord({ smeId: 'sme-new', status: 'verified' });
+    expect(emitterModule.emitKycWebhookForSme).toHaveBeenCalledWith(
+      expect.objectContaining({ smeId: 'sme-new', status: 'verified' }),
+    );
+  });
+
+  it('calls emitKycWebhookForSme after update (existing record)', async () => {
+    setupDb({ sme_id: 'sme-existing' });
+    await kycService.persistKycRecord({ smeId: 'sme-existing', status: 'rejected' });
+    expect(emitterModule.emitKycWebhookForSme).toHaveBeenCalledWith(
+      expect.objectContaining({ smeId: 'sme-existing', status: 'rejected' }),
+    );
+  });
+
+  it('passes recordId and verifiedAt through to the emitter', async () => {
+    setupDb(null);
+    await kycService.persistKycRecord({
+      smeId: 'sme-full', status: 'verified',
+      providerRecordId: 'rec_99', verifiedAt: '2026-07-01T00:00:00Z',
+    });
+    expect(emitterModule.emitKycWebhookForSme).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordId: 'rec_99',
+        verifiedAt: '2026-07-01T00:00:00Z',
+      }),
+    );
+  });
+
+  it('persistKycRecord still resolves even when emitter throws', async () => {
+    setupDb(null);
+    emitterModule.emitKycWebhookForSme.mockRejectedValueOnce(new Error('emitter crash'));
+
+    const result = await kycService.persistKycRecord({ smeId: 'sme-robust', status: 'pending' });
+    expect(result).toMatchObject({ smeId: 'sme-robust', status: 'pending' });
+  });
+
+  it('emits correct event for each KYC status', async () => {
+    for (const [status] of [['verified'], ['rejected'], ['exempted'], ['pending']]) {
+      jest.clearAllMocks();
+      emitterModule.emitKycWebhookForSme.mockResolvedValue(undefined);
+      setupDb(null);
+
+      await kycService.persistKycRecord({ smeId: `sme-${status}`, status });
+      expect(emitterModule.emitKycWebhookForSme).toHaveBeenCalledWith(
+        expect.objectContaining({ status }),
+      );
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Payload structure and signature compatibility
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('KYC webhook payload structure', () => {
+  const { sortKeys, createSignatureHeader, verifySignature } = require('../src/services/webhooks');
+
+  it('payload keys are deterministically sorted', () => {
+    const payload = sortKeys({
+      tenantId: 't1', event: 'kyc.verified', smeId: 'sme-1',
+      timestamp: '2026-01-01T00:00:00Z',
+      kyc: { verifiedAt: null, status: 'verified', recordId: 'r1' },
+    });
+    const keys = Object.keys(payload);
+    expect(keys).toEqual([...keys].sort());
+  });
+
+  it('signed payload passes verifySignature', () => {
+    const secret = 'webhook-secret-abc';
+    const payload = sortKeys({
+      event: 'kyc.verified', smeId: 'sme-1', tenantId: 't1',
+      timestamp: '2026-01-01T00:00:00Z',
+      kyc: { recordId: 'r1', status: 'verified', verifiedAt: null },
+    });
+    const body   = JSON.stringify(payload);
+    const header = createSignatureHeader(secret, body);
+    const result = verifySignature(secret, body, header, 60_000);
+    expect(result.valid).toBe(true);
+  });
+
+  it('tampered payload fails verifySignature', () => {
+    const secret  = 'webhook-secret-abc';
+    const body    = JSON.stringify({ event: 'kyc.verified', smeId: 'sme-1' });
+    const header  = createSignatureHeader(secret, body);
+    const tampered = JSON.stringify({ event: 'kyc.exempted', smeId: 'sme-1' });
+    const result  = verifySignature(secret, tampered, header, 60_000);
+    expect(result.valid).toBe(false);
+  });
+
+  it('KYC_WEBHOOK_EVENTS contains all four events', () => {
+    expect(KYC_WEBHOOK_EVENTS).toEqual({
+      VERIFIED: 'kyc.verified',
+      REJECTED: 'kyc.rejected',
+      EXEMPTED: 'kyc.exempted',
+      PENDING:  'kyc.pending',
+    });
+  });
+});


### PR DESCRIPTION
- Add kyc_webhook_dead_letters migration (sme_id-scoped DLQ table)
- Add src/services/kycWebhookEmitter.js: tenant lookup via invoices, payload-size bounding (KYC_WEBHOOK_MAX_PAYLOAD_BYTES, default 64 KB), fire-and-forget emitKycWebhookForSme(), enqueueKycWebhookDelivery()
- Add src/jobs/kycWebhookDelivery.js: createKycWebhookDeliveryHandler with exponential-backoff retry, dead-letter path, Prometheus metrics
- Hook emitKycWebhookForSme into kycService.persistKycRecord (fire-and-forget)
- Emit kyc.verified / kyc.rejected / kyc.exempted / kyc.pending events
- 60 tests covering delivery, retry, DLQ, payload-size guard, signature verification, kycService integration, and all edge cases

closes #955