### PR TITLE
docs(indexer): add request examples

### DIFF
--- a/docs/indexer-examples.md
+++ b/docs/indexer-examples.md
@@ -1,0 +1,143 @@
+# Indexer endpoint examples
+
+This document provides ready-to-run `curl` examples for the admin indexer endpoint exposed by the backend.
+
+## Base URL
+
+```bash
+export BASE_URL="http://localhost:3001"
+```
+
+## Authentication
+
+The route at `/api/admin/indexer/events` accepts either:
+
+- an `Authorization: Bearer <JWT>` header, or
+- an `X-API-Key: <key>` header.
+
+For local testing, set one of the following before running the examples:
+
+```bash
+export ADMIN_JWT="<admin-jwt>"
+export API_KEY="<valid-api-key>"
+```
+
+If your deployment expects a tenant context, also set:
+
+```bash
+export TENANT_ID="tenant-test"
+```
+
+## 1. List the latest indexed events
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+Example response shape:
+
+```json
+{
+  "data": [
+    {
+      "event_id": "evt_9f21ac",
+      "invoice_id": "inv_001",
+      "event_type": "escrow_created",
+      "ledger_sequence": 100,
+      "paging_token": "100-1",
+      "contract_id": null,
+      "tx_hash": null,
+      "observed_at": "2026-01-01T00:00:00.000Z",
+      "created_at": "2026-01-01T00:00:01.000Z"
+    }
+  ],
+  "meta": {
+    "total": 1,
+    "limit": 20,
+    "hasMore": false,
+    "nextCursor": null,
+    "timestamp": "2026-07-25T12:00:00.000Z",
+    "version": "0.1.0"
+  },
+  "error": null,
+  "message": "Indexer events retrieved successfully."
+}
+```
+
+## 2. Filter by invoice ID and page size
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?invoiceId=inv_001&limit=10" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+This uses the validated `invoiceId` filter, which accepts 1-128 characters matching `^[a-zA-Z0-9_-]+$`.
+
+## 3. Filter by event type and sort by ledger sequence
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?eventType=escrow_created&sortBy=ledger_sequence&order=asc&limit=25" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+Supported `sortBy` values are `observed_at` and `ledger_sequence`.
+
+## 4. Use cursor pagination for stable paging
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?limit=5" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+Use the returned `meta.nextCursor` value on the next request:
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?cursor=<nextCursor>&limit=5" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+Cursors are opaque and HMAC-signed. A malformed or tampered cursor returns `400` with a validation error.
+
+## 5. Authenticate with an API key instead of a JWT
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?limit=5" \
+  -H "X-API-Key: $API_KEY" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+## Validation examples
+
+### Invalid sort field
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?sortBy=yield_bps" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+This returns `400` with a validation error because `sortBy` must be one of `observed_at` or `ledger_sequence`.
+
+### Invalid contract ID
+
+```bash
+curl -X GET "$BASE_URL/api/admin/indexer/events?contractId=BADADDR" \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-tenant-id: $TENANT_ID" \
+  -H "Accept: application/json"
+```
+
+This returns `400` because `contractId` must match the Stellar contract address format.

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -23,6 +23,8 @@ The route is mounted in `src/app.js` via:
 mountFeatureRouter(app, '/api/admin/indexer', adminIndexerRoutes);
 ```
 
+For runnable curl examples and auth variations, see [indexer-examples.md](indexer-examples.md).
+
 Indexer health (staleness of the last processed ledger) is reported separately
 through `GET /health` and `GET /health/detailed` (`checkIndexerStaleness` in
 `src/services/health.js`); it is not part of this route and is not covered

--- a/tests/indexerDocs.test.js
+++ b/tests/indexerDocs.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+describe('indexer examples documentation', () => {
+  test('documents the admin indexer route with runnable curl examples', () => {
+    const docPath = path.join(__dirname, '..', 'docs', 'indexer-examples.md');
+    expect(fs.existsSync(docPath)).toBe(true);
+
+    const content = fs.readFileSync(docPath, 'utf8');
+    expect(content).toContain('/api/admin/indexer/events');
+    expect(content).toContain('Authorization: Bearer');
+    expect(content).toContain('X-API-Key');
+    expect(content).toContain('x-tenant-id');
+    expect(content).toContain('curl');
+  });
+});


### PR DESCRIPTION
Closes #931 


## PR Summary

This PR adds ready-to-run curl examples for the admin indexer endpoint so operators can quickly test and validate the API without manually reconstructing requests.

## What changed

- Added a new documentation guide at indexer-examples.md with copy-paste examples for:
  - listing indexed events
  - filtering by invoice ID and event type
  - sorting by observed_at or ledger_sequence
  - cursor-based pagination
  - API key authentication
  - validation-error examples
- Linked the new guide from indexer.md for easier discovery.
- Added a regression test in indexerDocs.test.js to ensure the documentation includes the route, auth headers, and runnable examples.

## Why

The indexer endpoint previously lacked practical, runnable examples for common admin workflows. This change improves developer and operator experience by documenting the request shape and expected auth requirements directly in the docs.

## Notes

- Examples are aligned with the current route contract at /api/admin/indexer/events.
- Authentication examples cover both Bearer JWT and X-API-Key usage.
- No application behavior was changed; this is documentation-only.