### PR TITLE
refactor(indexer): add validation schemas for request/response payloads

### DIFF
--- a/src/routes/adminIndexer.js
+++ b/src/routes/adminIndexer.js
@@ -16,117 +16,16 @@
 const express = require('express');
 
 const router = express.Router();
-const { listIndexerEvents, INDEXER_SORT_FIELDS } = require('../services/indexerService');
+const { listIndexerEvents } = require('../services/indexerService');
 const { CursorError } = require('../utils/cursorPagination');
 const { adminStack } = require('../middleware/stacks');
 const responseHelper = require('../utils/responseHelper');
 const logger = require('../logger');
-
-/**
- * Maximum page size clamped by the service layer.
- * @constant {number}
- */
-const MAX_LIMIT = 100;
+const { validateIndexerQuery } = require('../schemas/indexerQuery');
 
 // Apply admin auth (JWT or API key) + tenant extraction to every route in this
 // file.
 router.use(...adminStack);
-
-/**
- * Validates and normalises query parameters for the events listing endpoint.
- *
- * @param {object} query - Express `req.query` object.
- * @returns {{ isValid: boolean, fieldErrors: Record<string,string>, params: object }}
- */
-function _parseQuery(query) {
-  const fieldErrors = {};
-  const params = { filters: {}, sorting: {}, pagination: {} };
-
-  const ALLOWED_PARAMS = new Set(['invoiceId', 'eventType', 'contractId', 'sortBy', 'order', 'cursor', 'page', 'limit']);
-  const unknown = Object.keys(query).filter((k) => !ALLOWED_PARAMS.has(k));
-  if (unknown.length > 0) {
-    fieldErrors._unknown = `Unknown query parameters: ${unknown.join(', ')}`;
-  }
-
-  const { invoiceId, eventType, contractId, sortBy, order, cursor, page, limit } = query;
-
-  // ── Filters ───────────────────────────────────────────────────────────────
-  if (invoiceId !== undefined) {
-    if (typeof invoiceId === 'string' && /^[a-zA-Z0-9_-]{1,128}$/.test(invoiceId.trim())) {
-      params.filters.invoiceId = invoiceId.trim();
-    } else {
-      fieldErrors.invoiceId = 'invoiceId must be 1–128 alphanumeric/underscore/hyphen characters';
-    }
-  }
-
-  if (eventType !== undefined) {
-    if (typeof eventType === 'string' && eventType.trim().length > 0 && eventType.trim().length <= 128) {
-      params.filters.eventType = eventType.trim();
-    } else {
-      fieldErrors.eventType = 'eventType must be a non-empty string (max 128 chars)';
-    }
-  }
-
-  if (contractId !== undefined) {
-    if (typeof contractId === 'string' && /^C[A-Z2-7]{55}$/.test(contractId.trim())) {
-      params.filters.contractId = contractId.trim();
-    } else {
-      fieldErrors.contractId = 'contractId must be a valid Stellar contract address (C… 56 chars)';
-    }
-  }
-
-  // ── Sorting ───────────────────────────────────────────────────────────────
-  if (sortBy !== undefined) {
-    if (INDEXER_SORT_FIELDS.includes(sortBy)) {
-      params.sorting.sortBy = sortBy;
-    } else {
-      fieldErrors.sortBy = `sortBy must be one of: ${INDEXER_SORT_FIELDS.join(', ')}`;
-    }
-  }
-
-  if (order !== undefined) {
-    const lowerOrder = String(order).toLowerCase();
-    if (lowerOrder === 'asc' || lowerOrder === 'desc') {
-      params.sorting.order = lowerOrder;
-    } else {
-      fieldErrors.order = 'order must be "asc" or "desc"';
-    }
-  }
-
-  // ── Pagination ────────────────────────────────────────────────────────────
-  if (cursor !== undefined) {
-    if (typeof cursor === 'string' && cursor.length > 0 && cursor.length <= 2048) {
-      params.pagination.cursor = cursor;
-    } else {
-      fieldErrors.cursor = 'cursor must be a non-empty string (max 2048 chars)';
-    }
-  }
-
-  // page is only relevant when no cursor is provided
-  if (cursor === undefined && page !== undefined) {
-    const val = parseInt(page, 10);
-    if (!isNaN(val) && val >= 1) {
-      params.pagination.page = val;
-    } else {
-      fieldErrors.page = 'page must be an integer >= 1';
-    }
-  }
-
-  if (limit !== undefined) {
-    const val = parseInt(limit, 10);
-    if (!isNaN(val) && val >= 1 && val <= MAX_LIMIT) {
-      params.pagination.limit = val;
-    } else {
-      fieldErrors.limit = `limit must be an integer between 1 and ${MAX_LIMIT}`;
-    }
-  }
-
-  return {
-    isValid: Object.keys(fieldErrors).length === 0,
-    fieldErrors,
-    params,
-  };
-}
 
 /**
  * @swagger
@@ -252,8 +151,8 @@ function _parseQuery(query) {
  */
 router.get('/events', async (req, res, next) => {
   try {
-    // ── 1. Parse and validate query parameters ──────────────────────────────
-    const { isValid, fieldErrors, params } = _parseQuery(req.query);
+    // ── 1. Parse and validate query parameters using Zod schema ───────────────
+    const { isValid, fieldErrors, params } = validateIndexerQuery(req.query);
 
     if (!isValid) {
       return res.status(400).json(

--- a/src/schemas/indexerQuery.js
+++ b/src/schemas/indexerQuery.js
@@ -1,0 +1,258 @@
+'use strict';
+
+/**
+ * @fileoverview Zod validation schemas for indexer query request payloads.
+ *
+ * Replaces ad-hoc validation in the admin indexer route with declarative
+ * schemas that produce structured error messages at the API boundary.
+ *
+ * @module schemas/indexerQuery
+ */
+
+const { z } = require('zod');
+const { INDEXER_SORT_FIELDS } = require('../services/indexerService');
+
+/**
+ * Regex for invoiceId validation: 1-128 alphanumeric/underscore/hyphen characters.
+ */
+const INVOICE_ID_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
+
+/**
+ * Regex for contractId validation: Stellar contract address (C + 55 alphanumeric/base32 chars).
+ */
+const CONTRACT_ID_REGEX = /^C[A-Z2-7]{55}$/;
+
+/**
+ * Maximum allowed limit for pagination.
+ */
+const MAX_LIMIT = 100;
+
+/**
+ * Schema for the invoiceId query parameter.
+ */
+const invoiceIdSchema = z
+  .string({ invalid_type_error: 'invoiceId must be a string' })
+  .trim()
+  .regex(INVOICE_ID_REGEX, {
+    message: 'invoiceId must be 1-128 alphanumeric/underscore/hyphen characters',
+  })
+  .optional();
+
+/**
+ * Schema for the eventType query parameter.
+ */
+const eventTypeSchema = z
+  .string({ invalid_type_error: 'eventType must be a string' })
+  .min(1, { message: 'eventType must be a non-empty string (max 128 chars)' })
+  .max(128, { message: 'eventType must be a non-empty string (max 128 chars)' })
+  .trim()
+  .optional();
+
+/**
+ * Schema for the contractId query parameter.
+ */
+const contractIdSchema = z
+  .string({ invalid_type_error: 'contractId must be a string' })
+  .regex(CONTRACT_ID_REGEX, {
+    message: 'contractId must be a valid Stellar contract address (C... 56 chars)',
+  })
+  .trim()
+  .optional();
+
+/**
+ * Schema for the sortBy query parameter.
+ */
+const sortBySchema = z
+  .string({ invalid_type_error: 'sortBy must be a string' })
+  .refine((val) => INDEXER_SORT_FIELDS.includes(val), {
+    message: `sortBy must be one of: ${INDEXER_SORT_FIELDS.join(', ')}`,
+  })
+  .optional();
+
+/**
+ * Schema for the order query parameter.
+ */
+const orderSchema = z
+  .string({ invalid_type_error: 'order must be a string' })
+  .transform((val) => val.toLowerCase())
+  .refine((val) => val === 'asc' || val === 'desc', {
+    message: 'order must be "asc" or "desc"',
+  })
+  .optional();
+
+/**
+ * Schema for the cursor query parameter.
+ */
+const cursorSchema = z
+  .string({ invalid_type_error: 'cursor must be a string' })
+  .min(1, { message: 'cursor must be a non-empty string (max 2048 chars)' })
+  .max(2048, { message: 'cursor must be a non-empty string (max 2048 chars)' })
+  .optional();
+
+/**
+ * Schema for the page query parameter.
+ */
+const pageSchema = z
+  .string({ invalid_type_error: 'page must be a string' })
+  .transform((val, ctx) => {
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'page must be an integer >= 1',
+      });
+      return z.NEVER;
+    }
+    return parsed;
+  })
+  .refine((val) => val >= 1, {
+    message: 'page must be an integer >= 1',
+  })
+  .optional();
+
+/**
+ * Schema for the limit query parameter.
+ */
+const limitSchema = z
+  .string({ invalid_type_error: 'limit must be a string' })
+  .transform((val, ctx) => {
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `limit must be an integer between 1 and ${MAX_LIMIT}`,
+      });
+      return z.NEVER;
+    }
+    return parsed;
+  })
+  .refine((val) => val >= 1 && val <= MAX_LIMIT, {
+    message: `limit must be an integer between 1 and ${MAX_LIMIT}`,
+  })
+  .optional();
+
+/**
+ * Complete schema for the indexer query parameters.
+ * All fields are optional since they are query params with defaults applied in the route.
+ */
+const indexerQuerySchema = z
+  .object({
+    invoiceId: invoiceIdSchema,
+    eventType: eventTypeSchema,
+    contractId: contractIdSchema,
+    sortBy: sortBySchema,
+    order: orderSchema,
+    cursor: cursorSchema,
+    page: pageSchema,
+    limit: limitSchema,
+  })
+  .strict();
+
+/**
+ * Parses Zod validation errors into a field-level error map.
+ *
+ * @param {import('zod').ZodError} zodError - The Zod validation error.
+ * @returns {Record<string, string>} Field name to error message mapping.
+ */
+function parseValidationErrors(zodError) {
+  const fieldErrors = {};
+  for (const issue of zodError.issues ?? zodError.errors ?? []) {
+    const path = issue.path.join('.') || '_root';
+    if (!fieldErrors[path]) {
+      fieldErrors[path] = issue.message;
+    }
+  }
+  return fieldErrors;
+}
+
+/**
+ * Validates query parameters against the indexer schema.
+ *
+ * @param {object} query - Express req.query object.
+ * @returns {{ isValid: boolean, fieldErrors: Record<string, string>, params: object }}
+ *   Validation result with field errors and parsed parameters.
+ */
+function validateIndexerQuery(query) {
+  // First check for unknown parameters
+  const ALLOWED_PARAMS = new Set([
+    'invoiceId', 'eventType', 'contractId', 'sortBy', 'order', 'cursor', 'page', 'limit'
+  ]);
+  const unknown = Object.keys(query).filter((k) => !ALLOWED_PARAMS.has(k));
+  if (unknown.length > 0) {
+    return {
+      isValid: false,
+      fieldErrors: { _unknown: `Unknown query parameters: ${unknown.join(', ')}` },
+      params: {},
+    };
+  }
+
+  // Ignore page when cursor is supplied (matches original behaviour)
+  const queryToValidate = { ...query };
+  if (queryToValidate.cursor && queryToValidate.page !== undefined) {
+    delete queryToValidate.page;
+  }
+
+  const result = indexerQuerySchema.safeParse(queryToValidate);
+
+  if (!result.success) {
+    const fieldErrors = parseValidationErrors(result.error);
+    return {
+      isValid: false,
+      fieldErrors,
+      params: {},
+    };
+  }
+
+  // Parse validated data into the expected params structure
+  const validated = result.data;
+  const params = {
+    filters: {},
+    sorting: {},
+    pagination: {},
+  };
+
+  // Apply filters
+  if (validated.invoiceId !== undefined) {
+    params.filters.invoiceId = validated.invoiceId;
+  }
+  if (validated.eventType !== undefined) {
+    params.filters.eventType = validated.eventType;
+  }
+  if (validated.contractId !== undefined) {
+    params.filters.contractId = validated.contractId;
+  }
+
+  // Apply sorting
+  if (validated.sortBy !== undefined) {
+    params.sorting.sortBy = validated.sortBy;
+  }
+  if (validated.order !== undefined) {
+    params.sorting.order = validated.order;
+  }
+
+  // Apply pagination
+  if (validated.cursor !== undefined) {
+    params.pagination.cursor = validated.cursor;
+  }
+  if (validated.page !== undefined) {
+    params.pagination.page = validated.page;
+  }
+  if (validated.limit !== undefined) {
+    params.pagination.limit = validated.limit;
+  }
+
+  return {
+    isValid: true,
+    fieldErrors: {},
+    params,
+  };
+}
+
+module.exports = {
+  indexerQuerySchema,
+  parseValidationErrors,
+  validateIndexerQuery,
+  INVOICE_ID_REGEX,
+  CONTRACT_ID_REGEX,
+  MAX_LIMIT,
+};

--- a/tests/indexerQuery.schema.test.js
+++ b/tests/indexerQuery.schema.test.js
@@ -1,0 +1,559 @@
+'use strict';
+
+/**
+ * @fileoverview Comprehensive tests for indexer query validation schemas (#930).
+ *
+ * Covers:
+ *  - indexerQuerySchema: valid passes, invalid rejected with details
+ *  - validateIndexerQuery: integration helper producing field-level errors
+ *  - parseValidationErrors: Zod error formatting
+ *  - Edge cases: unknown params, boundary values, type coercion
+ */
+
+const {
+  indexerQuerySchema,
+  validateIndexerQuery,
+  parseValidationErrors,
+  INVOICE_ID_REGEX,
+  CONTRACT_ID_REGEX,
+  MAX_LIMIT,
+} = require('../src/schemas/indexerQuery');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const VALID_CONTRACT_ID = 'CDLZFC3SYJ27SBCC6BAKCY73WFXHBTE357R67CW567QX65ECUGN45RXI';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regex exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Schema constants', () => {
+  test('INVOICE_ID_REGEX matches valid invoice IDs', () => {
+    expect(INVOICE_ID_REGEX.test('inv_123')).toBe(true);
+    expect(INVOICE_ID_REGEX.test('a')).toBe(true);
+    expect(INVOICE_ID_REGEX.test('A'.repeat(128))).toBe(true);
+    expect(INVOICE_ID_REGEX.test('my-invoice-001')).toBe(true);
+  });
+
+  test('INVOICE_ID_REGEX rejects invalid invoice IDs', () => {
+    expect(INVOICE_ID_REGEX.test('')).toBe(false);
+    expect(INVOICE_ID_REGEX.test('has spaces')).toBe(false);
+    expect(INVOICE_ID_REGEX.test('a'.repeat(129))).toBe(false);
+    expect(INVOICE_ID_REGEX.test('special!chars')).toBe(false);
+  });
+
+  test('CONTRACT_ID_REGEX matches valid Stellar contract IDs', () => {
+    expect(CONTRACT_ID_REGEX.test(VALID_CONTRACT_ID)).toBe(true);
+  });
+
+  test('CONTRACT_ID_REGEX rejects invalid contract IDs', () => {
+    expect(CONTRACT_ID_REGEX.test('BADADDR')).toBe(false);
+    expect(CONTRACT_ID_REGEX.test('')).toBe(false);
+    expect(CONTRACT_ID_REGEX.test('D' + 'A'.repeat(55))).toBe(false); // Wrong prefix
+    expect(CONTRACT_ID_REGEX.test('C' + 'A'.repeat(54))).toBe(false); // Too short
+  });
+
+  test('MAX_LIMIT is 100', () => {
+    expect(MAX_LIMIT).toBe(100);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// indexerQuerySchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('indexerQuerySchema', () => {
+  describe('valid payloads', () => {
+    test('empty object (all fields optional)', () => {
+      const result = indexerQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    test('all valid filter params', () => {
+      const result = indexerQuerySchema.safeParse({
+        invoiceId: 'inv_001',
+        eventType: 'escrow_created',
+        contractId: VALID_CONTRACT_ID,
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.invoiceId).toBe('inv_001');
+      expect(result.data.eventType).toBe('escrow_created');
+      expect(result.data.contractId).toBe(VALID_CONTRACT_ID);
+    });
+
+    test('valid sorting params', () => {
+      const result = indexerQuerySchema.safeParse({
+        sortBy: 'observed_at',
+        order: 'asc',
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.sortBy).toBe('observed_at');
+      // Order is lowercased by transform
+      expect(result.data.order).toBe('asc');
+    });
+
+    test('order is case-insensitive', () => {
+      const asc = indexerQuerySchema.safeParse({ order: 'ASC' });
+      expect(asc.success).toBe(true);
+      expect(asc.data.order).toBe('asc');
+
+      const desc = indexerQuerySchema.safeParse({ order: 'DESC' });
+      expect(desc.success).toBe(true);
+      expect(desc.data.order).toBe('desc');
+
+      const mixed = indexerQuerySchema.safeParse({ order: 'Desc' });
+      expect(mixed.success).toBe(true);
+      expect(mixed.data.order).toBe('desc');
+    });
+
+    test('valid pagination params (offset mode)', () => {
+      const result = indexerQuerySchema.safeParse({
+        page: '3',
+        limit: '20',
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.page).toBe(3);
+      expect(result.data.limit).toBe(20);
+    });
+
+    test('valid cursor pagination', () => {
+      const cursor = 'someValidCursor.abc123';
+      const result = indexerQuerySchema.safeParse({ cursor });
+      expect(result.success).toBe(true);
+      expect(result.data.cursor).toBe(cursor);
+    });
+
+    test('all valid params together', () => {
+      const result = indexerQuerySchema.safeParse({
+        invoiceId: 'inv_001',
+        eventType: 'escrow_funded',
+        sortBy: 'ledger_sequence',
+        order: 'desc',
+        page: '1',
+        limit: '50',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('invalid payloads', () => {
+    test('invalid invoiceId (contains space)', () => {
+      const result = indexerQuerySchema.safeParse({
+        invoiceId: 'has spaces',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('invoiceId too long (>128 chars)', () => {
+      const result = indexerQuerySchema.safeParse({
+        invoiceId: 'a'.repeat(129),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('eventType too long (>128 chars)', () => {
+      const result = indexerQuerySchema.safeParse({
+        eventType: 'a'.repeat(129),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('eventType empty string', () => {
+      const result = indexerQuerySchema.safeParse({
+        eventType: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('invalid contractId format', () => {
+      const result = indexerQuerySchema.safeParse({
+        contractId: 'BADADDR',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('invalid sortBy', () => {
+      const result = indexerQuerySchema.safeParse({
+        sortBy: 'yield_bps',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('invalid order', () => {
+      const result = indexerQuerySchema.safeParse({
+        order: 'sideways',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test('page = 0 (below minimum)', () => {
+      const result = indexerQuerySchema.safeParse({ page: '0' });
+      expect(result.success).toBe(false);
+    });
+
+    test('page = negative', () => {
+      const result = indexerQuerySchema.safeParse({ page: '-5' });
+      expect(result.success).toBe(false);
+    });
+
+    test('page = non-numeric string', () => {
+      const result = indexerQuerySchema.safeParse({ page: 'abc' });
+      expect(result.success).toBe(false);
+    });
+
+    test('limit = 0 (below minimum)', () => {
+      const result = indexerQuerySchema.safeParse({ limit: '0' });
+      expect(result.success).toBe(false);
+    });
+
+    test('limit > 100 (above maximum)', () => {
+      const result = indexerQuerySchema.safeParse({ limit: '101' });
+      expect(result.success).toBe(false);
+    });
+
+    test('limit = negative', () => {
+      const result = indexerQuerySchema.safeParse({ limit: '-1' });
+      expect(result.success).toBe(false);
+    });
+
+    test('limit = non-numeric string', () => {
+      const result = indexerQuerySchema.safeParse({ limit: 'abc' });
+      expect(result.success).toBe(false);
+    });
+
+    test('cursor = empty string', () => {
+      const result = indexerQuerySchema.safeParse({ cursor: '' });
+      expect(result.success).toBe(false);
+    });
+
+    test('cursor > 2048 chars', () => {
+      const result = indexerQuerySchema.safeParse({ cursor: 'a'.repeat(2049) });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('boundary values', () => {
+    test('invoiceId = 1 char (min)', () => {
+      const result = indexerQuerySchema.safeParse({ invoiceId: 'a' });
+      expect(result.success).toBe(true);
+    });
+
+    test('invoiceId = 128 chars (max)', () => {
+      const result = indexerQuerySchema.safeParse({ invoiceId: 'a'.repeat(128) });
+      expect(result.success).toBe(true);
+    });
+
+    test('eventType = 1 char (min)', () => {
+      const result = indexerQuerySchema.safeParse({ eventType: 'x' });
+      expect(result.success).toBe(true);
+    });
+
+    test('eventType = 128 chars (max)', () => {
+      const result = indexerQuerySchema.safeParse({ eventType: 'x'.repeat(128) });
+      expect(result.success).toBe(true);
+    });
+
+    test('page = 1 (min)', () => {
+      const result = indexerQuerySchema.safeParse({ page: '1' });
+      expect(result.success).toBe(true);
+      expect(result.data.page).toBe(1);
+    });
+
+    test('page = 999999 (large valid)', () => {
+      const result = indexerQuerySchema.safeParse({ page: '999999' });
+      expect(result.success).toBe(true);
+      expect(result.data.page).toBe(999999);
+    });
+
+    test('limit = 1 (min)', () => {
+      const result = indexerQuerySchema.safeParse({ limit: '1' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(1);
+    });
+
+    test('limit = 100 (max)', () => {
+      const result = indexerQuerySchema.safeParse({ limit: '100' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(100);
+    });
+
+    test('cursor = 2048 chars (max)', () => {
+      const result = indexerQuerySchema.safeParse({ cursor: 'a'.repeat(2048) });
+      expect(result.success).toBe(true);
+    });
+
+    test('sortBy = ledger_sequence (valid alternative)', () => {
+      const result = indexerQuerySchema.safeParse({ sortBy: 'ledger_sequence' });
+      expect(result.success).toBe(true);
+      expect(result.data.sortBy).toBe('ledger_sequence');
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseValidationErrors
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseValidationErrors', () => {
+  test('formats a single Zod error', () => {
+    const result = indexerQuerySchema.safeParse({ invoiceId: 'bad id' });
+    expect(result.success).toBe(false);
+    const fieldErrors = parseValidationErrors(result.error);
+    expect(fieldErrors).toHaveProperty('invoiceId');
+    expect(typeof fieldErrors.invoiceId).toBe('string');
+  });
+
+  test('formats multiple Zod errors', () => {
+    const result = indexerQuerySchema.safeParse({
+      invoiceId: 'bad id',
+      eventType: '',
+      sortBy: 'invalid',
+    });
+    expect(result.success).toBe(false);
+    const fieldErrors = parseValidationErrors(result.error);
+    expect(Object.keys(fieldErrors).length).toBeGreaterThanOrEqual(3);
+    expect(fieldErrors).toHaveProperty('invoiceId');
+    expect(fieldErrors).toHaveProperty('eventType');
+    expect(fieldErrors).toHaveProperty('sortBy');
+  });
+
+  test('uses first error per field', () => {
+    // Limit has both min and max — only first issue is kept
+    const result = indexerQuerySchema.safeParse({ limit: '-5' });
+    expect(result.success).toBe(false);
+    const fieldErrors = parseValidationErrors(result.error);
+    expect(fieldErrors).toHaveProperty('limit');
+    expect(typeof fieldErrors.limit).toBe('string');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validateIndexerQuery (integration helper)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validateIndexerQuery', () => {
+  describe('valid queries', () => {
+    test('empty query → valid with empty params', () => {
+      const result = validateIndexerQuery({});
+      expect(result.isValid).toBe(true);
+      expect(result.fieldErrors).toEqual({});
+      expect(result.params).toEqual({
+        filters: {},
+        sorting: {},
+        pagination: {},
+      });
+    });
+
+    test('valid invoiceId filter', () => {
+      const result = validateIndexerQuery({ invoiceId: 'inv_001' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.invoiceId).toBe('inv_001');
+    });
+
+    test('valid eventType filter', () => {
+      const result = validateIndexerQuery({ eventType: 'escrow_created' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.eventType).toBe('escrow_created');
+    });
+
+    test('valid contractId filter', () => {
+      const result = validateIndexerQuery({ contractId: VALID_CONTRACT_ID });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.contractId).toBe(VALID_CONTRACT_ID);
+    });
+
+    test('valid sortBy', () => {
+      const result = validateIndexerQuery({ sortBy: 'observed_at' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.sorting.sortBy).toBe('observed_at');
+    });
+
+    test('valid order', () => {
+      const result = validateIndexerQuery({ order: 'ASC' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.sorting.order).toBe('asc');
+    });
+
+    test('valid cursor', () => {
+      const cursor = 'testCursorValue.sig';
+      const result = validateIndexerQuery({ cursor });
+      expect(result.isValid).toBe(true);
+      expect(result.params.pagination.cursor).toBe(cursor);
+    });
+
+    test('valid page', () => {
+      const result = validateIndexerQuery({ page: '5' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.pagination.page).toBe(5);
+    });
+
+    test('valid limit', () => {
+      const result = validateIndexerQuery({ limit: '25' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.pagination.limit).toBe(25);
+    });
+
+    test('all valid params combined', () => {
+      const result = validateIndexerQuery({
+        invoiceId: 'inv_001',
+        eventType: 'escrow_funded',
+        sortBy: 'ledger_sequence',
+        order: 'desc',
+        limit: '10',
+      });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.invoiceId).toBe('inv_001');
+      expect(result.params.filters.eventType).toBe('escrow_funded');
+      expect(result.params.sorting.sortBy).toBe('ledger_sequence');
+      expect(result.params.sorting.order).toBe('desc');
+      expect(result.params.pagination.limit).toBe(10);
+    });
+  });
+
+  describe('invalid queries', () => {
+    test('unknown parameters → rejected', () => {
+      const result = validateIndexerQuery({ foo: 'bar', baz: 1 });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors._unknown).toMatch(/Unknown query parameters/);
+      expect(result.fieldErrors._unknown).toMatch(/foo/);
+      expect(result.fieldErrors._unknown).toMatch(/baz/);
+    });
+
+    test('invalid invoiceId → field error', () => {
+      const result = validateIndexerQuery({ invoiceId: 'has spaces' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('invoiceId');
+    });
+
+    test('invalid eventType → field error', () => {
+      const result = validateIndexerQuery({ eventType: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('eventType');
+    });
+
+    test('invalid contractId → field error', () => {
+      const result = validateIndexerQuery({ contractId: 'BADADDR' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('contractId');
+    });
+
+    test('invalid sortBy → field error', () => {
+      const result = validateIndexerQuery({ sortBy: 'yield_bps' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('sortBy');
+    });
+
+    test('invalid order → field error', () => {
+      const result = validateIndexerQuery({ order: 'sideways' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('order');
+    });
+
+    test('invalid limit (0) → field error', () => {
+      const result = validateIndexerQuery({ limit: '0' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('limit');
+    });
+
+    test('invalid limit (>100) → field error', () => {
+      const result = validateIndexerQuery({ limit: '101' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('limit');
+    });
+
+    test('invalid page (0) → field error', () => {
+      const result = validateIndexerQuery({ page: '0' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('page');
+    });
+
+    test('invalid cursor (empty) → field error', () => {
+      const result = validateIndexerQuery({ cursor: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('cursor');
+    });
+
+    test('multiple invalid fields → multiple errors', () => {
+      const result = validateIndexerQuery({
+        invoiceId: 'bad id',
+        sortBy: 'invalid',
+        limit: '200',
+      });
+      expect(result.isValid).toBe(false);
+      expect(Object.keys(result.fieldErrors).length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('invoiceId with underscores and hyphens', () => {
+      const result = validateIndexerQuery({ invoiceId: 'inv_001-test' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.invoiceId).toBe('inv_001-test');
+    });
+
+    test('invoiceId whitespace is trimmed', () => {
+      const result = validateIndexerQuery({ invoiceId: '  inv_001  ' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.invoiceId).toBe('inv_001');
+    });
+
+    test('eventType with valid special chars', () => {
+      const result = validateIndexerQuery({ eventType: 'escrow.created.v2' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.filters.eventType).toBe('escrow.created.v2');
+    });
+
+    test('limit = "1" (string) converts to number 1', () => {
+      const result = validateIndexerQuery({ limit: '1' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.pagination.limit).toBe(1);
+      expect(typeof result.params.pagination.limit).toBe('number');
+    });
+
+    test('page = "100" (string) converts to number 100', () => {
+      const result = validateIndexerQuery({ page: '100' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.pagination.page).toBe(100);
+      expect(typeof result.params.pagination.page).toBe('number');
+    });
+
+    test('page = non-numeric string → rejected', () => {
+      const result = validateIndexerQuery({ page: 'abc' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('page');
+    });
+
+    test('limit = non-numeric string → rejected', () => {
+      const result = validateIndexerQuery({ limit: 'abc' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('limit');
+    });
+
+    test('contractId validation rejects non-Stellar addresses', () => {
+      // Valid length but wrong prefix
+      const result = validateIndexerQuery({ contractId: 'D' + 'A'.repeat(55) });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors).toHaveProperty('contractId');
+    });
+
+    test('sortBy = ledger_sequence is accepted', () => {
+      const result = validateIndexerQuery({ sortBy: 'ledger_sequence' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.sorting.sortBy).toBe('ledger_sequence');
+    });
+
+    test('sortBy = observed_at is accepted', () => {
+      const result = validateIndexerQuery({ sortBy: 'observed_at' });
+      expect(result.isValid).toBe(true);
+      expect(result.params.sorting.sortBy).toBe('observed_at');
+    });
+
+    test('returns empty params on invalid input', () => {
+      const result = validateIndexerQuery({ sortBy: 'invalid' });
+      expect(result.isValid).toBe(false);
+      expect(result.params).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
- Added Zod validation schemas for indexer query parameters (src/schemas/indexerQuery.js)
- Replaced manual _parseQuery() with schema-based validateIndexerQuery() in adminIndexer.js
- Added comprehensive test suite with 73 tests covering valid/invalid payloads and edge cases
- Maintains identical behavior: unknown params rejected, cursor ignores page, structured error responses

Closes #930