### PR TITLE
docs(invoice-state): Added runnable curl/HTTP examples

### DIFF
--- a/docs/invoice-state-examples.md
+++ b/docs/invoice-state-examples.md
@@ -1,0 +1,848 @@
+# Invoice-State Endpoints — Runnable curl/HTTP Examples
+
+Ready-to-run request and response examples for every endpoint in the
+invoice-state API. All paths are relative to the base URL. Copy, paste, and
+adjust the placeholder values to match your environment.
+
+## Prerequisites
+
+```bash
+# Set these before running any example.
+export BASE_URL="http://localhost:3001"
+export TENANT_ID="tenant-alpha"
+export TOKEN="your-jwt-token-here"
+export INVOICE_ID="inv-001"
+```
+
+Every example includes the `x-tenant-id` header. If your JWT already carries a
+`tenantId` claim you may omit the header, but including it explicitly is the
+recommended practice.
+
+---
+
+## 1. GET /api/invoices/:id/state
+
+Returns the current lifecycle state and the transitions available from that
+state.
+
+### 1.1 Pending invoice (non-terminal)
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/$INVOICE_ID/state" \
+  -H "x-tenant-id: $TENANT_ID"
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "currentState": "pending",
+    "allowedTransitions": ["approved", "rejected", "cancelled"],
+    "isTerminal": false
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice state retrieved successfully"
+}
+```
+
+### 1.2 Terminal invoice (linked_escrow)
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/inv-003/state" \
+  -H "x-tenant-id: $TENANT_ID"
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-003",
+    "currentState": "linked_escrow",
+    "allowedTransitions": [],
+    "isTerminal": true
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice state retrieved successfully"
+}
+```
+
+### 1.3 Invoice not found
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/nonexistent-id/state" \
+  -H "x-tenant-id: $TENANT_ID"
+```
+
+**Response — 404 Not Found**
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Invoice not found",
+    "code": "INVOICE_NOT_FOUND",
+    "details": null
+  }
+}
+```
+
+---
+
+## 2. POST /api/invoices/:id/transition
+
+Generic state transition. Accepts any valid `targetState` in the request body.
+
+### 2.1 Approve a pending invoice
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/transition" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{
+    "targetState": "approved",
+    "reason": "Invoice verified by finance team"
+  }'
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "previousState": "pending",
+    "currentState": "approved",
+    "transitionedAt": "2026-07-24T10:30:00.000Z",
+    "transitionedBy": "user-123",
+    "reason": "Invoice verified by finance team",
+    "auditLogId": "AUDIT-1714132200000-abc123def"
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice transitioned from pending to approved"
+}
+```
+
+### 2.2 Reject a pending invoice (reason required)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/transition" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{
+    "targetState": "rejected",
+    "reason": "Missing supporting documentation"
+  }'
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "previousState": "pending",
+    "currentState": "rejected",
+    "transitionedAt": "2026-07-24T10:30:01.000Z",
+    "transitionedBy": "user-123",
+    "reason": "Missing supporting documentation",
+    "auditLogId": "AUDIT-1714132201000-xyz789"
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:01.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice transitioned from pending to rejected"
+}
+```
+
+### 2.3 Missing targetState (400)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/transition" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "reason": "Forgot the target state" }'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Target state is required",
+    "code": "MISSING_TARGET_STATE",
+    "details": null
+  }
+}
+```
+
+### 2.4 Invalid transition — silent jump (400)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/transition" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{
+    "targetState": "linked_escrow",
+    "reason": "Trying to skip approval"
+  }'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Invalid state transition from 'pending' to 'linked_escrow'",
+    "code": "INVALID_TRANSITION",
+    "details": {
+      "allowedTransitions": ["approved", "rejected", "cancelled"]
+    }
+  }
+}
+```
+
+### 2.5 Missing reason for terminal target (400)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/transition" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "targetState": "rejected" }'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Reason is required when transitioning to a terminal state",
+    "code": "MISSING_TRANSITION_REASON",
+    "details": null
+  }
+}
+```
+
+---
+
+## 3. POST /api/invoices/:id/approve
+
+Convenience shortcut that hardcodes `targetState = "approved"`.
+
+### 3.1 Approve with reason
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/approve" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "reason": "All documentation checks passed" }'
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "previousState": "pending",
+    "currentState": "approved",
+    "transitionedAt": "2026-07-24T10:30:00.000Z",
+    "transitionedBy": "user-123",
+    "auditLogId": "AUDIT-8a4c10d2"
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice approved successfully"
+}
+```
+
+### 3.2 Approve without body (also valid)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/approve" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{}'
+```
+
+The approve endpoint defaults the reason to `"Invoice approved"` when no
+body or no reason field is provided.
+
+### 3.3 Already in approved state (400)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/inv-002/approve" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "reason": "Already approved" }'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Invoice is already in state: approved",
+    "code": "ALREADY_IN_TARGET_STATE",
+    "details": null
+  }
+}
+```
+
+---
+
+## 4. POST /api/invoices/:id/link-escrow
+
+Links an `approved` invoice to an escrow contract. This endpoint is
+**KYC-gated** — the authenticated principal must hold a `smeId` claim and the
+SME must have a `verified` or `exempted` KYC status.
+
+### 4.1 Link with escrow ID
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/inv-002/link-escrow" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{
+    "escrowId": "CESCROW123AAABBBCCCDDDEEEFFFGGGHHH",
+    "reason": "Soroban escrow contract deployed and funded"
+  }'
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-002",
+    "previousState": "approved",
+    "currentState": "linked_escrow",
+    "escrowId": "CESCROW123AAABBBCCCDDDEEEFFFGGGHHH",
+    "transitionedAt": "2026-07-24T11:00:00.000Z",
+    "transitionedBy": "user-456",
+    "auditLogId": "AUDIT-9b5d21e3"
+  },
+  "meta": {
+    "timestamp": "2026-07-24T11:00:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice linked to escrow successfully"
+}
+```
+
+### 4.2 Link without escrowId (escrowId is null)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/inv-002/link-escrow" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "reason": "Pending escrow contract ID" }'
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-002",
+    "previousState": "approved",
+    "currentState": "linked_escrow",
+    "escrowId": null,
+    "transitionedAt": "2026-07-24T11:00:00.000Z",
+    "transitionedBy": "user-456",
+    "auditLogId": "AUDIT-9b5d21e4"
+  },
+  "meta": {
+    "timestamp": "2026-07-24T11:00:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice linked to escrow successfully"
+}
+```
+
+### 4.3 Invoice not in approved state (400)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/link-escrow" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "escrowId": "escrow-456" }'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Invoice must be in approved state to link to escrow",
+    "code": "CANNOT_LINK_TO_ESCROW",
+    "details": null
+  }
+}
+```
+
+### 4.4 KYC gate failure (403)
+
+Returned when the authenticated SME does not hold a `verified` or `exempted`
+KYC status.
+
+**Response — 403 Forbidden**
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "SME KYC status 'pending' does not permit funding operations.",
+    "code": "KYC_GATE_FAILED",
+    "details": null
+  }
+}
+```
+
+### 4.5 Missing smeId claim (400)
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Authenticated principal is missing smeId.",
+    "code": "MISSING_SME_ID",
+    "details": null
+  }
+}
+```
+
+---
+
+## 5. POST /api/invoices/:id/reject
+
+Convenience shortcut for `pending → rejected`. A **non-empty `reason`**
+is mandatory.
+
+### 5.1 Reject with reason
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/reject" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{
+    "reason": "Invalid supporting documentation — VAT registration number missing"
+  }'
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "previousState": "pending",
+    "currentState": "rejected",
+    "transitionedAt": "2026-07-24T10:30:01.000Z",
+    "transitionedBy": "user-789",
+    "reason": "Invalid supporting documentation — VAT registration number missing",
+    "auditLogId": "AUDIT-c2e7f4a9"
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:01.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice rejected successfully"
+}
+```
+
+### 5.2 Missing reason (400)
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/$INVOICE_ID/reject" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{}'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Reason is required for rejection",
+    "code": "MISSING_TRANSITION_REASON",
+    "details": null
+  }
+}
+```
+
+### 5.3 Cannot reject an approved invoice (400)
+
+`approved → rejected` is not a valid transition. Use `cancelled` instead.
+
+**Request**
+
+```bash
+curl -s -X POST "$BASE_URL/api/invoices/inv-002/reject" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -d '{ "reason": "Cannot reject approved invoice" }'
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Invalid state transition from 'approved' to 'rejected'",
+    "code": "INVALID_TRANSITION",
+    "details": {
+      "allowedTransitions": ["linked_escrow", "cancelled"]
+    }
+  }
+}
+```
+
+---
+
+## 6. GET /api/invoices/:id/history
+
+Returns the ordered audit trail of all state transitions, most recent first.
+
+### 6.1 Invoice with transitions
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/$INVOICE_ID/history" \
+  -H "x-tenant-id: $TENANT_ID"
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-001",
+    "currentState": "linked_escrow",
+    "transitions": [
+      {
+        "id": "AUDIT-1714134000000-def456",
+        "timestamp": "2026-07-24T11:00:00.000Z",
+        "actor": "user-456",
+        "fromState": "approved",
+        "toState": "linked_escrow",
+        "reason": "Escrow contract created",
+        "ipAddress": "192.168.1.100"
+      },
+      {
+        "id": "AUDIT-1714132200000-abc123",
+        "timestamp": "2026-07-24T10:30:00.000Z",
+        "actor": "user-123",
+        "fromState": "pending",
+        "toState": "approved",
+        "reason": "Documentation verified",
+        "ipAddress": "192.168.1.1"
+      }
+    ],
+    "totalTransitions": 2
+  },
+  "meta": {
+    "timestamp": "2026-07-24T11:01:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice transition history retrieved successfully"
+}
+```
+
+### 6.2 Invoice with no transitions
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/inv-002/history" \
+  -H "x-tenant-id: $TENANT_ID"
+```
+
+**Response — 200 OK**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    "invoiceId": "inv-002",
+    "currentState": "approved",
+    "transitions": [],
+    "totalTransitions": 0
+  },
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Invoice transition history retrieved successfully"
+}
+```
+
+### 6.3 Invoice not found
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/nonexistent-id/history" \
+  -H "x-tenant-id: $TENANT_ID"
+```
+
+**Response — 404 Not Found**
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Invoice not found",
+    "code": "INVOICE_NOT_FOUND",
+    "details": null
+  }
+}
+```
+
+---
+
+## Common Errors
+
+### Missing tenant context (400)
+
+Returned by the `extractTenant` middleware when neither the `x-tenant-id`
+header nor a JWT `tenantId` claim is present.
+
+**Request**
+
+```bash
+curl -s -X GET "$BASE_URL/api/invoices/$INVOICE_ID/state"
+```
+
+**Response — 400 Bad Request**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "error": "Missing tenant context.",
+  "message": "A valid tenant identifier must be supplied via the x-tenant-id header or an authenticated JWT claim."
+}
+```
+
+### Rate limiting (429)
+
+All invoice-state endpoints are rate-limited to 60 requests per 15-minute
+window per client (API key / IP). Exceeding the limit returns:
+
+**Response — 429 Too Many Requests**
+
+```http
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+
+{
+  "error": "Too many requests",
+  "message": "Rate limit exceeded. Please try again later."
+}
+```
+
+### Terminal state (400)
+
+Attempting any transition on an invoice in a terminal state (`linked_escrow`,
+`rejected`, or `cancelled`) returns:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "data": null,
+  "meta": {
+    "timestamp": "2026-07-24T10:30:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": {
+    "message": "Cannot transition from terminal state: linked_escrow",
+    "code": "TERMINAL_STATE",
+    "details": null
+  }
+}
+```
+
+---
+
+*All examples verified against `src/routes/invoiceStateRoutes.js` and
+`src/services/invoiceStateMachine.js`.*

--- a/tests/invoiceStateExamples.test.js
+++ b/tests/invoiceStateExamples.test.js
@@ -1,0 +1,623 @@
+/**
+ * Invoice-State Examples — Integration Tests
+ *
+ * Validates that the documented examples in docs/invoice-state-examples.md
+ * match the actual route behaviour. Drives each endpoint with supertest and
+ * asserts the response envelope shape, status codes, and error codes.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/middleware/kycGating', () => ({
+  requireKycForFunding: jest.fn((_req, _res, next) => next()),
+  auditKycAccess: jest.fn((_req, _res, next) => next()),
+}));
+
+const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
+const invoiceService = require('../src/services/invoiceService');
+const { clearAuditLogs, getAuditLogs } = require('../src/services/auditLog');
+
+const TENANT_A = 'tenant-alpha';
+const TENANT_B = 'tenant-beta';
+
+function storeKey(tenantId, invoiceId) {
+  return `${tenantId}:${invoiceId}`;
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.use((req, _res, next) => {
+    req.user = { id: 'test-user-123', sub: 'test-user-123', smeId: 'sme-verified' };
+    next();
+  });
+
+  app.use('/api/invoices', invoiceStateRoutes);
+
+  app.use((err, _req, res, _next) => {
+    res.status(500).json({ error: err.message });
+  });
+
+  return app;
+}
+
+describe('Invoice-State Examples — documented response shapes', () => {
+  let app;
+  /** @type {Map<string, object>} */
+  let invoiceStore;
+
+  function seedFixtures() {
+    invoiceStore.set(storeKey(TENANT_A, 'inv-001'), {
+      invoice_id: 'inv-001',
+      tenant_id: TENANT_A,
+      status: 'pending',
+      amount: 1000,
+      customer: 'Acme Corp',
+    });
+    invoiceStore.set(storeKey(TENANT_A, 'inv-002'), {
+      invoice_id: 'inv-002',
+      tenant_id: TENANT_A,
+      status: 'approved',
+      amount: 2000,
+      customer: 'TechCo',
+    });
+    invoiceStore.set(storeKey(TENANT_A, 'inv-003'), {
+      invoice_id: 'inv-003',
+      tenant_id: TENANT_A,
+      status: 'linked_escrow',
+      amount: 5000,
+      customer: 'GlobalInc',
+    });
+    invoiceStore.set(storeKey(TENANT_A, 'inv-004'), {
+      invoice_id: 'inv-004',
+      tenant_id: TENANT_A,
+      status: 'rejected',
+      amount: 3000,
+      customer: 'FailCo',
+    });
+    invoiceStore.set(storeKey(TENANT_A, 'inv-005'), {
+      invoice_id: 'inv-005',
+      tenant_id: TENANT_A,
+      status: 'cancelled',
+      amount: 4000,
+      customer: 'CancelCo',
+    });
+  }
+
+  beforeEach(() => {
+    clearAuditLogs();
+    invoiceStore = new Map();
+    seedFixtures();
+
+    jest.spyOn(invoiceService, 'getInvoiceById').mockImplementation(async (id, tenantId) => {
+      return invoiceStore.get(storeKey(tenantId, id)) || null;
+    });
+
+    jest.spyOn(invoiceService, 'updateInvoice').mockImplementation(async (id, updates, tenantId) => {
+      const key = storeKey(tenantId, id);
+      const existing = invoiceStore.get(key);
+      if (!existing) return null;
+      const updated = { ...existing, ...updates };
+      invoiceStore.set(key, updated);
+      return updated;
+    });
+
+    app = buildApp();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  1. GET /api/invoices/:id/state                                     */
+  /* ------------------------------------------------------------------ */
+  describe('GET /api/invoices/:id/state', () => {
+    it('returns documented shape for a pending invoice', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-001/state')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error', null);
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.data.invoiceId).toBe('inv-001');
+      expect(res.body.data.currentState).toBe('pending');
+      expect(Array.isArray(res.body.data.allowedTransitions)).toBe(true);
+      expect(res.body.data.allowedTransitions).toContain('approved');
+      expect(res.body.data.allowedTransitions).toContain('rejected');
+      expect(res.body.data.allowedTransitions).toContain('cancelled');
+      expect(res.body.data.isTerminal).toBe(false);
+
+      expect(res.body.meta).toHaveProperty('timestamp');
+      expect(res.body.meta).toHaveProperty('version');
+    });
+
+    it('returns documented shape for a terminal invoice', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-003/state')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.invoiceId).toBe('inv-003');
+      expect(res.body.data.currentState).toBe('linked_escrow');
+      expect(res.body.data.allowedTransitions).toEqual([]);
+      expect(res.body.data.isTerminal).toBe(true);
+    });
+
+    it('returns 404 INVOICE_NOT_FOUND for unknown invoice', async () => {
+      const res = await request(app)
+        .get('/api/invoices/nonexistent-id/state')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expect(res.body.error.message).toBe('Invoice not found');
+      expect(res.body.data).toBeNull();
+    });
+
+    it('returns 404 for cross-tenant access', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-001/state')
+        .set('x-tenant-id', TENANT_B);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  2. POST /api/invoices/:id/transition                               */
+  /* ------------------------------------------------------------------ */
+  describe('POST /api/invoices/:id/transition', () => {
+    it('returns documented shape for pending → approved', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'approved', reason: 'Invoice verified by finance team' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error', null);
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.data.invoiceId).toBe('inv-001');
+      expect(res.body.data.previousState).toBe('pending');
+      expect(res.body.data.currentState).toBe('approved');
+      expect(res.body.data.transitionedBy).toBe('test-user-123');
+      expect(res.body.data.reason).toBe('Invoice verified by finance team');
+      expect(res.body.data.auditLogId).toBeDefined();
+      expect(typeof res.body.data.auditLogId).toBe('string');
+      expect(res.body.data.transitionedAt).toBeDefined();
+
+      expect(res.body.message).toContain('pending to approved');
+    });
+
+    it('returns documented shape for pending → rejected', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'rejected', reason: 'Missing supporting documentation' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.previousState).toBe('pending');
+      expect(res.body.data.currentState).toBe('rejected');
+      expect(res.body.data.reason).toBe('Missing supporting documentation');
+    });
+
+    it('returns MISSING_TARGET_STATE when targetState is absent', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'Forgot the target state' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('MISSING_TARGET_STATE');
+      expect(res.body.data).toBeNull();
+    });
+
+    it('returns INVALID_TRANSITION with allowedTransitions for silent jump', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'linked_escrow', reason: 'Trying to skip approval' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_TRANSITION');
+      expect(res.body.error.details).toBeDefined();
+      expect(Array.isArray(res.body.error.details.allowedTransitions)).toBe(true);
+      expect(res.body.error.details.allowedTransitions).toContain('approved');
+    });
+
+    it('returns MISSING_TRANSITION_REASON for terminal target without reason', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'rejected' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('MISSING_TRANSITION_REASON');
+      expect(res.body.error.message).toContain('Reason is required');
+    });
+
+    it('returns TERMINAL_STATE for transition from terminal state', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-003/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'approved' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('TERMINAL_STATE');
+    });
+
+    it('returns 404 for unknown invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-999/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'approved' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  3. POST /api/invoices/:id/approve                                  */
+  /* ------------------------------------------------------------------ */
+  describe('POST /api/invoices/:id/approve', () => {
+    it('returns documented shape for successful approval', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/approve')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'All documentation checks passed' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error', null);
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.data.invoiceId).toBe('inv-001');
+      expect(res.body.data.previousState).toBe('pending');
+      expect(res.body.data.currentState).toBe('approved');
+      expect(res.body.data.transitionedBy).toBe('test-user-123');
+      expect(res.body.data.auditLogId).toBeDefined();
+      expect(res.body.data.transitionedAt).toBeDefined();
+
+      expect(res.body.message).toBe('Invoice approved successfully');
+    });
+
+    it('accepts empty body (reason defaults to "Invoice approved")', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/approve')
+        .set('x-tenant-id', TENANT_A)
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.currentState).toBe('approved');
+      expect(res.body.message).toBe('Invoice approved successfully');
+    });
+
+    it('returns ALREADY_IN_TARGET_STATE for already approved invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-002/approve')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'Already approved' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('ALREADY_IN_TARGET_STATE');
+      expect(res.body.data).toBeNull();
+    });
+
+    it('returns TERMINAL_STATE for terminal invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-003/approve')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'Trying to approve terminal' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('TERMINAL_STATE');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  4. POST /api/invoices/:id/link-escrow                              */
+  /* ------------------------------------------------------------------ */
+  describe('POST /api/invoices/:id/link-escrow', () => {
+    it('returns documented shape with escrowId', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-002/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({
+          escrowId: 'CESCROW123AAABBBCCCDDDEEEFFFGGGHHH',
+          reason: 'Soroban escrow contract deployed and funded',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error', null);
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.data.invoiceId).toBe('inv-002');
+      expect(res.body.data.previousState).toBe('approved');
+      expect(res.body.data.currentState).toBe('linked_escrow');
+      expect(res.body.data.escrowId).toBe('CESCROW123AAABBBCCCDDDEEEFFFGGGHHH');
+      expect(res.body.data.transitionedBy).toBe('test-user-123');
+      expect(res.body.data.auditLogId).toBeDefined();
+      expect(res.body.data.transitionedAt).toBeDefined();
+
+      expect(res.body.message).toBe('Invoice linked to escrow successfully');
+    });
+
+    it('returns null escrowId when escrowId is not provided', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-002/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'Pending escrow contract ID' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.escrowId).toBeNull();
+    });
+
+    it('returns CANNOT_LINK_TO_ESCROW for non-approved invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ escrowId: 'escrow-456' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('CANNOT_LINK_TO_ESCROW');
+      expect(res.body.data).toBeNull();
+    });
+
+    it('returns CANNOT_LINK_TO_ESCROW for already linked invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-003/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ escrowId: 'escrow-789' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('CANNOT_LINK_TO_ESCROW');
+    });
+
+    it('returns 404 for unknown invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-999/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ escrowId: 'escrow-000' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+
+    it('returns KYC_GATE_FAILED when KYC check fails', async () => {
+      const { requireKycForFunding } = require('../src/middleware/kycGating');
+      requireKycForFunding.mockImplementationOnce((_req, res, _next) => {
+        res.status(403).json({
+          data: null,
+          error: {
+            message: "SME KYC status 'pending' does not permit funding operations.",
+            code: 'KYC_GATE_FAILED',
+            details: null,
+          },
+        });
+      });
+
+      const res = await request(app)
+        .post('/api/invoices/inv-002/link-escrow')
+        .set('x-tenant-id', TENANT_A)
+        .send({ escrowId: 'escrow-000' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('KYC_GATE_FAILED');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  5. POST /api/invoices/:id/reject                                   */
+  /* ------------------------------------------------------------------ */
+  describe('POST /api/invoices/:id/reject', () => {
+    it('returns documented shape for successful rejection', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/reject')
+        .set('x-tenant-id', TENANT_A)
+        .send({
+          reason: 'Invalid supporting documentation — VAT registration number missing',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error', null);
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.data.invoiceId).toBe('inv-001');
+      expect(res.body.data.previousState).toBe('pending');
+      expect(res.body.data.currentState).toBe('rejected');
+      expect(res.body.data.reason).toBe(
+        'Invalid supporting documentation — VAT registration number missing',
+      );
+      expect(res.body.data.transitionedBy).toBe('test-user-123');
+      expect(res.body.data.auditLogId).toBeDefined();
+      expect(res.body.data.transitionedAt).toBeDefined();
+
+      expect(res.body.message).toBe('Invoice rejected successfully');
+    });
+
+    it('returns MISSING_TRANSITION_REASON when reason is empty', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/reject')
+        .set('x-tenant-id', TENANT_A)
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('MISSING_TRANSITION_REASON');
+      expect(res.body.data).toBeNull();
+    });
+
+    it('returns INVALID_TRANSITION when trying to reject approved invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-002/reject')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'Cannot reject approved invoice' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_TRANSITION');
+      expect(res.body.error.details).toBeDefined();
+      expect(Array.isArray(res.body.error.details.allowedTransitions)).toBe(true);
+    });
+
+    it('returns ALREADY_IN_TARGET_STATE for already rejected invoice', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-004/reject')
+        .set('x-tenant-id', TENANT_A)
+        .send({ reason: 'Trying to reject again' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('ALREADY_IN_TARGET_STATE');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  6. GET /api/invoices/:id/history                                   */
+  /* ------------------------------------------------------------------ */
+  describe('GET /api/invoices/:id/history', () => {
+    it('returns documented shape with multiple transitions', async () => {
+      await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'approved', reason: 'First transition' });
+
+      await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'linked_escrow', reason: 'Second transition' });
+
+      const res = await request(app)
+        .get('/api/invoices/inv-001/history')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error', null);
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.data.invoiceId).toBe('inv-001');
+      expect(res.body.data.currentState).toBe('linked_escrow');
+      expect(Array.isArray(res.body.data.transitions)).toBe(true);
+      expect(res.body.data.transitions).toHaveLength(2);
+      expect(res.body.data.totalTransitions).toBe(2);
+
+      const first = res.body.data.transitions[0];
+      expect(first).toHaveProperty('id');
+      expect(first).toHaveProperty('timestamp');
+      expect(first).toHaveProperty('actor');
+      expect(first).toHaveProperty('fromState');
+      expect(first).toHaveProperty('toState');
+      expect(first).toHaveProperty('reason');
+      expect(first).toHaveProperty('ipAddress');
+      expect(first.fromState).toBe('approved');
+      expect(first.toState).toBe('linked_escrow');
+    });
+
+    it('returns documented shape with empty transitions', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-001/history')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.invoiceId).toBe('inv-001');
+      expect(res.body.data.transitions).toEqual([]);
+      expect(res.body.data.totalTransitions).toBe(0);
+    });
+
+    it('returns 404 INVOICE_NOT_FOUND for unknown invoice', async () => {
+      const res = await request(app)
+        .get('/api/invoices/nonexistent-id/history')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      expect(res.body.data).toBeNull();
+    });
+
+    it('returns 404 for cross-tenant access', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-001/history')
+        .set('x-tenant-id', TENANT_B);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Common errors                                                      */
+  /* ------------------------------------------------------------------ */
+  describe('Common errors', () => {
+    it('returns 400 when tenant context is missing', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-001/state');
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns INVOICE_NOT_FOUND consistently across all endpoints', async () => {
+      const endpoints = [
+        { method: 'get', path: '/api/invoices/inv-999/state' },
+        { method: 'post', path: '/api/invoices/inv-999/transition', body: { targetState: 'approved' } },
+        { method: 'post', path: '/api/invoices/inv-999/approve', body: {} },
+        { method: 'post', path: '/api/invoices/inv-999/link-escrow', body: { escrowId: 'x' } },
+        { method: 'post', path: '/api/invoices/inv-999/reject', body: { reason: 'x' } },
+        { method: 'get', path: '/api/invoices/inv-999/history' },
+      ];
+
+      for (const ep of endpoints) {
+        const req = request(app)[ep.method](ep.path).set('x-tenant-id', TENANT_A);
+        const res = ep.body ? await req.send(ep.body) : await req;
+        expect(res.status).toBe(404);
+        expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+      }
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Response envelope integrity                                        */
+  /* ------------------------------------------------------------------ */
+  describe('Response envelope integrity', () => {
+    it('all successful responses include meta.timestamp and meta.version', async () => {
+      const res = await request(app)
+        .get('/api/invoices/inv-001/state')
+        .set('x-tenant-id', TENANT_A);
+
+      expect(res.body.meta).toBeDefined();
+      expect(typeof res.body.meta.timestamp).toBe('string');
+      expect(typeof res.body.meta.version).toBe('string');
+      expect(res.body.meta.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('all error responses include meta and error.code', async () => {
+      const res = await request(app)
+        .post('/api/invoices/inv-001/transition')
+        .set('x-tenant-id', TENANT_A)
+        .send({ targetState: 'linked_escrow' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.meta).toBeDefined();
+      expect(typeof res.body.error.code).toBe('string');
+      expect(typeof res.body.error.message).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds copy-pasteable curl examples and HTTP response blocks for every invoice-state endpoint, plus a supertest integration test suite that validates each documented example against the live route handlers.

## Changes

| File | Type | Description |
|------|------|-------------|
| `docs/invoice-state-examples.md` | **New** | Runnable request/response examples for all 6 invoice-state endpoints with full headers, status lines, and JSON bodies |
| `tests/invoiceStateExamples.test.js` | **New** | 33 supertest tests that drive each endpoint and assert the documented response shape, status codes, and error codes |

## Documented endpoints

| Method | Path | Examples |
|--------|------|----------|
| `GET` | `/api/invoices/:id/state` | pending, terminal, 404 |
| `POST` | `/api/invoices/:id/transition` | approve, reject, missing targetState, invalid transition, missing reason |
| `POST` | `/api/invoices/:id/approve` | with reason, empty body, already approved |
| `POST` | `/api/invoices/:id/link-escrow` | with escrowId, without escrowId, not approved, KYC gate failure, missing smeId |
| `POST` | `/api/invoices/:id/reject` | with reason, missing reason, can't reject approved |
| `GET` | `/api/invoices/:id/history` | multi-transition, empty, 404 |
| — | Common errors | missing tenant (400), rate limiting (429), terminal state (400) |

## Verification

- [x] `npm run lint:new` — 0 errors
- [x] `npm test -- tests/invoiceStateExamples.test.js` — 33/33 pass
- [x] `npm test -- tests/invoice.state.test.js` — 130/130 pass (no regressions)
- [x] All 201 invoice-state tests pass
- [x] All example paths, headers, and JSON shapes verified against `src/routes/invoiceStateRoutes.js` and `src/services/invoiceStateMachine.js`

## Test output

npm test -- tests/invoiceStateExamples.test.js
Test Suites: 1 passed, 1 total
Tests:       33 passed, 33 total

## Notes for reviewers

- **No source code was modified** — documentation + test only.
- Each curl example includes all required headers (`x-tenant-id`, `Content-Type`, `Authorization` where applicable) and placeholder env vars (`$BASE_URL`, `$TOKEN`, `$TENANT_ID`, `$INVOICE_ID`).
- The test file mocks KYC gating and `invoiceService` (same pattern as `tests/invoice.state.test.js`) and drives each endpoint through supertest to assert the documented response envelope shape.
- Pre-existing failures in the full test suite (`recordMetricsEndpointOutcome` in `src/metrics.js`) are unrelated to this change.

Closes #916