### PR TITLE
feat(escrow-read): add bulk operations endpoint

### DIFF
--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -23,11 +23,13 @@ const apiKeysRoutes = require('../apiKeys'); // ← Added
 const { extractTenant } = require('../../middleware/tenant');
 const { authenticateToken } = require('../../middleware/auth');
 const invoiceService = require('../../services/invoiceService');
-const { resolveEscrowAddress } = require('../../config/escrowMap');
+const { resolveEscrowAddress, EscrowNotFoundError } = require('../../config/escrowMap');
 const { readEscrowState } = require('../../services/escrowRead');
+const { batchReadEscrowStates } = require('../../services/escrowBatchRead');
 const { computeEscrowDerivedFields } = require('../../services/escrowDerived');
 const AppError = require('../../errors/AppError');
 const { invoiceCreateSchema, invoiceUpdateSchema, parseValidationErrors } = require('../../schemas/invoice');
+const { escrowBatchReadSchema } = require('../../schemas/escrowBatchRead');
 const { validatePatchFields, detectLockedFieldChange } = require('../../middleware/patchInvoice');
 const { validateHealthQuery, rejectBodyOnGet } = require('../../schemas/health');
 
@@ -56,6 +58,7 @@ router.get('/', (req, res) => {
       health: 'GET /v1/health',
       invoices: 'GET/POST /v1/invoices',
       escrow: 'GET/POST /v1/escrow',
+      'escrow-batch': 'POST /v1/escrow/batch',
       sme: 'POST /v1/sme/invoice',
       'api-keys': 'GET /v1/api-keys',
     },
@@ -195,6 +198,98 @@ router.get('/escrow/:invoiceId', authenticateToken, async (req, res, next) => {
       message: state.fromProjection
         ? 'Escrow state read from event projection.'
         : 'Escrow state read from live Soroban contract.',
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+/**
+ * POST /v1/escrow/batch
+ *
+ * Reads escrow state for a bounded batch of invoice IDs in a single request.
+ * Each ID is resolved and read independently: an unmapped invoice ID or a
+ * failed on-chain read is reported per-item in `errors` rather than failing
+ * the whole batch (mirrors the failure-isolation semantics already used by
+ * {@link module:services/escrowBatchRead}).
+ *
+ * Body:
+ *   invoiceIds  {string[]}  1–100 invoice identifiers (required)
+ *
+ * Response 200:
+ *   { data: { results: object[], errors: object[] }, message: string }
+ */
+router.post('/escrow/batch', authenticateToken, async (req, res, next) => {
+  try {
+    const parsed = escrowBatchReadSchema.safeParse(req.body);
+    if (!parsed.success) {
+      const fieldErrors = parseValidationErrors(parsed.error);
+      return next(
+        new AppError({
+          type: 'https://liquifact.com/probs/validation-error',
+          title: 'Validation Error',
+          status: 422,
+          detail: 'Request body contains invalid or missing fields.',
+          instance: req.originalUrl,
+          code: 'VALIDATION_ERROR',
+          retryable: false,
+          retryHint: 'Correct the highlighted fields and retry.',
+          fieldErrors,
+        }),
+      );
+    }
+
+    const { invoiceIds } = parsed.data;
+
+    // Resolve escrow addresses up front so an unmapped invoice ID is reported
+    // per-item instead of aborting the whole batch.
+    const addressByInvoiceId = new Map();
+    const errors = [];
+
+    const markUnmapped = (invoiceId) => {
+      errors.push({
+        invoiceId,
+        error: `No escrow contract mapping found for invoice ID '${invoiceId}'`,
+        code: 'NOT_FOUND',
+      });
+    };
+
+    for (const rawId of invoiceIds) {
+      const invoiceId = String(rawId || '').trim().replace(/\s+/g, '');
+      try {
+        const escrowAddress = resolveEscrowAddress(invoiceId);
+        if (!escrowAddress) {
+          markUnmapped(invoiceId);
+          continue;
+        }
+        addressByInvoiceId.set(invoiceId, escrowAddress);
+      } catch (err) {
+        if (err instanceof EscrowNotFoundError) {
+          markUnmapped(invoiceId);
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    const mappedIds = [...addressByInvoiceId.keys()];
+    const { results: readResults, errors: readErrors } = mappedIds.length
+      ? await batchReadEscrowStates(mappedIds)
+      : { results: [], errors: [] };
+
+    const results = readResults.map((state) => {
+      const escrowAddress = addressByInvoiceId.get(state.invoiceId);
+      const derived = computeEscrowDerivedFields(state, {
+        ledgerCloseTime: state.ledgerCloseTime,
+      });
+      return { ...state, ...derived, escrowAddress };
+    });
+
+    errors.push(...readErrors);
+
+    return res.json({
+      data: { results, errors },
+      message: `Processed ${invoiceIds.length} invoice ID(s): ${results.length} succeeded, ${errors.length} failed.`,
     });
   } catch (err) {
     return next(err);

--- a/src/schemas/escrowBatchRead.js
+++ b/src/schemas/escrowBatchRead.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * @fileoverview Zod schema for the bulk escrow-read request body.
+ *
+ * Exposes:
+ *  - `MAX_BATCH_SIZE`         — upper bound on invoice IDs per request
+ *  - `escrowBatchReadSchema`  — strict body schema (rejects unknown keys)
+ *
+ * @module schemas/escrowBatchRead
+ */
+
+const { z } = require('zod');
+
+/** Upper bound on invoice IDs accepted per bulk-read request. */
+const MAX_BATCH_SIZE = 100;
+
+/**
+ * Bulk escrow-read request body schema.
+ *
+ * `invoiceIds` values are not format-validated here — malformed or unmapped
+ * IDs are reported per-item in the response `errors` array by the route
+ * handler rather than failing the whole batch.
+ *
+ * @type {import('zod').ZodObject}
+ */
+const escrowBatchReadSchema = z
+  .object({
+    invoiceIds: z
+      .array(z.string())
+      .min(1, 'invoiceIds must contain at least one invoice ID')
+      .max(MAX_BATCH_SIZE, `invoiceIds must not exceed ${MAX_BATCH_SIZE} items`),
+  })
+  .strict();
+
+module.exports = {
+  MAX_BATCH_SIZE,
+  escrowBatchReadSchema,
+};

--- a/tests/v1.escrow.batch.test.js
+++ b/tests/v1.escrow.batch.test.js
@@ -1,0 +1,311 @@
+'use strict';
+
+/**
+ * @fileoverview Tests for POST /v1/escrow/batch — the bulk escrow-read endpoint.
+ *
+ * Covers:
+ *  - Success path (multiple valid invoice IDs read in one request)
+ *  - Partial-failure isolation (unmapped invoice ID does not fail the batch)
+ *  - Empty-batch rejection (422)
+ *  - Over-cap rejection (422, > MAX_BATCH_SIZE items)
+ *  - Non-array / wrong-shaped body rejection (422)
+ *  - Auth error path (missing / invalid token → 401)
+ *  - Response shape assertions
+ */
+
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { createStandardizedApp } = require('../src/app');
+const { MAX_BATCH_SIZE } = require('../src/schemas/escrowBatchRead');
+
+// ── Shared mocks (mirror tests/v1.escrow.read.test.js) ─────────────────────
+
+jest.mock('../src/config/escrowMap', () => ({
+  resolveEscrowAddress: jest.fn((id) => {
+    if (!id || id === 'unknown-batch-inv' || id === 'nonexistent_batch_999') return null;
+    return `C_BATCH_ESCROW_FOR_${id.toUpperCase()}`;
+  }),
+  EscrowNotFoundError: class EscrowNotFoundError extends Error {},
+}));
+
+jest.mock('../src/services/soroban', () => ({
+  callSorobanContract: jest.fn(async (operation) => {
+    return operation();
+  }),
+}));
+
+// In-memory store keyed by invoice_id for the projection table.
+jest.mock('../src/db/knex', () => {
+  const rows = new Map();
+  const fakeDb = jest.fn((table) => ({
+    _table: table,
+    _whereId: null,
+    where(field, value) {
+      if (typeof field === 'string') {
+        this._whereId = String(value);
+      }
+      return this;
+    },
+    async first() {
+      if (!this._whereId) return null;
+      return rows.get(this._whereId) || null;
+    },
+    async del() {
+      rows.clear();
+      return 0;
+    },
+    async destroy() {
+      rows.clear();
+    },
+    async insert(payload) {
+      const entries = Array.isArray(payload) ? payload : [payload];
+      entries.forEach((entry) => {
+        if (entry && entry.invoice_id) {
+          rows.set(entry.invoice_id, entry);
+        }
+      });
+      return entries.length;
+    },
+  }));
+  fakeDb.destroy = async () => {
+    rows.clear();
+  };
+  return fakeDb;
+}, { virtual: true });
+
+const db = require('../src/db/knex');
+const { createRedisEscrowSummaryCache } = require('../src/cache/redis');
+
+// ── JWT helpers ───────────────────────────────────────────────────────────
+
+const TEST_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+function makeToken(payload = {}) {
+  return jwt.sign(
+    { sub: 'test-user', id: 'user_batch', tenantId: 'tenant_batch_test', ...payload },
+    TEST_SECRET,
+    { expiresIn: '1h' }
+  );
+}
+
+function authHeader(payload = {}) {
+  return `Bearer ${makeToken(payload)}`;
+}
+
+// ── Test suite ───────────────────────────────────────────────────────────
+
+describe('POST /v1/escrow/batch (authenticated)', () => {
+  let app;
+  let cache;
+
+  beforeAll(() => {
+    app = createStandardizedApp();
+    cache = createRedisEscrowSummaryCache();
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    if (cache && cache.client) {
+      await cache.client.quit();
+    }
+  });
+
+  beforeEach(async () => {
+    await db('escrow_event_projection').del();
+    if (cache && cache.client) {
+      await cache.client.flushall();
+    }
+  });
+
+  // ── Success paths ─────────────────────────────────────────────────────
+
+  it('returns 200 with per-item results for a batch of valid invoice IDs', async () => {
+    await db('escrow_event_projection').insert([
+      {
+        invoice_id: 'inv_batch_1',
+        latest_event_id: 'evt_batch_1',
+        latest_event_type: 'funded',
+        latest_ledger_sequence: 100,
+        latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 5000 }),
+        latest_observed_at: new Date(),
+      },
+      {
+        invoice_id: 'inv_batch_2',
+        latest_event_id: 'evt_batch_2',
+        latest_event_type: 'funded',
+        latest_ledger_sequence: 200,
+        latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 8000 }),
+        latest_observed_at: new Date(),
+      },
+    ]);
+
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: ['inv_batch_1', 'inv_batch_2'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeNull();
+    expect(res.body.data.results).toHaveLength(2);
+    expect(res.body.data.errors).toHaveLength(0);
+
+    const byId = Object.fromEntries(res.body.data.results.map((r) => [r.invoiceId, r]));
+    expect(byId.inv_batch_1.fundedAmount).toBe(5000);
+    expect(byId.inv_batch_1.escrowAddress).toBe('C_BATCH_ESCROW_FOR_INV_BATCH_1');
+    expect(byId.inv_batch_1).toHaveProperty('daysToMaturity');
+    expect(byId.inv_batch_2.fundedAmount).toBe(8000);
+  });
+
+  it('returns 200 with a neutral stub result for a mapped invoice with no projection', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: ['inv_batch_live'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(1);
+    expect(res.body.data.results[0].status).toBe('not_found');
+    expect(res.body.data.results[0].fundedAmount).toBe(0);
+  });
+
+  // ── Partial-failure isolation ────────────────────────────────────────
+
+  it('isolates an unmapped invoice ID into errors without failing the batch', async () => {
+    await db('escrow_event_projection').insert({
+      invoice_id: 'inv_batch_ok',
+      latest_event_id: 'evt_ok',
+      latest_event_type: 'funded',
+      latest_ledger_sequence: 1,
+      latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 100 }),
+      latest_observed_at: new Date(),
+    });
+
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: ['inv_batch_ok', 'unknown-batch-inv'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(1);
+    expect(res.body.data.results[0].invoiceId).toBe('inv_batch_ok');
+    expect(res.body.data.errors).toHaveLength(1);
+    expect(res.body.data.errors[0]).toMatchObject({
+      invoiceId: 'unknown-batch-inv',
+      code: 'NOT_FOUND',
+    });
+    expect(res.body.data.errors[0].error).toMatch(/No escrow contract mapping found/);
+  });
+
+  it('returns all-errors when every invoice ID in the batch is unmapped', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: ['unknown-batch-inv', 'nonexistent_batch_999'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(0);
+    expect(res.body.data.errors).toHaveLength(2);
+  });
+
+  // ── Validation-failure paths ─────────────────────────────────────────
+
+  it('returns 422 for an empty invoiceIds array', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: [] });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it(`returns 422 when invoiceIds exceeds the ${MAX_BATCH_SIZE}-item cap`, async () => {
+    const invoiceIds = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => `inv_over_${i}`);
+
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 422 when invoiceIds is missing', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 422 when invoiceIds is not an array', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: 'inv_batch_1' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 422 for an unknown top-level field (strict schema)', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: ['inv_batch_1'], extraField: 'nope' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  // ── Auth error paths ──────────────────────────────────────────────────
+
+  it('returns 401 when no Authorization header is present', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .send({ invoiceIds: ['inv_batch_1'] });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 before validating the body when unauthenticated', async () => {
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .send({ invoiceIds: [] });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  // ── Response shape assertions ─────────────────────────────────────────
+
+  it('returns a well-formed envelope with results/errors arrays and a summary message', async () => {
+    await db('escrow_event_projection').insert({
+      invoice_id: 'inv_batch_shape',
+      latest_event_id: 'evt_shape',
+      latest_event_type: 'funded',
+      latest_ledger_sequence: 1,
+      latest_event_body: JSON.stringify({ status: 'funded', fundedAmount: 100 }),
+      latest_observed_at: new Date(),
+    });
+
+    const res = await request(app)
+      .post('/v1/escrow/batch')
+      .set('Authorization', authHeader())
+      .send({ invoiceIds: ['inv_batch_shape', 'unknown-batch-inv'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).toHaveProperty('meta');
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toBeNull();
+    expect(Array.isArray(res.body.data.results)).toBe(true);
+    expect(Array.isArray(res.body.data.errors)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /v1/escrow/batch`, accepting a bounded array (1–100) of invoice IDs and returning per-item `results`/`errors` without failing the whole batch, per #790.
- Reuses the existing `batchReadEscrowStates` concurrency/timeout/retry engine (`src/services/escrowBatchRead.js`) for the on-chain reads.
- Unmapped invoice IDs (no escrow contract mapping) are isolated into `errors` with `code: 'NOT_FOUND'`, mirroring the existing `GET /v1/escrow/:invoiceId` behavior, instead of aborting the request.
- New Zod schema `src/schemas/escrowBatchRead.js` enforces the array shape and the 100-item cap (`MAX_BATCH_SIZE`), rejecting empty/oversized/malformed bodies with a 422.

Closes #790

## Test plan
- [x] `npx eslint` on all changed/new files — clean.
- [x] New Zod schema verified directly (empty batch, missing field, non-array, unknown key, at-cap, over-cap) — all pass.
- [ ] `npm test` / `npm run build` — **could not be run**: `src/metrics.js` on `main` references `recordMetricsEndpointOutcome`, which is never defined anywhere in the file. This throws a `ReferenceError` at module-load time for any file that transitively requires `src/services/escrowRead.js` (→ `tokenMeta.js` → `cacheStore.js` → `metrics.js`), which includes `src/app.js`. This is a pre-existing bug on `main`, unrelated to this change — I confirmed it also breaks the already-merged `tests/v1.escrow.read.test.js` and `tests/escrow.batch.test.js` unmodified. A full local run on `main` shows **113 of 179 test suites failing** with the identical error. I did not touch `metrics.js` in this PR to keep the diff scoped to #790; happy to open a separate fix if useful.
- New HTTP-level tests added in `tests/v1.escrow.batch.test.js` (success, partial-failure isolation, empty/over-cap/malformed-body rejection, auth, response shape) mirror the conventions of `tests/v1.escrow.read.test.js` but are currently blocked from running by the issue above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)