### PR TITLE
feat(config): compress large responses

### DIFF
--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -27,6 +27,7 @@
  */
 
 const express = require('express');
+const compression = require('compression');
 const { adminStack } = require('../middleware/stacks');
 const {
   runtimeConfigSchema,
@@ -37,9 +38,11 @@ const { adminConfigLimiter } = require('../middleware/rateLimit');
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
 const logger = require('../logger');
-const idempotencyMiddleware = require('../middleware/idempotency');
 
 const router = express.Router();
+
+// Compress config responses above 500 bytes (issue #52)
+router.use(compression({ threshold: 500 }));
 
 // ── Apply per-client rate limit *before* admin auth + tenant extraction ─────
 // Mounting the limiter ahead of adminStack ensures failed authentication

--- a/tests/adminConfig.compression.test.js
+++ b/tests/adminConfig.compression.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+// Mock admin stack to bypass authentication for these tests
+jest.mock('../src/middleware/stacks', () => ({
+  adminStack: [(req, res, next) => {
+    req.tenantId = 'tenant_123';
+    next();
+  }],
+}));
+
+// Mock idempotency middleware since we don't want to set up the DB
+jest.mock('../src/middleware/idempotency', () => (req, res, next) => next());
+
+// Mock rate limiter
+jest.mock('../src/middleware/rateLimit', () => ({
+  adminConfigLimiter: (req, res, next) => next(),
+}));
+
+// We only need to test the route behavior
+const adminConfigRouter = require('../src/routes/adminConfig');
+
+describe('Admin Config Compression', () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // Mount it at the expected path
+    app.use('/api/admin/config', adminConfigRouter);
+  });
+
+  // A small payload < 500 bytes
+  const smallPayload = {
+    section: 'webhook',
+    config: {
+      url: 'https://example.com/webhook',
+      secret: 'supersecret_1234567890',
+      events: ['invoice.created'],
+    }
+  };
+
+  // A large payload > 500 bytes
+  const largeEvents = Array(45).fill(0).map((_, i) => `event.name.number.${i}.which.is.long`);
+  const largePayload = {
+    section: 'webhook',
+    config: {
+      url: 'https://example.com/webhook',
+      secret: 'supersecret_1234567890',
+      events: largeEvents,
+    }
+  };
+
+  it('does not compress small responses', async () => {
+    const res = await request(app)
+      .post('/api/admin/config')
+      .set('Accept-Encoding', 'gzip')
+      .send(smallPayload);
+      
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('compresses large responses above the threshold', async () => {
+    const res = await request(app)
+      .post('/api/admin/config')
+      .set('Accept-Encoding', 'gzip')
+      .send(largePayload);
+      
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  it('does not compress large responses if Accept-Encoding is not set', async () => {
+    const res = await request(app)
+      .post('/api/admin/config')
+      .send(largePayload);
+      
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #976 


Large config responses waste bandwidth. This PR enables `gzip`/`deflate` compression for them, respecting the `Accept-Encoding` header.

### Changes
- Added the `compression` middleware to the `/api/admin/config` router in `src/routes/adminConfig.js`.
- Configured a size threshold (500 bytes) so that smaller payloads remain uncompressed.
- Created `tests/adminConfig.compression.test.js` to ensure the threshold is respected and `Accept-Encoding` is handled correctly.
- Removed a duplicated `idempotencyMiddleware` declaration in `src/routes/adminConfig.js` to resolve a preexisting linting error in the file.

### Test Output
```text
PASS tests/adminConfig.compression.test.js
  Admin Config Compression
    ✓ does not compress small responses (12 ms)
    ✓ compresses large responses above the threshold (8 ms)
    ✓ does not compress large responses if Accept-Encoding is not set (6 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```
*(All `npm run lint`, `npm test`, and `npm run build` checks pass successfully)*