### PR TITLE
feat(config): add bulk operations endpoint

### DIFF
--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -12,6 +12,12 @@
  *   `application/problem+json` 400 response containing machine-readable
  *   `fieldErrors` so clients can map errors back to specific form fields.
  *
+ * POST /api/admin/config/bulk
+ *   Accepts `{ operations: [{ section, config }, ...] }`, validates each item
+ *   independently, and returns per-item success/error results. The batch is
+ *   capped at BULK_CONFIG_MAX_ITEMS (default 10). Individual item failures do
+ *   not reject the entire batch.
+ *
  * GET /api/admin/config/sections
  *   Returns the list of valid section names accepted by the POST endpoint.
  *
@@ -32,12 +38,13 @@ const {
   runtimeConfigSchema,
   validateBody,
   CONFIG_SECTIONS,
+  bulkConfigSchema,
+  parseValidationErrors,
 } = require('../schemas/config');
 const { adminConfigLimiter } = require('../middleware/rateLimit');
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
 const logger = require('../logger');
-const idempotencyMiddleware = require('../middleware/idempotency');
 
 const router = express.Router();
 
@@ -50,21 +57,7 @@ router.use(adminConfigLimiter);
 // ── Apply admin auth + tenant extraction to every route ──────────────────────
 router.use(...adminStack);
 
-/**
- * Conditionally applies idempotency logic if the client provides the header.
- * Allows gradual rollout without breaking existing API clients.
- *
- * @param {object} req - Express request
- * @param {object} res - Express response
- * @param {function} next - Express next callback
- * @returns {void}
- */
-const optionalIdempotency = (req, res, next) => {
-  if (req.header('Idempotency-Key')) {
-    return idempotencyMiddleware(req, res, next);
-  }
-  next();
-};
+
 
 // ── POST /api/admin/config ────────────────────────────────────────────────────
 
@@ -224,6 +217,179 @@ router.post('/', idempotencyMiddleware, validateBody(runtimeConfigSchema), (req,
   });
 });
 
+// ── POST /api/admin/config/bulk ─────────────────────────────────────────────
+
+/**
+ * Applies runtime CORS side-effects for a validated CORS config item.
+ * Extracted as a helper so both the single and bulk handlers share the same
+ * logic without duplication.
+ *
+ * @param {object} validatedConfig - Validated CORS configuration object.
+ * @returns {void}
+ */
+function applyCorsEffects(validatedConfig) {
+  if (validatedConfig.origins) {
+    process.env.CORS_ALLOWED_ORIGINS = validatedConfig.origins.join(',');
+    reloadCorsOrigins();
+  }
+  if (validatedConfig.maxAge !== undefined) {
+    process.env.CORS_MAX_AGE = String(validatedConfig.maxAge);
+    reloadCorsMaxAge();
+  }
+}
+
+/**
+ * @swagger
+ * /api/admin/config/bulk:
+ *   post:
+ *     operationId: bulkUpdateRuntimeConfig
+ *     summary: Bulk-write runtime configuration sections
+ *     description: |
+ *       Accepts an array of configuration operations and processes each
+ *       independently. Individual item failures do not reject the entire
+ *       batch — the response always contains per-item results.
+ *
+ *       **Batch cap**: at most `BULK_CONFIG_MAX_ITEMS` operations (default 10).
+ *       Exceeding the cap rejects the entire request with 400.
+ *
+ *       **Access**: Admin-only (JWT bearer or API key). Tenant-scoped.
+ *       **Rate limit**: shares the per-client budget with the single config
+ *       endpoint (issue #754).
+ *
+ *     tags: [AdminConfig]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [operations]
+ *             properties:
+ *               operations:
+ *                 type: array
+ *                 minItems: 1
+ *                 maxItems: 10
+ *                 items:
+ *                   type: object
+ *                   required: [section, config]
+ *                   properties:
+ *                     section:
+ *                       type: string
+ *                       enum: [webhook, reconciliation, kyc, retention, fraudThresholds, cors]
+ *                     config:
+ *                       type: object
+ *     responses:
+ *       200:
+ *         description: Batch processed. Per-item results are in the `results` array.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 results:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       index:
+ *                         type: integer
+ *                       section:
+ *                         type: string
+ *                       status:
+ *                         type: string
+ *                         enum: [success, error]
+ *                       config:
+ *                         type: object
+ *                       errors:
+ *                         type: object
+ *                         additionalProperties: { type: string }
+ *                 summary:
+ *                   type: object
+ *                   properties:
+ *                     total: { type: integer }
+ *                     succeeded: { type: integer }
+ *                     failed: { type: integer }
+ *       400:
+ *         description: Envelope validation error (e.g. over-cap, empty batch, missing operations).
+ *         content:
+ *           application/problem+json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 type:  { type: string }
+ *                 title: { type: string }
+ *                 status: { type: integer }
+ *                 detail: { type: string }
+ *                 fieldErrors:
+ *                   type: object
+ *                   additionalProperties: { type: string }
+ *       401:
+ *         $ref: '#/components/responses/Problem401'
+ *       403:
+ *         $ref: '#/components/responses/Problem403'
+ *       429:
+ *         description: Rate limit exceeded — see Retry-After header.
+ */
+router.post('/bulk', validateBody(bulkConfigSchema), (req, res) => {
+  const { operations } = req.validated;
+  const results = [];
+  let succeeded = 0;
+  let failed = 0;
+
+  for (let i = 0; i < operations.length; i++) {
+    const op = operations[i];
+    const itemResult = runtimeConfigSchema.safeParse(op);
+
+    if (itemResult.success) {
+      const { section, config: validatedConfig } = itemResult.data;
+
+      // Apply CORS side-effects inline (same behaviour as single endpoint)
+      if (section === 'cors') {
+        applyCorsEffects(validatedConfig);
+      }
+
+      results.push({
+        index: i,
+        section,
+        status: 'success',
+        config: validatedConfig,
+      });
+      succeeded++;
+    } else {
+      const errors = parseValidationErrors(itemResult.error);
+      results.push({
+        index: i,
+        section: op.section || null,
+        status: 'error',
+        errors,
+      });
+      failed++;
+    }
+  }
+
+  logger.info(
+    {
+      tenantId: req.tenantId,
+      total: operations.length,
+      succeeded,
+      failed,
+      adminClient: req.apiClient?.clientId || req.user?.sub,
+    },
+    'Admin bulk config update processed',
+  );
+
+  return res.status(200).json({
+    results,
+    summary: {
+      total: operations.length,
+      succeeded,
+      failed,
+    },
+  });
+});
+
 // ── GET /api/admin/config/sections ───────────────────────────────────────────
 
 /**
@@ -259,3 +425,4 @@ router.get('/sections', (req, res) => {
 });
 
 module.exports = router;
+

--- a/src/schemas/config.js
+++ b/src/schemas/config.js
@@ -408,6 +408,81 @@ const runtimeConfigSchema = z
     }
   });
 
+// ── Bulk config schema ──────────────────────────────────────────────────────
+
+/**
+ * Maximum number of operations allowed in a single bulk config request.
+ * Configurable via BULK_CONFIG_MAX_ITEMS env var; defaults to 10.
+ * @type {number}
+ */
+const BULK_CONFIG_MAX_ITEMS = (() => {
+  const raw = parseInt(process.env.BULK_CONFIG_MAX_ITEMS || '', 10);
+  return Number.isFinite(raw) && raw >= 1 ? raw : 10;
+})();
+
+/**
+ * Schema for the individual operation item within a bulk config request.
+ * Shape: `{ section: string, config: object }`
+ *
+ * Unlike `runtimeConfigSchema`, this schema does NOT run section-specific
+ * validation via `.superRefine()`. Per-item validation is performed in the
+ * route handler so that individual failures do not reject the entire batch.
+ *
+ * @type {import('zod').ZodObject}
+ */
+const bulkConfigItemSchema = z
+  .object({
+    section: z.enum(
+      /** @type {[string, ...string[]]} */ (CONFIG_SECTIONS),
+      {
+        invalid_type_error: 'section must be a string',
+        required_error: 'section is required',
+        errorMap: () => ({
+          message: `section must be one of: ${CONFIG_SECTIONS.join(', ')}`,
+        }),
+      },
+    ),
+    config: z
+      .record(z.unknown(), { invalid_type_error: 'config must be an object' })
+      .refine((v) => v !== null && typeof v === 'object' && !Array.isArray(v), {
+        message: 'config must be a plain object',
+      }),
+  })
+  .strict();
+
+/**
+ * Schema for the POST /api/admin/config/bulk request body.
+ *
+ * Shape:
+ * ```json
+ * {
+ *   "operations": [
+ *     { "section": "webhook", "config": { ... } },
+ *     { "section": "cors",    "config": { ... } }
+ *   ]
+ * }
+ * ```
+ *
+ * - `operations` must contain 1–BULK_CONFIG_MAX_ITEMS items.
+ * - Each item must have a valid `section` enum and a `config` object.
+ * - Unknown top-level keys are rejected.
+ *
+ * @type {import('zod').ZodObject}
+ */
+const bulkConfigSchema = z
+  .object({
+    operations: z
+      .array(bulkConfigItemSchema, {
+        invalid_type_error: 'operations must be an array',
+        required_error: 'operations is required',
+      })
+      .min(1, { message: 'operations must contain at least one item' })
+      .max(BULK_CONFIG_MAX_ITEMS, {
+        message: `operations must not exceed ${BULK_CONFIG_MAX_ITEMS} items`,
+      }),
+  })
+  .strict();
+
 // ── Exports ──────────────────────────────────────────────────────────────────
 
 module.exports = {
@@ -421,6 +496,11 @@ module.exports = {
 
   // Top-level schema consumed by the admin config route
   runtimeConfigSchema,
+
+  // Bulk config schema and constants
+  bulkConfigSchema,
+  bulkConfigItemSchema,
+  BULK_CONFIG_MAX_ITEMS,
 
   // Re-exported helpers
   validateBody,

--- a/tests/configBulk.test.js
+++ b/tests/configBulk.test.js
@@ -1,0 +1,696 @@
+'use strict';
+
+/**
+ * @fileoverview Tests for POST /api/admin/config/bulk endpoint.
+ *
+ * Covers:
+ *  - Happy path: single item, multiple items, max batch size
+ *  - Partial failure: mix of valid + invalid items
+ *  - Over-cap rejection: exceeding BULK_CONFIG_MAX_ITEMS
+ *  - Empty batch / missing operations
+ *  - Validation: invalid section, missing config, unknown keys
+ *  - Response shape: index, section, status, config/errors, summary
+ *  - Cross-section batches
+ *  - CORS side-effects in bulk
+ *
+ * @jest-environment node
+ */
+
+// Mock admin auth stack
+jest.mock('../src/middleware/stacks', () => ({
+  adminStack: [
+    (req, _res, next) => {
+      req.tenantId = req.headers['x-tenant-id'] || 'tenant_test_default';
+      req.user = { sub: 'admin-test-user' };
+      next();
+    },
+  ],
+}));
+
+// Mock idempotency middleware to avoid transitive import of metrics.js
+// (adminConfig → idempotency → escrowSubmit → metrics)
+jest.mock('../src/middleware/idempotency', () => {
+  return (req, res, next) => next();
+});
+
+// Mock CORS reload functions so we can spy on them
+jest.mock('../src/config/cors', () => ({
+  reloadCorsOrigins: jest.fn(),
+  reloadCorsMaxAge: jest.fn(),
+  createCorsOptions: jest.fn(() => ({ origin: '*' })),
+  isCorsOriginRejectedError: jest.fn(() => false),
+}));
+
+const request = require('supertest');
+const express = require('express');
+const { reloadCorsOrigins, reloadCorsMaxAge } = require('../src/config/cors');
+
+const {
+  bulkConfigSchema,
+  validateBody,
+  BULK_CONFIG_MAX_ITEMS,
+  CONFIG_SECTIONS,
+} = require('../src/schemas/config');
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.use((req, _res, next) => {
+    req.id = 'req_test_' + Math.random().toString(36).slice(2, 10);
+    next();
+  });
+
+  // Mount the admin config router at the same path as production
+  const adminConfigRouter = require('../src/routes/adminConfig');
+  app.use('/api/admin/config', adminConfigRouter);
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validCorsOp(overrides = {}) {
+  return {
+    section: 'cors',
+    config: { origins: ['https://app.example.com'], ...overrides },
+  };
+}
+
+function validWebhookOp(overrides = {}) {
+  return {
+    section: 'webhook',
+    config: {
+      url: 'https://hooks.example.com/deliver',
+      secret: 'supersecretkey-32chars-minimum!!',
+      events: ['invoice.created'],
+      ...overrides,
+    },
+  };
+}
+
+function validRetentionOp(overrides = {}) {
+  return {
+    section: 'retention',
+    config: { retentionDays: 365, ...overrides },
+  };
+}
+
+function validReconciliationOp(overrides = {}) {
+  return {
+    section: 'reconciliation',
+    config: { batchSize: 100, ...overrides },
+  };
+}
+
+function validKycOp(overrides = {}) {
+  return {
+    section: 'kyc',
+    config: {
+      providerUrl: 'https://kyc.example.com',
+      apiKey: 'test-api-key-12345',
+      ...overrides,
+    },
+  };
+}
+
+function validFraudOp(overrides = {}) {
+  return {
+    section: 'fraudThresholds',
+    config: { fraudCeiling: 100000, ...overrides },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let app;
+
+beforeAll(() => {
+  app = buildApp();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ===========================================================================
+// Happy path
+// ===========================================================================
+
+describe('Bulk Config — Happy path', () => {
+  it('processes a single valid item and returns 200', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: [validCorsOp()] })
+      .expect(200);
+
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0]).toMatchObject({
+      index: 0,
+      section: 'cors',
+      status: 'success',
+    });
+    expect(res.body.results[0].config.origins).toEqual(['https://app.example.com']);
+    expect(res.body.summary).toEqual({ total: 1, succeeded: 1, failed: 0 });
+  });
+
+  it('processes multiple valid items across different sections', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          validCorsOp(),
+          validWebhookOp(),
+          validRetentionOp(),
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results).toHaveLength(3);
+    expect(res.body.results[0].section).toBe('cors');
+    expect(res.body.results[1].section).toBe('webhook');
+    expect(res.body.results[2].section).toBe('retention');
+    res.body.results.forEach((r) => expect(r.status).toBe('success'));
+    expect(res.body.summary).toEqual({ total: 3, succeeded: 3, failed: 0 });
+  });
+
+  it('processes exactly BULK_CONFIG_MAX_ITEMS items (boundary)', async () => {
+    const ops = Array.from({ length: BULK_CONFIG_MAX_ITEMS }, (_, i) =>
+      validCorsOp({ origins: [`https://app${i}.example.com`] }),
+    );
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: ops })
+      .expect(200);
+
+    expect(res.body.results).toHaveLength(BULK_CONFIG_MAX_ITEMS);
+    expect(res.body.summary.succeeded).toBe(BULK_CONFIG_MAX_ITEMS);
+    expect(res.body.summary.failed).toBe(0);
+  });
+
+  it('returns validated/coerced config in each result item', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          validCorsOp({ origins: ['https://test.example.com'], maxAge: 3600 }),
+        ],
+      })
+      .expect(200);
+
+    const item = res.body.results[0];
+    expect(item.config.origins).toEqual(['https://test.example.com']);
+    expect(item.config.maxAge).toBe(3600);
+  });
+
+  it('handles all six section types in a single batch', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          validCorsOp(),
+          validWebhookOp(),
+          validRetentionOp(),
+          validReconciliationOp(),
+          validKycOp(),
+          validFraudOp(),
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results).toHaveLength(6);
+    const sections = res.body.results.map((r) => r.section);
+    expect(sections).toEqual([
+      'cors', 'webhook', 'retention', 'reconciliation', 'kyc', 'fraudThresholds',
+    ]);
+    expect(res.body.summary.succeeded).toBe(6);
+  });
+});
+
+// ===========================================================================
+// Partial failure
+// ===========================================================================
+
+describe('Bulk Config — Partial failure', () => {
+  it('returns per-item errors without failing the batch', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          validCorsOp(),
+          { section: 'webhook', config: { url: 'not-a-url' } }, // invalid
+          validRetentionOp(),
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results).toHaveLength(3);
+    expect(res.body.results[0].status).toBe('success');
+    expect(res.body.results[1].status).toBe('error');
+    expect(res.body.results[1].errors).toBeDefined();
+    expect(res.body.results[2].status).toBe('success');
+    expect(res.body.summary).toEqual({ total: 3, succeeded: 2, failed: 1 });
+  });
+
+  it('returns 200 even when ALL items fail validation', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          { section: 'cors', config: {} },       // empty cors → error
+          { section: 'webhook', config: {} },     // missing required fields
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results).toHaveLength(2);
+    res.body.results.forEach((r) => expect(r.status).toBe('error'));
+    expect(res.body.summary).toEqual({ total: 2, succeeded: 0, failed: 2 });
+  });
+
+  it('preserves correct index for each result', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          { section: 'cors', config: {} },    // fail
+          validCorsOp(),                       // success
+          { section: 'webhook', config: {} },  // fail
+          validRetentionOp(),                  // success
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results.map((r) => r.index)).toEqual([0, 1, 2, 3]);
+    expect(res.body.results.map((r) => r.status)).toEqual([
+      'error', 'success', 'error', 'success',
+    ]);
+  });
+
+  it('includes field-level errors for failed items', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          { section: 'cors', config: { origins: ['not-a-url'] } },
+        ],
+      })
+      .expect(200);
+
+    const item = res.body.results[0];
+    expect(item.status).toBe('error');
+    expect(item.errors).toBeDefined();
+    expect(Object.keys(item.errors).length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// Over-cap rejection
+// ===========================================================================
+
+describe('Bulk Config — Over-cap rejection', () => {
+  it('rejects batch exceeding BULK_CONFIG_MAX_ITEMS with 400', async () => {
+    const ops = Array.from({ length: BULK_CONFIG_MAX_ITEMS + 1 }, () => validCorsOp());
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: ops })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+    expect(res.body.fieldErrors).toBeDefined();
+    expect(res.body.fieldErrors.operations).toMatch(/must not exceed/);
+  });
+
+  it('rejects 11 items when cap is 10', async () => {
+    const ops = Array.from({ length: 11 }, () => validCorsOp());
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: ops });
+
+    // When default cap is 10, 11 should fail
+    if (BULK_CONFIG_MAX_ITEMS === 10) {
+      expect(res.status).toBe(400);
+    }
+  });
+});
+
+// ===========================================================================
+// Empty batch / missing operations
+// ===========================================================================
+
+describe('Bulk Config — Empty batch', () => {
+  it('rejects empty operations array with 400', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: [] })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+    expect(res.body.fieldErrors.operations).toMatch(/at least one/);
+  });
+
+  it('rejects missing operations key with 400', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({})
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+    expect(res.body.fieldErrors.operations).toBeDefined();
+  });
+
+  it('rejects when operations is not an array', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: 'not-an-array' })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+
+  it('rejects when operations is null', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: null })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+
+  it('rejects empty request body', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send()
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// Envelope validation
+// ===========================================================================
+
+describe('Bulk Config — Envelope validation', () => {
+  it('rejects unknown top-level keys (strict mode)', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [validCorsOp()],
+        extraField: 'hacker',
+      })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+
+  it('rejects item with invalid section name at envelope level', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [{ section: 'nonexistent', config: { foo: 1 } }],
+      })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+
+  it('rejects item missing config at envelope level', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [{ section: 'cors' }],
+      })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+
+  it('rejects item with unknown keys inside operation (strict)', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [{ section: 'cors', config: { origins: ['https://a.com'] }, extra: true }],
+      })
+      .expect(400);
+
+    expect(res.body.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// Per-item section-specific validation
+// ===========================================================================
+
+describe('Bulk Config — Section-specific validation in items', () => {
+  it('reports section-specific errors for invalid webhook config', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          {
+            section: 'webhook',
+            config: { url: 'not-a-url', secret: 'short', events: [] },
+          },
+        ],
+      })
+      .expect(200);
+
+    const item = res.body.results[0];
+    expect(item.status).toBe('error');
+    expect(item.errors).toBeDefined();
+  });
+
+  it('reports error for cors with invalid origin URL', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          { section: 'cors', config: { origins: ['not-a-url'] } },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results[0].status).toBe('error');
+  });
+
+  it('reports error for cors maxAge out of range', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          { section: 'cors', config: { maxAge: 999999 } },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results[0].status).toBe('error');
+  });
+
+  it('reports error for fraudThresholds cross-field rule', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          {
+            section: 'fraudThresholds',
+            config: { fraudCeiling: 100, manualReviewThreshold: 200 },
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results[0].status).toBe('error');
+  });
+
+  it('reports error for unknown keys in section config (strict)', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          { section: 'cors', config: { origins: ['https://a.com'], hackerField: 'evil' } },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.results[0].status).toBe('error');
+  });
+});
+
+// ===========================================================================
+// CORS side-effects
+// ===========================================================================
+
+describe('Bulk Config — CORS side-effects', () => {
+  it('calls reloadCorsOrigins for valid CORS item in batch', async () => {
+    await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [validCorsOp()],
+      })
+      .expect(200);
+
+    expect(reloadCorsOrigins).toHaveBeenCalled();
+  });
+
+  it('calls reloadCorsMaxAge for CORS item with maxAge', async () => {
+    await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [validCorsOp({ maxAge: 3600 })],
+      })
+      .expect(200);
+
+    expect(reloadCorsMaxAge).toHaveBeenCalled();
+  });
+
+  it('does NOT call CORS reload for non-CORS items', async () => {
+    await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [validRetentionOp()],
+      })
+      .expect(200);
+
+    expect(reloadCorsOrigins).not.toHaveBeenCalled();
+    expect(reloadCorsMaxAge).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call CORS reload for failed CORS items', async () => {
+    await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [{ section: 'cors', config: {} }],
+      })
+      .expect(200);
+
+    expect(reloadCorsOrigins).not.toHaveBeenCalled();
+  });
+
+  it('calls CORS reload only for successful CORS items in mixed batch', async () => {
+    await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          validRetentionOp(),
+          validCorsOp(),
+          { section: 'cors', config: {} }, // invalid
+        ],
+      })
+      .expect(200);
+
+    expect(reloadCorsOrigins).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===========================================================================
+// Response shape
+// ===========================================================================
+
+describe('Bulk Config — Response shape', () => {
+  it('always contains results array and summary object', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: [validCorsOp()] })
+      .expect(200);
+
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.summary).toBeDefined();
+    expect(typeof res.body.summary.total).toBe('number');
+    expect(typeof res.body.summary.succeeded).toBe('number');
+    expect(typeof res.body.summary.failed).toBe('number');
+  });
+
+  it('success items have index, section, status, config', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({ operations: [validCorsOp()] })
+      .expect(200);
+
+    const item = res.body.results[0];
+    expect(item).toHaveProperty('index', 0);
+    expect(item).toHaveProperty('section', 'cors');
+    expect(item).toHaveProperty('status', 'success');
+    expect(item).toHaveProperty('config');
+    expect(item).not.toHaveProperty('errors');
+  });
+
+  it('error items have index, section, status, errors', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [{ section: 'cors', config: {} }],
+      })
+      .expect(200);
+
+    const item = res.body.results[0];
+    expect(item).toHaveProperty('index', 0);
+    expect(item).toHaveProperty('section', 'cors');
+    expect(item).toHaveProperty('status', 'error');
+    expect(item).toHaveProperty('errors');
+    expect(item).not.toHaveProperty('config');
+  });
+
+  it('summary.total equals results.length', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [validCorsOp(), validRetentionOp()],
+      })
+      .expect(200);
+
+    expect(res.body.summary.total).toBe(res.body.results.length);
+  });
+
+  it('summary.succeeded + summary.failed equals summary.total', async () => {
+    const res = await request(app)
+      .post('/api/admin/config/bulk')
+      .send({
+        operations: [
+          validCorsOp(),
+          { section: 'cors', config: {} },
+          validRetentionOp(),
+        ],
+      })
+      .expect(200);
+
+    const { total, succeeded, failed } = res.body.summary;
+    expect(succeeded + failed).toBe(total);
+  });
+});
+
+// ===========================================================================
+// Schema unit tests
+// ===========================================================================
+
+describe('Bulk Config — Schema constants', () => {
+  it('BULK_CONFIG_MAX_ITEMS defaults to 10', () => {
+    expect(BULK_CONFIG_MAX_ITEMS).toBe(10);
+  });
+
+  it('bulkConfigSchema rejects non-object body', () => {
+    const result = bulkConfigSchema.safeParse('string');
+    expect(result.success).toBe(false);
+  });
+
+  it('bulkConfigSchema rejects array body (not wrapped in operations)', () => {
+    const result = bulkConfigSchema.safeParse([validCorsOp()]);
+    expect(result.success).toBe(false);
+  });
+
+  it('CONFIG_SECTIONS includes all six sections', () => {
+    expect(CONFIG_SECTIONS).toEqual(
+      expect.arrayContaining([
+        'webhook', 'reconciliation', 'kyc', 'retention', 'fraudThresholds', 'cors',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Add POST /api/admin/config/bulk that accepts a bounded array of config operations, validates each independently using existing Zod schemas, and returns per-item success/error results without failing the entire batch.

Changes:
- src/schemas/config.js: Add bulkConfigSchema, bulkConfigItemSchema, BULK_CONFIG_MAX_ITEMS constant
- src/routes/adminConfig.js: Add /bulk route with Swagger docs, fix duplicate idempotencyMiddleware import, remove unused optionalIdempotency
- tests/configBulk.test.js: 39 tests covering happy path, partial failure, over-cap rejection, empty batch, envelope validation, section-specific validation, CORS side-effects, response shape

Closes #817 