### PR TITLE
feat(indexer): add bulk operations endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -44,6 +44,7 @@ const { validateHealthQuery, rejectBodyOnGet } = require('./schemas/health');
 const responseHelper = require('./utils/responseHelper');
 const logger = require('./logger');
 const { metricsAuth, metricsHandler } = require('./metrics');
+const { metricsLimiter } = require('./middleware/rateLimit');
 const { instrumentHealth } = require('./middleware/healthMetrics');
 const smeRoutes = require('./routes/sme');
 const invoiceFileRoutes = require('./routes/invoiceFile');

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1113,15 +1113,17 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
 });
 
 /**
- * Bounded enum of allowed `status_class` label values.
+ * Bounded enum of allowed `status_class` label values for persistence.
  * @readonly
  */
+const PERSISTENCE_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
 
 /**
  * Bounded enum of allowed `cause` label values for persistence errors.
  * Raw error messages are NEVER used as labels.
  * @readonly
  */
+const PERSISTENCE_CAUSE_ENUM = Object.freeze(['validation', 'storage', 'internal', 'none']);
 
 /**
  * Maps a raw persistence endpoint hint to a bounded metric label value.
@@ -1129,6 +1131,11 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} raw - Raw endpoint identifier.
  * @returns {string} Bounded value from {@link PERSISTENCE_ENDPOINT_ENUM}.
  */
+function normalizePersistenceEndpoint(raw) {
+  const ep = String(raw || '').trim().toLowerCase();
+  if (!ep) { return 'unknown'; }
+  return ep.replace(/[^a-z0-9_]/g, '_').slice(0, 64);
+}
 
 /**
  * Maps an HTTP status code to a bounded `status_class` label value.
@@ -1136,44 +1143,82 @@ const sorobanRpcRetryCausesTotal = new client.Counter({
  * @param {unknown} status - HTTP status code.
  * @returns {string} Bounded value from {'2xx'|'4xx'|'5xx'}.
  */
+function normalizePersistenceStatusClass(status) {
+  const code = Number(status);
+  if (code >= 500) { return '5xx'; }
+  if (code >= 400) { return '4xx'; }
+  return '2xx';
+}
 
 /**
  * Maps a raw persistence failure to a bounded `cause` label value.
- *
- * Recognises the storage-service error codes surfaced by the SME routes
- * (INVALID_MIME_TYPE, FILE_TOO_LARGE, INVALID_TENANT_ID) as client-side
- * `validation`, storage-layer failures as `storage`, and everything else as
- * `internal`. A 2xx outcome maps to `none`.
  *
  * @param {unknown} err - Raw error object or code (null/undefined for success).
  * @param {number} [status] - HTTP status code, used to disambiguate.
  * @returns {string} Bounded value from {'validation'|'storage'|'internal'|'none'}.
  */
+function normalizePersistenceCause(err, status) {
+  const code = Number(status);
+  if (!err && code < 400) { return 'none'; }
+  if (err) {
+    const msg = (err.code || err.message || String(err)).toUpperCase();
+    if (msg.includes('INVALID_MIME_TYPE') || msg.includes('FILE_TOO_LARGE') || msg.includes('INVALID_TENANT_ID')) {
+      return 'validation';
+    }
+    if (msg.includes('STORAGE') || msg.includes('ECONNREFUSED') || msg.includes('ETIMEOUT')) {
+      return 'storage';
+    }
+  }
+  return 'internal';
+}
 
 /**
  * Histogram: Wall-clock duration of persistence-endpoint requests in seconds.
  * @type {import('prom-client').Histogram}
  */
+const persistenceRequestDurationSeconds = new client.Histogram({
+  name: 'persistence_request_duration_seconds',
+  help: 'Duration of persistence endpoint requests in seconds',
+  labelNames: ['endpoint', 'status_class'],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [registry],
+});
 
 /**
  * Counter: Total persistence-endpoint requests.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestsTotal = new client.Counter({
+  name: 'persistence_requests_total',
+  help: 'Total number of persistence endpoint requests',
+  labelNames: ['endpoint', 'status_class'],
+  registers: [registry],
+});
 
 /**
  * Counter: Persistence-endpoint request errors by cause.
  * @type {import('prom-client').Counter}
  */
+const persistenceRequestErrorsTotal = new client.Counter({
+  name: 'persistence_request_errors_total',
+  help: 'Total number of persistence endpoint request errors by cause',
+  labelNames: ['endpoint', 'cause'],
+  registers: [registry],
+});
 
 /**
  * Bounded enum of allowed `status_class` label values for metrics endpoint.
  * @readonly
+ * @type {readonly string[]}
  */
+const METRICS_ENDPOINT_STATUS_CLASS_ENUM = Object.freeze(['2xx', '4xx', '5xx']);
 
 /**
  * Bounded enum of allowed `cause` label values for metrics endpoint errors.
  * @readonly
+ * @type {readonly string[]}
  */
+const METRICS_ENDPOINT_CAUSE_ENUM = Object.freeze(['none', 'auth_failure', 'internal_error']);
 
 /**
  * Maps an HTTP status code to a bounded `status_class` label value.
@@ -1213,6 +1258,68 @@ const metricsRequestDurationSeconds = new client.Histogram({
   buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
   registers: [registry],
 });
+
+/**
+ * Counter: Total metrics endpoint requests.
+ * @type {import('prom-client').Counter}
+ */
+const metricsRequestsTotal = new client.Counter({
+  name: 'metrics_requests_total',
+  help: 'Total number of metrics endpoint requests',
+  labelNames: ['status_class'],
+  registers: [registry],
+});
+
+/**
+ * Counter: Metrics endpoint request errors by cause.
+ * @type {import('prom-client').Counter}
+ */
+const metricsRequestErrorsTotal = new client.Counter({
+  name: 'metrics_request_errors_total',
+  help: 'Total number of metrics endpoint request errors',
+  labelNames: ['cause'],
+  registers: [registry],
+});
+
+/**
+ * Records the outcome of a metrics endpoint request.
+ *
+ * @param {object} params
+ * @param {number} params.statusCode - HTTP status code.
+ * @param {number} params.durationSeconds - Request duration in seconds.
+ * @param {Error}  [params.error] - Error that caused the failure, if any.
+ * @param {import('express').Request} [params.req] - Express request object.
+ * @returns {void}
+ */
+function recordMetricsEndpointOutcome({ statusCode, durationSeconds, error, req }) {
+  const statusClass = normalizeMetricsEndpointStatusClass(statusCode);
+
+  metricsRequestDurationSeconds.labels(statusClass).observe(durationSeconds);
+  metricsRequestsTotal.labels(statusClass).inc();
+
+  const cause = normalizeMetricsEndpointCause(error, statusCode);
+  if (cause !== 'none') {
+    metricsRequestErrorsTotal.labels(cause).inc();
+  }
+
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    statusClass,
+    statusCode,
+    durationSeconds: Number(durationSeconds.toFixed(6)),
+    cause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'metrics endpoint request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'metrics endpoint request rejected');
+  } else {
+    log.info(fields, 'metrics endpoint request completed');
+  }
+}
 
 // ── KYC webhook metrics (issue #731) ────────────────────────────────────────
 
@@ -1468,6 +1575,32 @@ const escrowReadCacheEvictionsTotal = new client.Counter({
   registers: [registry],
 });
 
+// ── CORS origin-cache metrics ──────────────────────────────────────────────
+
+const corsCacheHitsTotal = new client.Counter({
+  name: 'cors_cache_hits_total',
+  help: 'Total CORS origin-cache hits',
+  registers: [registry],
+});
+
+const corsCacheMissesTotal = new client.Counter({
+  name: 'cors_cache_misses_total',
+  help: 'Total CORS origin-cache misses',
+  registers: [registry],
+});
+
+const corsCacheEvictionsTotal = new client.Counter({
+  name: 'cors_cache_evictions_total',
+  help: 'Total CORS origin-cache evictions',
+  registers: [registry],
+});
+
+const corsCacheInvalidationsTotal = new client.Counter({
+  name: 'cors_cache_invalidations_total',
+  help: 'Total CORS origin-cache invalidations (full clears)',
+  registers: [registry],
+});
+
 
 /**
  * Returns the shared Prometheus registry.
@@ -1522,6 +1655,10 @@ module.exports = {
   escrowReadCacheHitsTotal,
   escrowReadCacheMissesTotal,
   escrowReadCacheEvictionsTotal,
+  corsCacheHitsTotal,
+  corsCacheMissesTotal,
+  corsCacheEvictionsTotal,
+  corsCacheInvalidationsTotal,
   persistenceRequestDurationSeconds,
   persistenceRequestsTotal,
   persistenceRequestErrorsTotal,

--- a/src/routes/adminConfig.js
+++ b/src/routes/adminConfig.js
@@ -37,7 +37,6 @@ const { adminConfigLimiter } = require('../middleware/rateLimit');
 const idempotencyMiddleware = require('../middleware/idempotency');
 const { reloadCorsOrigins, reloadCorsMaxAge } = require('../config/cors');
 const logger = require('../logger');
-const idempotencyMiddleware = require('../middleware/idempotency');
 
 const router = express.Router();
 

--- a/src/routes/adminIndexer.js
+++ b/src/routes/adminIndexer.js
@@ -16,7 +16,7 @@
 const express = require('express');
 
 const router = express.Router();
-const { listIndexerEvents, INDEXER_SORT_FIELDS } = require('../services/indexerService');
+const { listIndexerEvents, bulkIndexerEvents, validateBulkPayload, INDEXER_SORT_FIELDS, MAX_BULK_BATCH_SIZE } = require('../services/indexerService');
 const { CursorError } = require('../utils/cursorPagination');
 const { adminStack } = require('../middleware/stacks');
 const responseHelper = require('../utils/responseHelper');
@@ -300,6 +300,76 @@ router.get('/events', async (req, res, next) => {
     return res.status(200).json({
       ...responseHelper.success(result.data, result.meta),
       message: 'Indexer events retrieved successfully.',
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /api/admin/indexer/events/bulk:
+ *   post:
+ *     operationId: bulkIndexerEvents
+ *     summary: Bulk-ingest indexer events
+ *     description: |
+ *       Accepts a bounded JSON array of raw event objects, validates each
+ *       independently, and persists valid entries.  Invalid items produce an
+ *       error entry in the response without aborting the rest of the batch.
+ *
+ *       **Access**: Admin-only (JWT bearer or API key).
+ *
+ *       **Limits**: Maximum **50** items per request (HTTP 413 when exceeded).
+ *     tags: [Indexer]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             maxItems: 50
+ *             items:
+ *               $ref: '#/components/schemas/IndexerEvent'
+ *     responses:
+ *       200:
+ *         description: Per-item results (partial failure is reported, not thrown)
+ *       400:
+ *         description: Request body is not an array, is empty, or contains a non-object item
+ *         $ref: '#/components/responses/Problem400'
+ *       401:
+ *         $ref: '#/components/responses/Problem401'
+ *       403:
+ *         $ref: '#/components/responses/Problem403'
+ *       413:
+ *         description: Batch exceeds maximum allowed size
+ */
+router.post('/events/bulk', async (req, res, next) => {
+  try {
+    const validation = validateBulkPayload(req.body);
+
+    if (!validation.ok) {
+      return res.status(validation.error.status).json(
+        responseHelper.error(validation.error.message, validation.error.code, validation.error.details),
+      );
+    }
+
+    const result = await bulkIndexerEvents({
+      events: validation.events,
+      dbClient: req._dbClient,
+    });
+
+    const statusCode = result.meta.failed > 0 ? 207 : 200;
+
+    logger.info(
+      { requestId: req.id, succeeded: result.meta.succeeded, failed: result.meta.failed, total: result.meta.total },
+      'Bulk indexer events processed',
+    );
+
+    return res.status(statusCode).json({
+      ...responseHelper.success(result.data, result.meta),
+      message: 'Bulk indexer events processed.',
     });
   } catch (error) {
     return next(error);

--- a/src/services/indexerService.js
+++ b/src/services/indexerService.js
@@ -35,6 +35,7 @@
 
 const db = require('../db/knex');
 const { encodeCursor, decodeCursor } = require('../utils/cursorPagination');
+const { indexerEventSchema, parseValidationErrors } = require('../schemas/indexerEvent');
 
 /**
  * Allowed sort fields for the indexer listing endpoint.
@@ -68,6 +69,13 @@ const MAX_PAGE_SIZE = 100;
  * @type {number}
  */
 const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Maximum number of events accepted in a single bulk ingestion request.
+ * Protects against oversized payloads and unbounded write amplification.
+ * @type {number}
+ */
+const MAX_BULK_BATCH_SIZE = 50;
 
 /**
  * Columns selected from `escrow_events`.
@@ -260,11 +268,117 @@ async function listIndexerEvents({
   };
 }
 
+/**
+ * Validates the shape of the incoming batch payload before item-level
+ * processing begins.  Rejects non-arrays, arrays exceeding the cap, and
+ * arrays containing non-object entries early.
+ *
+ * @param {unknown} body - Parsed JSON request body.
+ * @returns {{ ok: boolean, events?: object[], error?: object }} When `ok` is
+ *   false the `error` field contains the response envelope to send.
+ */
+function validateBulkPayload(body) {
+  if (!Array.isArray(body)) {
+    return {
+      ok: false,
+      error: { status: 400, message: 'Request body must be a JSON array of event objects.', code: 'VALIDATION_ERROR', details: { _root: 'Expected an array.' } },
+    };
+  }
+
+  if (body.length === 0) {
+    return {
+      ok: false,
+      error: { status: 400, message: 'Batch must contain at least one event.', code: 'VALIDATION_ERROR', details: { _root: 'Array must not be empty.' } },
+    };
+  }
+
+  if (body.length > MAX_BULK_BATCH_SIZE) {
+    return {
+      ok: false,
+      error: { status: 413, message: `Batch exceeds maximum size of ${MAX_BULK_BATCH_SIZE} events.`, code: 'BATCH_TOO_LARGE', details: { maxBatchSize: MAX_BULK_BATCH_SIZE, received: body.length } },
+    };
+  }
+
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === null || typeof body[i] !== 'object') {
+      return {
+        ok: false,
+        error: { status: 400, message: `Item at index ${i} must be a non-null object.`, code: 'VALIDATION_ERROR', details: { [`items[${i}]`]: 'Expected a non-null object.' } },
+      };
+    }
+  }
+
+  return { ok: true, events: body };
+}
+
+/**
+ * Accepts a bounded array of raw indexer events, validates each one
+ * individually, persists valid events, and returns per-item results.
+ *
+ * Failures on one item never abort the rest of the batch — callers always
+ * receive a result entry for every input item.
+ *
+ * @param {object} options
+ * @param {object[]} options.events - Raw event payloads to ingest.
+ * @param {import('knex').Knex} [options.dbClient] - Injectable Knex client.
+ * @returns {Promise<{ data: object[], meta: object }>}
+ *   `data` is an array of per-item result objects. `meta` contains
+ *   `succeeded`, `failed`, and `total` counts.
+ */
+async function bulkIndexerEvents({ events, dbClient } = {}) {
+  const knex = dbClient || db;
+  const results = [];
+
+  for (let i = 0; i < events.length; i++) {
+    const raw = events[i];
+    try {
+      const parsed = indexerEventSchema.safeParse(raw);
+      if (!parsed.success) {
+        results.push({ index: i, success: false, error: { code: 'VALIDATION_ERROR', details: parseValidationErrors(parsed.error) } });
+        continue;
+      }
+
+      const d = parsed.data;
+      const normalized = {
+        event_id: d.eventId,
+        invoice_id: d.invoiceId,
+        event_type: d.eventType,
+        ledger_sequence: d.ledgerSequence,
+        paging_token: d.pagingToken || null,
+        contract_id: d.contractId !== undefined ? d.contractId : null,
+        tx_hash: d.txHash !== undefined ? d.txHash : null,
+        event_body: d.eventBody !== undefined ? JSON.stringify(d.eventBody) : null,
+        observed_at: d.observedAt || new Date().toISOString(),
+      };
+
+      await knex('escrow_events')
+        .insert(normalized)
+        .onConflict('event_id')
+        .merge();
+
+      results.push({ index: i, success: true, eventId: normalized.event_id });
+    } catch (err) {
+      results.push({ index: i, success: false, error: { code: 'PERSIST_ERROR', message: err.message || 'Unexpected error.' } });
+    }
+  }
+
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.length - succeeded;
+
+  return {
+    data: results,
+    meta: { succeeded, failed, total: results.length },
+  };
+}
+
 module.exports = {
   listIndexerEvents,
+  bulkIndexerEvents,
+  validateBulkPayload,
   INDEXER_SORT_FIELDS,
   DEFAULT_SORT_FIELD,
   DEFAULT_ORDER,
   MAX_PAGE_SIZE,
   DEFAULT_PAGE_SIZE,
+  MAX_BULK_BATCH_SIZE,
 };

--- a/tests/indexerBulk.test.js
+++ b/tests/indexerBulk.test.js
@@ -1,0 +1,487 @@
+'use strict';
+
+/**
+ * @fileoverview Tests for the bulk indexer events endpoint (#22).
+ *
+ * Covers:
+ *  - Service layer: validateBulkPayload, bulkIndexerEvents
+ *  - Route: POST /api/admin/indexer/events/bulk
+ *  - Edge cases: empty batch, over-cap rejected, partial failure, auth guard
+ */
+
+const VALID_EVENT = {
+  eventId: 'evt_001',
+  invoiceId: 'INV-100',
+  eventType: 'escrow_created',
+  ledgerSequence: 100,
+};
+
+function makeValidEvent(overrides = {}) {
+  return { ...VALID_EVENT, ...overrides };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 1: validateBulkPayload unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validateBulkPayload()', () => {
+  let validateBulkPayload;
+
+  beforeAll(() => {
+    ({ validateBulkPayload } = require('../src/services/indexerService'));
+  });
+
+  test('rejects non-array body', () => {
+    const result = validateBulkPayload({ not: 'array' });
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(400);
+    expect(result.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('rejects null body', () => {
+    const result = validateBulkPayload(null);
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(400);
+  });
+
+  test('rejects string body', () => {
+    const result = validateBulkPayload('hello');
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(400);
+  });
+
+  test('rejects empty array', () => {
+    const result = validateBulkPayload([]);
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(400);
+    expect(result.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('rejects batch exceeding MAX_BULK_BATCH_SIZE (50)', () => {
+    const oversized = Array.from({ length: 51 }, (_, i) => makeValidEvent({ eventId: `evt_${i}` }));
+    const result = validateBulkPayload(oversized);
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(413);
+    expect(result.error.code).toBe('BATCH_TOO_LARGE');
+    expect(result.error.details.maxBatchSize).toBe(50);
+    expect(result.error.details.received).toBe(51);
+  });
+
+  test('accepts batch at exact cap (50)', () => {
+    const atCap = Array.from({ length: 50 }, (_, i) => makeValidEvent({ eventId: `evt_${i}` }));
+    const result = validateBulkPayload(atCap);
+    expect(result.ok).toBe(true);
+    expect(result.events).toHaveLength(50);
+  });
+
+  test('rejects array with a non-object item', () => {
+    const result = validateBulkPayload([makeValidEvent(), 'not-an-object']);
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(400);
+    expect(result.error.details).toHaveProperty(['items[1]']);
+  });
+
+  test('rejects array with null item', () => {
+    const result = validateBulkPayload([makeValidEvent(), null]);
+    expect(result.ok).toBe(false);
+    expect(result.error.status).toBe(400);
+  });
+
+  test('accepts single valid event', () => {
+    const result = validateBulkPayload([makeValidEvent()]);
+    expect(result.ok).toBe(true);
+    expect(result.events).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 2: bulkIndexerEvents service unit tests
+// Uses an in-memory Knex fake — no real DB required.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('bulkIndexerEvents()', () => {
+  let bulkIndexerEvents;
+
+  beforeAll(() => {
+    ({ bulkIndexerEvents } = require('../src/services/indexerService'));
+  });
+
+  function makeFakeKnex() {
+    const inserted = [];
+    const q = {
+      insert: jest.fn(function (row) { inserted.push(row); return q; }),
+      onConflict: jest.fn(() => q),
+      merge: jest.fn(function () { return Promise.resolve(); }),
+    };
+    q.onConflict.mockReturnValue(q);
+
+    const knex = jest.fn(() => q);
+    knex.inserted = inserted;
+    knex._q = q;
+    return knex;
+  }
+
+  test('persists a single valid event and returns success', async () => {
+    const knex = makeFakeKnex();
+    const result = await bulkIndexerEvents({ events: [makeValidEvent()], dbClient: knex });
+
+    expect(result.meta.total).toBe(1);
+    expect(result.meta.succeeded).toBe(1);
+    expect(result.meta.failed).toBe(0);
+    expect(result.data[0].success).toBe(true);
+    expect(result.data[0].eventId).toBe('evt_001');
+  });
+
+  test('returns per-item error for invalid event without aborting batch', async () => {
+    const knex = makeFakeKnex();
+    const events = [
+      makeValidEvent(),
+      { eventId: '', invoiceId: 'INV-100', eventType: 'escrow_created', ledgerSequence: 100 },
+    ];
+    const result = await bulkIndexerEvents({ events, dbClient: knex });
+
+    expect(result.meta.total).toBe(2);
+    expect(result.meta.succeeded).toBe(1);
+    expect(result.meta.failed).toBe(1);
+    expect(result.data[0].success).toBe(true);
+    expect(result.data[1].success).toBe(false);
+    expect(result.data[1].error.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('all items fail when all are invalid', async () => {
+    const knex = makeFakeKnex();
+    const events = [
+      { notAnEvent: true },
+      { eventId: 'x' },
+    ];
+    const result = await bulkIndexerEvents({ events, dbClient: knex });
+
+    expect(result.meta.succeeded).toBe(0);
+    expect(result.meta.failed).toBe(2);
+    expect(result.data.every((r) => r.success === false)).toBe(true);
+  });
+
+  test('catches DB errors and returns PERSIST_ERROR without aborting', async () => {
+    const knex = makeFakeKnex();
+    knex._q.merge.mockRejectedValueOnce(new Error('disk full'));
+    const events = [makeValidEvent(), makeValidEvent({ eventId: 'evt_002' })];
+    const result = await bulkIndexerEvents({ events, dbClient: knex });
+
+    expect(result.meta.succeeded).toBe(1);
+    expect(result.meta.failed).toBe(1);
+    expect(result.data[0].success).toBe(false);
+    expect(result.data[0].error.code).toBe('PERSIST_ERROR');
+    expect(result.data[1].success).toBe(true);
+  });
+
+  test('normalizes field names from camelCase to snake_case on insert', async () => {
+    const knex = makeFakeKnex();
+    await bulkIndexerEvents({ events: [makeValidEvent()], dbClient: knex });
+
+    const inserted = knex.inserted[0];
+    expect(inserted.event_id).toBe('evt_001');
+    expect(inserted.invoice_id).toBe('INV-100');
+    expect(inserted.event_type).toBe('escrow_created');
+    expect(inserted.ledger_sequence).toBe(100);
+  });
+
+  test('applies defaults for optional fields', async () => {
+    const knex = makeFakeKnex();
+    await bulkIndexerEvents({ events: [makeValidEvent()], dbClient: knex });
+
+    const inserted = knex.inserted[0];
+    expect(inserted.paging_token).toBeNull();
+    expect(inserted.contract_id).toBeNull();
+    expect(inserted.tx_hash).toBeNull();
+    expect(inserted.observed_at).toBeTruthy();
+  });
+
+  test('preserves contractId and txHash when provided', async () => {
+    const knex = makeFakeKnex();
+    const event = makeValidEvent({
+      contractId: 'CDLZFC3SYJ27SBCC6BAKCY73WFXHBTE357R67CW567QX65ECUGN45RXI',
+      txHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    });
+    await bulkIndexerEvents({ events: [event], dbClient: knex });
+
+    const inserted = knex.inserted[0];
+    expect(inserted.contract_id).toBe('CDLZFC3SYJ27SBCC6BAKCY73WFXHBTE357R67CW567QX65ECUGN45RXI');
+    expect(inserted.tx_hash).toBe('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+  });
+
+  test('serializes eventBody as JSON string', async () => {
+    const knex = makeFakeKnex();
+    const event = makeValidEvent({ eventBody: { foo: 'bar' } });
+    await bulkIndexerEvents({ events: [event], dbClient: knex });
+
+    const inserted = knex.inserted[0];
+    expect(inserted.event_body).toBe('{"foo":"bar"}');
+  });
+
+  test('empty events array returns zero totals', async () => {
+    const knex = makeFakeKnex();
+    const result = await bulkIndexerEvents({ events: [], dbClient: knex });
+
+    expect(result.meta.total).toBe(0);
+    expect(result.meta.succeeded).toBe(0);
+    expect(result.meta.failed).toBe(0);
+    expect(result.data).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 3: Route integration tests (POST /api/admin/indexer/events/bulk)
+// Uses supertest with a top-level jest.mock on the db so no real DB is hit.
+// ─────────────────────────────────────────────────────────────────────────────
+
+jest.mock('../src/db/knex', () => {
+  const q = {
+    insert: jest.fn().mockReturnThis(),
+    onConflict: jest.fn().mockReturnThis(),
+    merge: jest.fn().mockResolvedValue(undefined),
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    count: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue({ total: 0, 'count(*)': 0 }),
+    then: jest.fn(function (resolve) {
+      return Promise.resolve([]).then(resolve);
+    }),
+  };
+  const mockDb = jest.fn(() => q);
+  mockDb._q = q;
+  return mockDb;
+});
+
+describe('POST /api/admin/indexer/events/bulk route', () => {
+  const request = require('supertest');
+  const jwt = require('jsonwebtoken');
+  const { createApp } = require('../src/app');
+  const db = require('../src/db/knex');
+
+  const SECRET = process.env.JWT_SECRET;
+  const ISS = process.env.JWT_ISSUER || 'liquifact';
+  const AUD = process.env.JWT_AUDIENCE || 'liquifact-api';
+
+  function makeAdminToken(tenantId = 'tenant-test') {
+    return jwt.sign(
+      { sub: 'admin-user', tenantId, role: 'admin' },
+      SECRET,
+      { algorithm: 'HS256', issuer: ISS, audience: AUD },
+    );
+  }
+
+  let app;
+  let mockQ;
+  const adminToken = makeAdminToken();
+
+  beforeAll(() => {
+    app = createApp();
+    mockQ = db._q;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQ.insert.mockReturnThis();
+    mockQ.onConflict.mockReturnThis();
+    mockQ.merge.mockResolvedValue(undefined);
+  });
+
+  test('401 when no Authorization header', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .send([makeValidEvent()]);
+    expect(res.status).toBe(401);
+  });
+
+  test('401 for invalid Bearer token', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', 'Bearer not.a.valid.jwt')
+      .send([makeValidEvent()]);
+    expect(res.status).toBe(401);
+  });
+
+  test('400 when body is not an array', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send({ not: 'array' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/array/i);
+  });
+
+  test('400 when body is an empty array', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send([]);
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/at least one/i);
+  });
+
+  test('413 when batch exceeds max size (50)', async () => {
+    const oversized = Array.from({ length: 51 }, (_, i) => makeValidEvent({ eventId: `evt_${i}` }));
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send(oversized);
+    expect(res.status).toBe(413);
+    expect(res.body.error.code).toBe('BATCH_TOO_LARGE');
+  });
+
+  test('400 when array contains a non-object item', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send([makeValidEvent(), 'bad-item']);
+    expect(res.status).toBe(400);
+  });
+
+  test('200 with all items valid', async () => {
+    const events = [
+      makeValidEvent({ eventId: 'evt_1' }),
+      makeValidEvent({ eventId: 'evt_2' }),
+    ];
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send(events);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data.every((r) => r.success === true)).toBe(true);
+    expect(res.body.meta.succeeded).toBe(2);
+    expect(res.body.meta.failed).toBe(0);
+    expect(res.body.meta.total).toBe(2);
+    expect(res.body.message).toBe('Bulk indexer events processed.');
+  });
+
+  test('200 with single valid event', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send([makeValidEvent()]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].success).toBe(true);
+  });
+
+  test('207 when some items fail validation', async () => {
+    const events = [
+      makeValidEvent({ eventId: 'evt_ok' }),
+      { invoiceId: 'INV-BAD', eventType: 'x', ledgerSequence: 1 },
+    ];
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send(events);
+
+    expect(res.status).toBe(207);
+    expect(res.body.meta.succeeded).toBe(1);
+    expect(res.body.meta.failed).toBe(1);
+    expect(res.body.data[0].success).toBe(true);
+    expect(res.body.data[1].success).toBe(false);
+  });
+
+  test('207 when DB write fails for some items', async () => {
+    mockQ.merge.mockRejectedValueOnce(new Error('constraint violation'));
+
+    const events = [
+      makeValidEvent({ eventId: 'evt_ok' }),
+      makeValidEvent({ eventId: 'evt_db_fail' }),
+    ];
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send(events);
+
+    expect(res.status).toBe(207);
+    expect(res.body.meta.succeeded).toBe(1);
+    expect(res.body.meta.failed).toBe(1);
+    expect(res.body.data[0].success).toBe(false);
+    expect(res.body.data[0].error.code).toBe('PERSIST_ERROR');
+    expect(res.body.data[1].success).toBe(true);
+  });
+
+  test('207 when all items fail validation', async () => {
+    const events = [
+      { not: 'valid' },
+      { also: 'invalid' },
+    ];
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send(events);
+
+    expect(res.status).toBe(207);
+    expect(res.body.meta.succeeded).toBe(0);
+    expect(res.body.meta.failed).toBe(2);
+  });
+
+  test('response includes data, meta, error, and message fields', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send([makeValidEvent()]);
+
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).toHaveProperty('meta');
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).toHaveProperty('message');
+    expect(res.body.error).toBeNull();
+  });
+
+  test('per-item result includes index, success, and eventId', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send([makeValidEvent({ eventId: 'evt_shape' })]);
+
+    const item = res.body.data[0];
+    expect(item).toHaveProperty('index', 0);
+    expect(item).toHaveProperty('success', true);
+    expect(item).toHaveProperty('eventId', 'evt_shape');
+  });
+
+  test('per-item error result includes index, success, and error', async () => {
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send([{ bad: true }]);
+
+    const item = res.body.data[0];
+    expect(item).toHaveProperty('index', 0);
+    expect(item).toHaveProperty('success', false);
+    expect(item).toHaveProperty('error');
+    expect(item.error).toHaveProperty('code');
+  });
+
+  test('200 with exactly 50 events (at cap)', async () => {
+    const atCap = Array.from({ length: 50 }, (_, i) => makeValidEvent({ eventId: `evt_${i}` }));
+    const res = await request(app)
+      .post('/api/admin/indexer/events/bulk')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .set('x-tenant-id', 'tenant-test')
+      .send(atCap);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(50);
+    expect(res.body.meta.succeeded).toBe(50);
+  });
+});

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -284,6 +284,7 @@ jest.mock('../../src/middleware/rateLimit', () => {
     sensitiveLimiter: noopMiddleware,
     apiKeyLimiter: noopMiddleware,
     adminConfigLimiter: noopMiddleware,
+    metricsLimiter: noopMiddleware,
     healthLimiter: noopMiddleware,
     createConfigRateLimiter: jest.fn(() => noopMiddleware),
     invoiceStateLimiter: noopMiddleware,


### PR DESCRIPTION


- Add POST /api/admin/indexer/events/bulk accepting a bounded array (max 50 items)
- Per-item validation with independent success/error reporting
- 207 Multi-Status on partial failure, 413 on over-cap
- Comprehensive tests: empty batch, over-cap, partial failure, DB errors, auth guard
- Fix pre-existing broken stubs in metrics.js, adminConfig.js duplicate import, and missing metricsLimiter in app.js

closes #822