### PR TITLE
feat(api-keys): add bulk operations endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,6 +35,7 @@ const { performHealthChecks } = require('./services/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
+const apiKeysRoutes = require('./routes/apiKeys').router;
 
 /**
  * Returns a 403 JSON response only for the dedicated blocked-origin CORS error.
@@ -151,6 +152,8 @@ function createApp() {
       },
     });
   });
+
+  app.use('/api/api-keys', apiKeysRoutes);
 
   // Invoices — GET (list)
   app.get('/api/invoices', async (req, res) => {

--- a/src/routes/apiKeys.js
+++ b/src/routes/apiKeys.js
@@ -1,0 +1,264 @@
+'use strict';
+
+const express = require('express');
+const { z } = require('zod');
+const { hashApiKey, initDb } = require('../middleware/apiKey');
+const AppError = require('../errors/AppError');
+
+const router = express.Router();
+
+const MAX_BULK_ITEMS = 25;
+
+const bulkItemSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('create'),
+    name: z.string().trim().min(1).max(255),
+    apiKey: z.string().trim().min(8).max(4096),
+  }),
+  z.object({
+    action: z.literal('rename'),
+    id: z.number().int().positive(),
+    name: z.string().trim().min(1).max(255),
+  }),
+  z.object({
+    action: z.literal('activate'),
+    id: z.number().int().positive(),
+  }),
+  z.object({
+    action: z.literal('deactivate'),
+    id: z.number().int().positive(),
+  }),
+]);
+
+/**
+ * Closes the SQLite database handle.
+ *
+ * @param {object} db - SQLite database handle.
+ * @returns {Promise<void>}
+ */
+function closeDb(db) {
+  return new Promise((resolve, reject) => {
+    db.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+/**
+ * Runs an SQL statement on the provided database handle.
+ *
+ * @param {object} db - SQLite database handle.
+ * @param {string} sql - SQL statement to execute.
+ * @param {unknown[]} [params=[]] - Statement parameters.
+ * @returns {Promise<object>} Statement metadata.
+ */
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function onRun(err) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(this);
+    });
+  });
+}
+
+/**
+ * Fetches a single row from the provided database handle.
+ *
+ * @param {object} db - SQLite database handle.
+ * @param {string} sql - SQL statement to execute.
+ * @param {unknown[]} [params=[]] - Statement parameters.
+ * @returns {Promise<object|undefined>} Query result row.
+ */
+function get(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(row);
+    });
+  });
+}
+
+/**
+ * Ensures the api_keys table exists before processing a bulk request.
+ *
+ * @param {object} db - SQLite database handle.
+ * @returns {Promise<void>}
+ */
+async function ensureApiKeyTable(db) {
+  await run(db, `
+    CREATE TABLE IF NOT EXISTS api_keys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      key_hash TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      last_used_at DATETIME,
+      is_active BOOLEAN DEFAULT 1,
+      audit_log TEXT
+    )
+  `);
+}
+
+/**
+ * Creates a new API key entry.
+ *
+ * @param {object} db - SQLite database handle.
+ * @param {object} item - Parsed bulk operation.
+ * @returns {Promise<object>} Created key summary.
+ */
+async function createKey(db, item) {
+  const keyHash = hashApiKey(item.apiKey);
+  await run(db, 'INSERT INTO api_keys (key_hash, name, is_active) VALUES (?, ?, 1)', [
+    keyHash,
+    item.name,
+  ]);
+  const row = await get(db, 'SELECT id, name, is_active FROM api_keys WHERE key_hash = ?', [keyHash]);
+  return {
+    id: row.id,
+    name: row.name,
+    isActive: Boolean(row.is_active),
+  };
+}
+
+/**
+ * Updates an existing API key entry.
+ *
+ * @param {object} db - SQLite database handle.
+ * @param {object} item - Parsed bulk operation.
+ * @returns {Promise<object>} Updated key summary.
+ */
+async function updateKey(db, item) {
+  const existing = await get(db, 'SELECT id, name, is_active FROM api_keys WHERE id = ?', [item.id]);
+  if (!existing) {
+    throw new AppError({
+      type: 'https://liquifact.com/probs/not-found',
+      title: 'API Key Not Found',
+      status: 404,
+      detail: `API key ${item.id} was not found`,
+    });
+  }
+
+  if (item.action === 'rename') {
+    await run(db, 'UPDATE api_keys SET name = ? WHERE id = ?', [item.name, item.id]);
+  } else {
+    await run(db, 'UPDATE api_keys SET is_active = ? WHERE id = ?', [item.action === 'activate' ? 1 : 0, item.id]);
+  }
+
+  const updated = await get(db, 'SELECT id, name, is_active FROM api_keys WHERE id = ?', [item.id]);
+  return {
+    id: updated.id,
+    name: updated.name,
+    isActive: Boolean(updated.is_active),
+  };
+}
+
+/**
+ * Normalizes thrown errors into a human-readable message string.
+ *
+ * @param {unknown} err - Thrown value.
+ * @returns {string} Readable error message.
+ */
+function normalizeError(err) {
+  if (err instanceof z.ZodError) {
+    return err.issues.map((issue) => issue.message).join(', ');
+  }
+  if (err && typeof err.message === 'string') {
+    return err.message;
+  }
+  return 'Unknown item error';
+}
+
+/**
+ * Processes a bounded bulk batch of api-key operations.
+ *
+ * @param {import('express').Request} req - Express request.
+ * @param {import('express').Response} res - Express response.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @returns {Promise<import('express').Response|void>}
+ */
+router.post('/bulk', async (req, res, next) => {
+  const items = req.body;
+
+  if (!Array.isArray(items)) {
+    return next(
+      new AppError({
+        type: 'https://liquifact.com/probs/validation-error',
+        title: 'Validation Error',
+        status: 400,
+        detail: 'Request body must be a JSON array of api-key operations',
+      })
+    );
+  }
+
+  if (items.length === 0) {
+    return next(
+      new AppError({
+        type: 'https://liquifact.com/probs/validation-error',
+        title: 'Validation Error',
+        status: 400,
+        detail: 'Batch must contain at least one api-key operation',
+      })
+    );
+  }
+
+  if (items.length > MAX_BULK_ITEMS) {
+    return next(
+      new AppError({
+        type: 'https://liquifact.com/probs/validation-error',
+        title: 'Validation Error',
+        status: 400,
+        detail: `Batch size exceeds maximum of ${MAX_BULK_ITEMS}`,
+      })
+    );
+  }
+
+  const db = initDb();
+  try {
+    await ensureApiKeyTable(db);
+    const results = [];
+
+    for (const [index, rawItem] of items.entries()) {
+      try {
+        const item = bulkItemSchema.parse(rawItem);
+        let result;
+
+        if (item.action === 'create') {
+          result = await createKey(db, item);
+        } else {
+          result = await updateKey(db, item);
+        }
+
+        results.push({ index, success: true, action: item.action, result });
+      } catch (err) {
+        results.push({
+          index,
+          success: false,
+          error: normalizeError(err),
+        });
+      }
+    }
+
+    const summary = {
+      total: results.length,
+      succeeded: results.filter((item) => item.success).length,
+      failed: results.filter((item) => !item.success).length,
+    };
+
+    return res.status(200).json({
+      data: results,
+      summary,
+    });
+  } catch (err) {
+    return next(err);
+  } finally {
+    await closeDb(db);
+  }
+});
+
+module.exports = {
+  router,
+  MAX_BULK_ITEMS,
+};

--- a/tests/apiKeys.bulk.test.js
+++ b/tests/apiKeys.bulk.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+const testDbPath = path.join(__dirname, 'test_api_keys_bulk.db');
+process.env.API_KEYS_DB_PATH = testDbPath;
+
+const { router } = require('../src/routes/apiKeys');
+const { hashApiKey, initDb } = require('../src/middleware/apiKey');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/api-keys', router);
+  app.use((err, req, res, next) => {
+    if (err.type) {
+      res.status(err.status || 500).json({ error: { message: err.detail || err.message } });
+      return;
+    }
+    next(err);
+  });
+  return app;
+}
+
+describe('API key bulk operations', () => {
+  beforeEach(async () => {
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+
+    const db = initDb();
+    await new Promise((resolve, reject) => {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS api_keys (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          key_hash TEXT NOT NULL UNIQUE,
+          name TEXT NOT NULL,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          last_used_at DATETIME,
+          is_active BOOLEAN DEFAULT 1,
+          audit_log TEXT
+        )
+      `, (err) => (err ? reject(err) : resolve()));
+    });
+
+    await new Promise((resolve, reject) => {
+      db.run(
+        'INSERT INTO api_keys (key_hash, name, is_active) VALUES (?, ?, ?)',
+        [hashApiKey('existing-key'), 'existing-service', 1],
+        (err) => (err ? reject(err) : resolve())
+      );
+    });
+
+    await new Promise((resolve) => db.close(() => resolve()));
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  test('rejects empty batch', async () => {
+    const app = createTestApp();
+    const response = await request(app).post('/api/api-keys/bulk').send([]);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.message).toBe('Batch must contain at least one api-key operation');
+  });
+
+  test('rejects over-cap batch', async () => {
+    const app = createTestApp();
+    const payload = Array.from({ length: 26 }, (_, index) => ({
+      action: 'create',
+      name: `service-${index}`,
+      apiKey: `key-${index}-12345`,
+    }));
+
+    const response = await request(app).post('/api/api-keys/bulk').send(payload);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.message).toBe('Batch size exceeds maximum of 25');
+  });
+
+  test('returns per-item success and failure without failing the batch', async () => {
+    const app = createTestApp();
+    const response = await request(app)
+      .post('/api/api-keys/bulk')
+      .send([
+        {
+          action: 'create',
+          name: 'new-service',
+          apiKey: 'new-secret-key-12345',
+        },
+        {
+          action: 'rename',
+          id: 999,
+          name: 'missing-service',
+        },
+        {
+          action: 'deactivate',
+          id: 1,
+        },
+      ]);
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({
+      total: 3,
+      succeeded: 2,
+      failed: 1,
+    });
+    expect(response.body.data).toHaveLength(3);
+    expect(response.body.data[0]).toMatchObject({
+      index: 0,
+      success: true,
+      action: 'create',
+    });
+    expect(response.body.data[1]).toMatchObject({
+      index: 1,
+      success: false,
+    });
+    expect(response.body.data[1].error).toMatch(/API Key Not Found|API key 999 was not found/);
+    expect(response.body.data[2]).toMatchObject({
+      index: 2,
+      success: true,
+      action: 'deactivate',
+      result: {
+        id: 1,
+        name: 'existing-service',
+        isActive: false,
+      },
+    });
+  });
+
+  test('validates individual items', async () => {
+    const app = createTestApp();
+    const response = await request(app)
+      .post('/api/api-keys/bulk')
+      .send([
+        {
+          action: 'create',
+          name: '',
+          apiKey: 'bad',
+        },
+      ]);
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({
+      total: 1,
+      succeeded: 0,
+      failed: 1,
+    });
+    expect(response.body.data[0].success).toBe(false);
+    expect(response.body.data[0].error).toMatch(/Too small|String must contain at least 1 character/);
+  });
+});


### PR DESCRIPTION
## Summary closes #827 
Added a bounded bulk endpoint for api-key operations at `POST /api/api-keys/bulk`.

## Behavior
- Accepts a JSON array of api-key operations
- Validates each item individually
- Enforces a maximum batch size of 25
- Returns per-item success/error results without failing the whole batch
- Rejects empty batches
- Rejects over-cap batches

## Tests
Added coverage for:
- empty batch
- partial failure
- over-cap rejected
- per-item validation failures

## Verification
- `npm.cmd test -- --runInBand tests/apiKeys.bulk.test.js`
- `npm.cmd exec eslint src/routes/apiKeys.js tests/apiKeys.bulk.test.js`

## Notes
- Mixed-success batches return `200` with per-item result objects

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/54049b83-8d7c-486f-8032-32d07ff1495e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1a94151e-d988-4c1f-8e01-1d45efca9132" />