### PR TITLE
refactor(metrics): add validation schemas for metrics request/response payloads

### DIFF
--- a/src/routes/sme/metrics.js
+++ b/src/routes/sme/metrics.js
@@ -2,7 +2,7 @@
  * @fileoverview SME Dashboard Metrics endpoints.
  *
  * Provides:
- *  - `GET /metrics`  — aggregated invoice counts for the authenticated user
+ *  - `GET /metrics`       — aggregated invoice counts for the authenticated user
  *  - `POST /metrics/bulk` — batch endpoint accepting an array of
  *    (tenantId, userId) pairs with per-item success/error results
  *
@@ -18,7 +18,15 @@ const { extractTenant } = require('../../middleware/tenant');
 const { CursorError } = require('../../utils/cursorPagination');
 const invoiceService = require('../../services/invoiceService');
 const { validateMetricsRequest } = require('../../utils/metricsValidation');
-const { validateBulkMetricsBody } = require('../../schemas/metrics');
+const {
+  validateBulkMetricsBody,
+  validateGetMetricsQuery,
+} = require('../../schemas/metrics');
+const {
+  toSmeMetricsResponse,
+  toSmeMetricsMeta,
+  toSmeMetricsApiResponse,
+} = require('../../dto/metrics');
 
 
 /**
@@ -116,57 +124,74 @@ const { validateBulkMetricsBody } = require('../../schemas/metrics');
  *                   type: string
  *                   format: date-time
  *       400:
- *         description: Bad Request - Missing tenant context or invalid cursor
+ *         description: Bad Request — missing tenant context, invalid cursor, or invalid query params
  *       401:
  *         description: Unauthorized
  */
-router.get('/metrics', authenticateToken, extractTenant, async (req, res, next) => {
-  try {
-    const ctx = validateMetricsRequest(req, res);
-    if (!ctx) { return; }
+router.get(
+  '/metrics',
+  authenticateToken,
+  extractTenant,
+  validateGetMetricsQuery,
+  async (req, res, next) => {
+    try {
+      const ctx = validateMetricsRequest(req, res);
+      if (!ctx) { return; }
 
-    const { userId, tenantId } = ctx;
+      const { userId, tenantId } = ctx;
 
-    const rawMetrics = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
-    const data = toSmeMetricsResponse(rawMetrics);
+      const rawMetrics = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
+      const data = toSmeMetricsResponse(rawMetrics);
 
-    const { cursor, limit } = req.query;
-    const usePagination = cursor !== undefined || limit !== undefined;
+      // Prefer schema-validated (and coerced) query values; fall back to raw
+      // query strings to preserve backward compatibility.
+      const validatedQuery = req.validatedQuery || {};
+      const cursor =
+        validatedQuery.cursor !== undefined
+          ? validatedQuery.cursor
+          : req.query.cursor;
+      const limit =
+        validatedQuery.limit !== undefined
+          ? String(validatedQuery.limit)
+          : req.query.limit;
 
-    if (!usePagination) {
+      const usePagination = cursor !== undefined || limit !== undefined;
+
+      if (!usePagination) {
+        const meta = toSmeMetricsMeta({
+          timestamp: new Date().toISOString(),
+          version: '0.1.0',
+        });
+        return res.json(toSmeMetricsApiResponse(data, meta));
+      }
+
+      let result;
+      try {
+        result = await invoiceService.getSmeInvoiceList(tenantId, userId, { cursor, limit });
+      } catch (err) {
+        if (err.name === 'CursorError' || err instanceof CursorError) {
+          return res.status(400).json({
+            error: { message: err.message },
+          });
+        }
+        throw err;
+      }
+
       const meta = toSmeMetricsMeta({
+        invoices: result.invoices,
+        total: result.meta.total,
+        limit: result.meta.limit,
+        hasMore: result.meta.hasMore,
+        nextCursor: result.meta.nextCursor,
         timestamp: new Date().toISOString(),
-        version: '0.1.0'
+        version: '0.1.0',
       });
       return res.json(toSmeMetricsApiResponse(data, meta));
-    }
-
-    let result;
-    try {
-      result = await invoiceService.getSmeInvoiceList(tenantId, userId, { cursor, limit });
     } catch (err) {
-      if (err.name === 'CursorError' || err instanceof CursorError) {
-        return res.status(400).json({
-          error: { message: err.message },
-        });
-      }
-      throw err;
+      return next(err);
     }
-
-    const meta = toSmeMetricsMeta({
-      invoices: result.invoices,
-      total: result.meta.total,
-      limit: result.meta.limit,
-      hasMore: result.meta.hasMore,
-      nextCursor: result.meta.nextCursor,
-      timestamp: new Date().toISOString(),
-      version: '0.1.0'
-    });
-    return res.json(toSmeMetricsApiResponse(data, meta));
-  } catch (err) {
-    return next(err);
   }
-});
+);
 
 /**
  * @swagger
@@ -250,69 +275,76 @@ router.get('/metrics', authenticateToken, extractTenant, async (req, res, next) 
  *       401:
  *         description: Unauthorized
  */
-router.post('/metrics/bulk', authenticateToken, extractTenant, express.json({ limit: '100kb' }), validateBulkMetricsBody, async (req, res, next) => {
-  try {
-    const callerCtx = validateMetricsRequest(req, res);
-    if (!callerCtx) {
-      return;
-    }
-
-    const { tenantId: callerTenantId } = callerCtx;
-    const { operations } = req.validated;
-
-    const results = [];
-    let succeeded = 0;
-    let failed = 0;
-
-    for (const op of operations) {
-      const { tenantId, userId } = op;
-
-      if (tenantId !== callerTenantId) {
-        results.push({
-          tenantId,
-          userId,
-          status: 'error',
-          data: null,
-          error: 'Cross-tenant access denied',
-        });
-        failed++;
-        continue;
+router.post(
+  '/metrics/bulk',
+  authenticateToken,
+  extractTenant,
+  express.json({ limit: '100kb' }),
+  validateBulkMetricsBody,
+  async (req, res, next) => {
+    try {
+      const callerCtx = validateMetricsRequest(req, res);
+      if (!callerCtx) {
+        return;
       }
 
-      try {
-        const data = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
-        results.push({
-          tenantId,
-          userId,
-          status: 'success',
-          data,
-          error: null,
-        });
-        succeeded++;
-      } catch (err) {
-        results.push({
-          tenantId,
-          userId,
-          status: 'error',
-          data: null,
-          error: err.message || 'Internal error',
-        });
-        failed++;
-      }
-    }
+      const { tenantId: callerTenantId } = callerCtx;
+      const { operations } = req.validated;
 
-    return res.json({
-      results,
-      meta: {
-        total: operations.length,
-        succeeded,
-        failed,
-        timestamp: new Date().toISOString(),
-      },
-    });
-  } catch (err) {
-    return next(err);
+      const results = [];
+      let succeeded = 0;
+      let failed = 0;
+
+      for (const op of operations) {
+        const { tenantId, userId } = op;
+
+        if (tenantId !== callerTenantId) {
+          results.push({
+            tenantId,
+            userId,
+            status: 'error',
+            data: null,
+            error: 'Cross-tenant access denied',
+          });
+          failed++;
+          continue;
+        }
+
+        try {
+          const data = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
+          results.push({
+            tenantId,
+            userId,
+            status: 'success',
+            data,
+            error: null,
+          });
+          succeeded++;
+        } catch (err) {
+          results.push({
+            tenantId,
+            userId,
+            status: 'error',
+            data: null,
+            error: err.message || 'Internal error',
+          });
+          failed++;
+        }
+      }
+
+      return res.json({
+        results,
+        meta: {
+          total: operations.length,
+          succeeded,
+          failed,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
   }
-});
+);
 
 module.exports = router;

--- a/src/schemas/metrics.js
+++ b/src/schemas/metrics.js
@@ -1,71 +1,223 @@
 'use strict';
 
 /**
- * @fileoverview Zod schemas for the SME metrics bulk endpoint.
+ * @fileoverview Zod schemas for the SME metrics endpoints.
  *
- * Exposes:
- *  - `bulkMetricsSchema` — strict body schema (rejects unknown keys)
- *  - `validateBulkMetricsBody` — Express middleware for body validation
+ * Exposes declarative request/response schemas for every metrics route so
+ * that validation is centralised, testable in isolation, and enforced at
+ * the route boundary rather than scattered across handler code.
+ *
+ * ## Request schemas
+ * - `getMetricsQuerySchema`      — query-param schema for `GET /api/sme/metrics`
+ * - `bulkMetricsSchema`          — body schema for `POST /api/sme/metrics/bulk`
+ * - `bulkMetricsOperationSchema` — per-item schema used inside `bulkMetricsSchema`
+ *
+ * ## Response schemas
+ * - `smeMetricsDataSchema`        — aggregated invoice-count shape
+ * - `smeMetricsMetaBaseSchema`    — mandatory meta fields
+ * - `smeMetricsMetaSchema`        — full meta including optional pagination fields
+ * - `smeMetricsApiResponseSchema` — top-level API response envelope
+ * - `bulkMetricsResultItemSchema` — per-item shape inside the bulk response
+ * - `bulkMetricsResponseSchema`   — full bulk response envelope
+ *
+ * ## Middleware
+ * - `validateGetMetricsQuery` — Express middleware for GET query validation
+ * - `validateBulkMetricsBody` — Express middleware for POST bulk body validation
+ *
+ * ## Response helpers (for tests / contract checks)
+ * - `validateSmeMetricsApiResponse` — validate a GET response against the schema
+ * - `validateBulkMetricsResponse`   — validate a bulk response against the schema
  *
  * @module schemas/metrics
  */
 
 const { z } = require('zod');
+const { createQueryValidator } = require('./validationHelper');
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
 /** Maximum number of operations allowed in a single bulk request. */
 const MAX_BULK_OPERATIONS = 25;
 
-// ── Schemas ──────────────────────────────────────────────────────────────────
+/** Minimum allowed `limit` query param for paginated GET requests. */
+const GET_METRICS_LIMIT_MIN = 1;
+
+/** Maximum allowed `limit` query param for paginated GET requests. */
+const GET_METRICS_LIMIT_MAX = 100;
+
+// ── Request schemas ──────────────────────────────────────────────────────────
+
+/**
+ * Query-parameter schema for `GET /api/sme/metrics`.
+ *
+ * Both `cursor` and `limit` are optional.
+ *  - `cursor` — opaque pagination cursor; non-empty when present.
+ *  - `limit`  — coerced from raw query string to an integer clamped 1–100.
+ *               Non-numeric or absent values yield `undefined` (no error).
+ *
+ * Unknown query parameters are stripped via `.strip()`.
+ *
+ * @type {z.ZodObject}
+ */
+const getMetricsQuerySchema = z
+  .object({
+    cursor: z
+      .string()
+      .trim()
+      .min(1, { message: 'cursor must not be empty when provided' })
+      .optional(),
+    limit: z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (val === undefined) { return undefined; }
+        const parsed = parseInt(val, 10);
+        if (isNaN(parsed)) { return undefined; }
+        return Math.min(Math.max(parsed, GET_METRICS_LIMIT_MIN), GET_METRICS_LIMIT_MAX);
+      })
+      .pipe(
+        z
+          .number()
+          .int()
+          .min(GET_METRICS_LIMIT_MIN)
+          .max(GET_METRICS_LIMIT_MAX)
+          .optional()
+      ),
+  })
+  .strip();
 
 /**
  * Single operation within a bulk metrics request.
- * Each operation specifies a (tenantId, userId) pair to query invoice counts for.
  *
  * @type {z.ZodObject<{tenantId: z.ZodString, userId: z.ZodString}>}
  */
-const bulkMetricsOperationSchema = z.object({
-  tenantId: z
-    .string({ message: 'tenantId is required' })
-    .trim()
-    .min(1, { message: 'tenantId must not be empty' })
-    .max(128, { message: 'tenantId must not exceed 128 characters' }),
-  userId: z
-    .string({ message: 'userId is required' })
-    .trim()
-    .min(1, { message: 'userId must not be empty' })
-    .max(128, { message: 'userId must not exceed 128 characters' }),
-}).strict();
+const bulkMetricsOperationSchema = z
+  .object({
+    tenantId: z
+      .string({ message: 'tenantId is required' })
+      .trim()
+      .min(1, { message: 'tenantId must not be empty' })
+      .max(128, { message: 'tenantId must not exceed 128 characters' }),
+    userId: z
+      .string({ message: 'userId is required' })
+      .trim()
+      .min(1, { message: 'userId must not be empty' })
+      .max(128, { message: 'userId must not exceed 128 characters' }),
+  })
+  .strict();
 
 /**
  * Bulk metrics request body schema.
  *
- * Accepts an `operations` array of {@link bulkMetricsOperationSchema} items.
- * Enforces:
- *  - `operations` must be a non-empty array.
- *  - Maximum of {@link MAX_BULK_OPERATIONS} items.
- *  - Each item is validated individually.
- *  - Unknown top-level or per-item keys are rejected.
- *
  * @type {z.ZodObject<{operations: z.ZodArray}>}
  */
-const bulkMetricsSchema = z.object({
-  operations: z
-    .array(bulkMetricsOperationSchema, {
-      message: `operations must be a non-empty array with at most ${MAX_BULK_OPERATIONS} items`,
-    })
-    .min(1, { message: 'operations must contain at least one item' })
-    .max(MAX_BULK_OPERATIONS, {
-      message: `operations must not exceed ${MAX_BULK_OPERATIONS} items`,
-    }),
-}).strict();
+const bulkMetricsSchema = z
+  .object({
+    operations: z
+      .array(bulkMetricsOperationSchema, {
+        message: `operations must be a non-empty array with at most ${MAX_BULK_OPERATIONS} items`,
+      })
+      .min(1, { message: 'operations must contain at least one item' })
+      .max(MAX_BULK_OPERATIONS, {
+        message: `operations must not exceed ${MAX_BULK_OPERATIONS} items`,
+      }),
+  })
+  .strict();
+
+// ── Response schemas ─────────────────────────────────────────────────────────
+
+/**
+ * Schema for the aggregated invoice-count block.
+ * All four counts are non-negative integers.
+ *
+ * @type {z.ZodObject}
+ */
+const smeMetricsDataSchema = z.object({
+  open: z.number().int().min(0, { message: 'open must be a non-negative integer' }),
+  funded: z.number().int().min(0, { message: 'funded must be a non-negative integer' }),
+  settled: z.number().int().min(0, { message: 'settled must be a non-negative integer' }),
+  defaulted: z.number().int().min(0, { message: 'defaulted must be a non-negative integer' }),
+});
+
+/**
+ * Mandatory meta fields always present in a metrics response.
+ *
+ * @type {z.ZodObject}
+ */
+const smeMetricsMetaBaseSchema = z.object({
+  timestamp: z
+    .string()
+    .datetime({ message: 'meta.timestamp must be an ISO-8601 datetime string' }),
+  version: z.string().min(1, { message: 'meta.version must not be empty' }),
+});
+
+/**
+ * Full meta schema including optional pagination fields.
+ *
+ * @type {z.ZodObject}
+ */
+const smeMetricsMetaSchema = smeMetricsMetaBaseSchema.extend({
+  invoices: z.array(z.record(z.unknown())).optional(),
+  total: z.number().int().min(0).optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  hasMore: z.boolean().optional(),
+  nextCursor: z.string().nullable().optional(),
+});
+
+/**
+ * Top-level API response envelope for `GET /api/sme/metrics`.
+ *
+ * @type {z.ZodObject}
+ */
+const smeMetricsApiResponseSchema = z.object({
+  data: smeMetricsDataSchema,
+  meta: smeMetricsMetaSchema,
+  error: z.record(z.unknown()).nullable(),
+  timestamp: z
+    .string()
+    .datetime({ message: 'response timestamp must be an ISO-8601 datetime string' }),
+});
+
+/**
+ * Schema for a single result item inside the bulk metrics response.
+ *
+ * @type {z.ZodObject}
+ */
+const bulkMetricsResultItemSchema = z.object({
+  tenantId: z.string(),
+  userId: z.string(),
+  status: z.enum(['success', 'error']),
+  data: smeMetricsDataSchema.nullable(),
+  error: z.string().nullable(),
+});
+
+/**
+ * Full response envelope for `POST /api/sme/metrics/bulk`.
+ *
+ * @type {z.ZodObject}
+ */
+const bulkMetricsResponseSchema = z.object({
+  results: z.array(bulkMetricsResultItemSchema),
+  meta: z.object({
+    total: z.number().int().min(0),
+    succeeded: z.number().int().min(0),
+    failed: z.number().int().min(0),
+    timestamp: z
+      .string()
+      .datetime({ message: 'meta.timestamp must be an ISO-8601 datetime string' }),
+  }),
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
  * Parses a Zod ZodError into a field-keyed error object.
  *
- * @param {z.ZodError} zodError - The Zod validation error.
- * @returns {Object<string, string[]>} Field path → list of error messages.
+ * Returns `{ [fieldPath]: string[] }` for backward compatibility with the
+ * existing bulk-body middleware contract that tests exercise.
+ *
+ * @param {z.ZodError} zodError
+ * @returns {Object<string, string[]>}
  */
 function parseValidationErrors(zodError) {
   const fieldErrors = {};
@@ -79,15 +231,30 @@ function parseValidationErrors(zodError) {
   return fieldErrors;
 }
 
+// ── Middleware ───────────────────────────────────────────────────────────────
+
 /**
- * Express middleware that validates `req.body` against {@link bulkMetricsSchema}.
+ * Express middleware that validates `req.query` for `GET /api/sme/metrics`.
  *
- * On success, attaches the parsed (and transformed) value to `req.validated`.
+ * On success, attaches parsed/coerced value to `req.validatedQuery`.
  * On failure, returns a 400 RFC 7807 Problem Details response.
  *
- * @param {import('express').Request} req - Express request object.
- * @param {import('express').Response} res - Express response object.
- * @param {import('express').NextFunction} next - Express next callback.
+ * @type {import('express').RequestHandler}
+ */
+const validateGetMetricsQuery = createQueryValidator(getMetricsQuerySchema, {
+  title: 'Invalid Query Parameters',
+  detail: 'One or more query parameters are invalid.',
+});
+
+/**
+ * Express middleware that validates `req.body` against `bulkMetricsSchema`.
+ *
+ * On success, attaches parsed value to `req.validated`.
+ * On failure, returns a 400 RFC 7807 Problem Details response.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
  * @returns {void}
  */
 function validateBulkMetricsBody(req, res, next) {
@@ -108,10 +275,55 @@ function validateBulkMetricsBody(req, res, next) {
   });
 }
 
+// ── Response validation helpers ───────────────────────────────────────────────
+
+/**
+ * Validates an SME metrics API response against the declared schema.
+ *
+ * @param {unknown} value
+ * @returns {{ success: true, data: object } | { success: false, error: z.ZodError }}
+ */
+function validateSmeMetricsApiResponse(value) {
+  return smeMetricsApiResponseSchema.safeParse(value);
+}
+
+/**
+ * Validates a bulk metrics response against the declared schema.
+ *
+ * @param {unknown} value
+ * @returns {{ success: true, data: object } | { success: false, error: z.ZodError }}
+ */
+function validateBulkMetricsResponse(value) {
+  return bulkMetricsResponseSchema.safeParse(value);
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
 module.exports = {
+  // Request schemas
+  getMetricsQuerySchema,
   bulkMetricsSchema,
   bulkMetricsOperationSchema,
+
+  // Response schemas
+  smeMetricsDataSchema,
+  smeMetricsMetaBaseSchema,
+  smeMetricsMetaSchema,
+  smeMetricsApiResponseSchema,
+  bulkMetricsResultItemSchema,
+  bulkMetricsResponseSchema,
+
+  // Middleware
+  validateGetMetricsQuery,
   validateBulkMetricsBody,
+
+  // Response validation helpers
+  validateSmeMetricsApiResponse,
+  validateBulkMetricsResponse,
+
+  // Utilities / constants
   parseValidationErrors,
   MAX_BULK_OPERATIONS,
+  GET_METRICS_LIMIT_MIN,
+  GET_METRICS_LIMIT_MAX,
 };

--- a/tests/unit/metrics.schema.test.js
+++ b/tests/unit/metrics.schema.test.js
@@ -1,0 +1,892 @@
+'use strict';
+
+/**
+ * @fileoverview Comprehensive unit tests for src/schemas/metrics.js
+ *
+ * Covers:
+ *  - getMetricsQuerySchema — query param validation for GET /api/sme/metrics
+ *  - bulkMetricsOperationSchema — per-item bulk request validation
+ *  - bulkMetricsSchema — full bulk request body validation
+ *  - Response schemas: smeMetricsDataSchema, smeMetricsMetaSchema,
+ *    smeMetricsApiResponseSchema, bulkMetricsResponseSchema
+ *  - validateGetMetricsQuery middleware
+ *  - validateBulkMetricsBody middleware
+ *  - validateSmeMetricsApiResponse / validateBulkMetricsResponse helpers
+ *  - Constants: MAX_BULK_OPERATIONS, GET_METRICS_LIMIT_MIN, GET_METRICS_LIMIT_MAX
+ */
+
+const {
+  getMetricsQuerySchema,
+  bulkMetricsOperationSchema,
+  bulkMetricsSchema,
+  smeMetricsDataSchema,
+  smeMetricsMetaBaseSchema,
+  smeMetricsMetaSchema,
+  smeMetricsApiResponseSchema,
+  bulkMetricsResultItemSchema,
+  bulkMetricsResponseSchema,
+  validateGetMetricsQuery,
+  validateBulkMetricsBody,
+  validateSmeMetricsApiResponse,
+  validateBulkMetricsResponse,
+  parseValidationErrors,
+  MAX_BULK_OPERATIONS,
+  GET_METRICS_LIMIT_MIN,
+  GET_METRICS_LIMIT_MAX,
+} = require('../../src/schemas/metrics');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRes() {
+  const res = {
+    _statusCode: null,
+    _body: undefined,
+    status: jest.fn(function (code) { this._statusCode = code; return this; }),
+    json: jest.fn(function (body) { this._body = body; return this; }),
+  };
+  return res;
+}
+
+function makeNext() {
+  return jest.fn();
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('MAX_BULK_OPERATIONS is 25', () => {
+    expect(MAX_BULK_OPERATIONS).toBe(25);
+  });
+
+  it('GET_METRICS_LIMIT_MIN is 1', () => {
+    expect(GET_METRICS_LIMIT_MIN).toBe(1);
+  });
+
+  it('GET_METRICS_LIMIT_MAX is 100', () => {
+    expect(GET_METRICS_LIMIT_MAX).toBe(100);
+  });
+});
+
+// ── getMetricsQuerySchema ─────────────────────────────────────────────────────
+
+describe('getMetricsQuerySchema', () => {
+  describe('valid inputs', () => {
+    it('parses empty query object successfully', () => {
+      const result = getMetricsQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({});
+    });
+
+    it('parses cursor-only query', () => {
+      const result = getMetricsQuerySchema.safeParse({ cursor: 'abc123' });
+      expect(result.success).toBe(true);
+      expect(result.data.cursor).toBe('abc123');
+    });
+
+    it('parses limit-only query and coerces to integer', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '10' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(10);
+    });
+
+    it('parses both cursor and limit together', () => {
+      const result = getMetricsQuerySchema.safeParse({ cursor: 'tok', limit: '5' });
+      expect(result.success).toBe(true);
+      expect(result.data.cursor).toBe('tok');
+      expect(result.data.limit).toBe(5);
+    });
+
+    it('trims whitespace from cursor', () => {
+      const result = getMetricsQuerySchema.safeParse({ cursor: '  abc  ' });
+      expect(result.success).toBe(true);
+      expect(result.data.cursor).toBe('abc');
+    });
+  });
+
+  describe('limit clamping and coercion', () => {
+    it('clamps limit above max to 100', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '999' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(100);
+    });
+
+    it('clamps limit below min to 1', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '-5' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(1);
+    });
+
+    it('treats non-numeric limit as undefined (no error)', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: 'abc' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBeUndefined();
+    });
+
+    it('treats limit=0 as 1 after clamping (max(parsed, 1))', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '0' });
+      expect(result.success).toBe(true);
+      // 0 parsed => Math.max(0, 1) = 1
+      expect(result.data.limit).toBe(1);
+    });
+
+    it('accepts limit at boundary value 1', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '1' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(1);
+    });
+
+    it('accepts limit at boundary value 100', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '100' });
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBe(100);
+    });
+
+    it('omits limit when not provided', () => {
+      const result = getMetricsQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      expect(result.data.limit).toBeUndefined();
+    });
+  });
+
+  describe('cursor validation', () => {
+    it('rejects empty string cursor', () => {
+      const result = getMetricsQuerySchema.safeParse({ cursor: '' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects whitespace-only cursor (trimmed to empty)', () => {
+      const result = getMetricsQuerySchema.safeParse({ cursor: '   ' });
+      expect(result.success).toBe(false);
+    });
+
+    it('omits cursor when not provided', () => {
+      const result = getMetricsQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      expect(result.data.cursor).toBeUndefined();
+    });
+  });
+
+  describe('unknown param stripping', () => {
+    it('strips unknown query parameters without error', () => {
+      const result = getMetricsQuerySchema.safeParse({ limit: '5', sortBy: 'date', page: '2' });
+      expect(result.success).toBe(true);
+      expect(result.data.sortBy).toBeUndefined();
+      expect(result.data.page).toBeUndefined();
+      expect(result.data.limit).toBe(5);
+    });
+  });
+});
+
+// ── bulkMetricsOperationSchema ────────────────────────────────────────────────
+
+describe('bulkMetricsOperationSchema', () => {
+  describe('valid inputs', () => {
+    it('accepts valid {tenantId, userId}', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: 't1', userId: 'u1' });
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ tenantId: 't1', userId: 'u1' });
+    });
+
+    it('trims whitespace from tenantId and userId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: '  t1  ', userId: '  u1  ' });
+      expect(result.success).toBe(true);
+      expect(result.data.tenantId).toBe('t1');
+      expect(result.data.userId).toBe('u1');
+    });
+
+    it('accepts 128-character tenantId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({
+        tenantId: 'a'.repeat(128),
+        userId: 'u1',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts 128-character userId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({
+        tenantId: 't1',
+        userId: 'b'.repeat(128),
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('rejects missing tenantId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ userId: 'u1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing userId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: 't1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty tenantId string', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: '', userId: 'u1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects whitespace-only tenantId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: '   ', userId: 'u1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty userId string', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: 't1', userId: '' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects tenantId exceeding 128 characters', () => {
+      const result = bulkMetricsOperationSchema.safeParse({
+        tenantId: 'a'.repeat(129),
+        userId: 'u1',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects userId exceeding 128 characters', () => {
+      const result = bulkMetricsOperationSchema.safeParse({
+        tenantId: 't1',
+        userId: 'b'.repeat(129),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown keys (strict mode)', () => {
+      const result = bulkMetricsOperationSchema.safeParse({
+        tenantId: 't1',
+        userId: 'u1',
+        extra: 'field',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-string tenantId', () => {
+      const result = bulkMetricsOperationSchema.safeParse({ tenantId: 123, userId: 'u1' });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// ── bulkMetricsSchema ─────────────────────────────────────────────────────────
+
+describe('bulkMetricsSchema', () => {
+  const validOp = { tenantId: 't1', userId: 'u1' };
+
+  describe('valid inputs', () => {
+    it('accepts a single-operation array', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: [validOp] });
+      expect(result.success).toBe(true);
+      expect(result.data.operations).toHaveLength(1);
+    });
+
+    it('accepts exactly 25 operations (the cap)', () => {
+      const ops = Array.from({ length: 25 }, (_, i) => ({ tenantId: 't1', userId: `u${i}` }));
+      const result = bulkMetricsSchema.safeParse({ operations: ops });
+      expect(result.success).toBe(true);
+      expect(result.data.operations).toHaveLength(25);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('rejects empty operations array', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: [] });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects operations exceeding 25 items', () => {
+      const ops = Array.from({ length: 26 }, (_, i) => ({ tenantId: 't1', userId: `u${i}` }));
+      const result = bulkMetricsSchema.safeParse({ operations: ops });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing operations field', () => {
+      const result = bulkMetricsSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects operations as a string', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: 'not-an-array' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects operations as null', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: null });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown top-level keys', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: [validOp], extra: true });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an operation with unknown keys inside (strict per-item)', () => {
+      const result = bulkMetricsSchema.safeParse({
+        operations: [{ tenantId: 't1', userId: 'u1', rogue: true }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an operation missing tenantId', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: [{ userId: 'u1' }] });
+      expect(result.success).toBe(false);
+    });
+
+    it('propagates fieldError paths for nested operation failures', () => {
+      const result = bulkMetricsSchema.safeParse({ operations: [{ userId: 'u1' }] });
+      expect(result.success).toBe(false);
+      // There should be an issue path referencing operations[0].tenantId
+      const paths = result.error.issues.map((i) => i.path.join('.'));
+      expect(paths.some((p) => p.includes('operations'))).toBe(true);
+    });
+  });
+});
+
+// ── smeMetricsDataSchema ──────────────────────────────────────────────────────
+
+describe('smeMetricsDataSchema', () => {
+  it('accepts valid counts', () => {
+    const result = smeMetricsDataSchema.safeParse({ open: 2, funded: 1, settled: 3, defaulted: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all-zero counts', () => {
+    const result = smeMetricsDataSchema.safeParse({ open: 0, funded: 0, settled: 0, defaulted: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative values', () => {
+    const result = smeMetricsDataSchema.safeParse({ open: -1, funded: 0, settled: 0, defaulted: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer floats', () => {
+    const result = smeMetricsDataSchema.safeParse({ open: 1.5, funded: 0, settled: 0, defaulted: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects string values', () => {
+    const result = smeMetricsDataSchema.safeParse({ open: '2', funded: 0, settled: 0, defaulted: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing fields', () => {
+    const result = smeMetricsDataSchema.safeParse({ open: 1, funded: 0, settled: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty object', () => {
+    const result = smeMetricsDataSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── smeMetricsMetaBaseSchema ──────────────────────────────────────────────────
+
+describe('smeMetricsMetaBaseSchema', () => {
+  it('accepts valid timestamp and version', () => {
+    const result = smeMetricsMetaBaseSchema.safeParse({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      version: '0.1.0',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing timestamp', () => {
+    const result = smeMetricsMetaBaseSchema.safeParse({ version: '0.1.0' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing version', () => {
+    const result = smeMetricsMetaBaseSchema.safeParse({ timestamp: '2026-01-01T00:00:00.000Z' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-ISO timestamp', () => {
+    const result = smeMetricsMetaBaseSchema.safeParse({ timestamp: 'not-a-date', version: '1.0' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty version', () => {
+    const result = smeMetricsMetaBaseSchema.safeParse({ timestamp: '2026-01-01T00:00:00.000Z', version: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── smeMetricsMetaSchema ──────────────────────────────────────────────────────
+
+describe('smeMetricsMetaSchema', () => {
+  const base = { timestamp: '2026-01-01T00:00:00.000Z', version: '0.1.0' };
+
+  it('accepts base-only meta (no pagination fields)', () => {
+    const result = smeMetricsMetaSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    expect(result.data.invoices).toBeUndefined();
+  });
+
+  it('accepts full paginated meta', () => {
+    const result = smeMetricsMetaSchema.safeParse({
+      ...base,
+      invoices: [{ id: '1' }],
+      total: 10,
+      limit: 5,
+      hasMore: true,
+      nextCursor: 'cur123',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.invoices).toHaveLength(1);
+    expect(result.data.total).toBe(10);
+    expect(result.data.limit).toBe(5);
+    expect(result.data.hasMore).toBe(true);
+    expect(result.data.nextCursor).toBe('cur123');
+  });
+
+  it('accepts nextCursor as null', () => {
+    const result = smeMetricsMetaSchema.safeParse({ ...base, nextCursor: null });
+    expect(result.success).toBe(true);
+    expect(result.data.nextCursor).toBeNull();
+  });
+
+  it('rejects negative total', () => {
+    const result = smeMetricsMetaSchema.safeParse({ ...base, total: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-boolean hasMore', () => {
+    const result = smeMetricsMetaSchema.safeParse({ ...base, hasMore: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects limit above 100', () => {
+    const result = smeMetricsMetaSchema.safeParse({ ...base, limit: 101 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── smeMetricsApiResponseSchema ───────────────────────────────────────────────
+
+describe('smeMetricsApiResponseSchema', () => {
+  const validResponse = {
+    data: { open: 1, funded: 0, settled: 2, defaulted: 0 },
+    meta: { timestamp: '2026-01-01T00:00:00.000Z', version: '0.1.0' },
+    error: null,
+    timestamp: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('accepts a valid response envelope', () => {
+    const result = smeMetricsApiResponseSchema.safeParse(validResponse);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts response with error object', () => {
+    const result = smeMetricsApiResponseSchema.safeParse({
+      ...validResponse,
+      error: { message: 'oops' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing data field', () => {
+    const { data: _d, ...rest } = validResponse;
+    const result = smeMetricsApiResponseSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing meta field', () => {
+    const { meta: _m, ...rest } = validResponse;
+    const result = smeMetricsApiResponseSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid top-level timestamp', () => {
+    const result = smeMetricsApiResponseSchema.safeParse({
+      ...validResponse,
+      timestamp: 'bad-date',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects data with invalid counts (negative)', () => {
+    const result = smeMetricsApiResponseSchema.safeParse({
+      ...validResponse,
+      data: { open: -1, funded: 0, settled: 0, defaulted: 0 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── bulkMetricsResponseSchema ─────────────────────────────────────────────────
+
+describe('bulkMetricsResponseSchema', () => {
+  const validBulkResponse = {
+    results: [
+      { tenantId: 't1', userId: 'u1', status: 'success', data: { open: 1, funded: 0, settled: 0, defaulted: 0 }, error: null },
+      { tenantId: 't1', userId: 'u2', status: 'error', data: null, error: 'some error' },
+    ],
+    meta: { total: 2, succeeded: 1, failed: 1, timestamp: '2026-01-01T00:00:00.000Z' },
+  };
+
+  it('accepts a valid bulk response', () => {
+    const result = bulkMetricsResponseSchema.safeParse(validBulkResponse);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty results array', () => {
+    const result = bulkMetricsResponseSchema.safeParse({
+      results: [],
+      meta: { total: 0, succeeded: 0, failed: 0, timestamp: '2026-01-01T00:00:00.000Z' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid status enum in result item', () => {
+    const result = bulkMetricsResponseSchema.safeParse({
+      ...validBulkResponse,
+      results: [{ ...validBulkResponse.results[0], status: 'pending' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing meta', () => {
+    const { meta: _m, ...rest } = validBulkResponse;
+    const result = bulkMetricsResponseSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative meta.total', () => {
+    const result = bulkMetricsResponseSchema.safeParse({
+      ...validBulkResponse,
+      meta: { ...validBulkResponse.meta, total: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-ISO meta.timestamp', () => {
+    const result = bulkMetricsResponseSchema.safeParse({
+      ...validBulkResponse,
+      meta: { ...validBulkResponse.meta, timestamp: 'not-a-date' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── validateSmeMetricsApiResponse helper ──────────────────────────────────────
+
+describe('validateSmeMetricsApiResponse', () => {
+  const validResponse = {
+    data: { open: 1, funded: 0, settled: 2, defaulted: 0 },
+    meta: { timestamp: '2026-01-01T00:00:00.000Z', version: '0.1.0' },
+    error: null,
+    timestamp: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('returns success:true for a valid response', () => {
+    const result = validateSmeMetricsApiResponse(validResponse);
+    expect(result.success).toBe(true);
+  });
+
+  it('returns success:false with ZodError for invalid response', () => {
+    const result = validateSmeMetricsApiResponse({ data: 'bad', meta: {}, error: null, timestamp: 't' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns success:false for null input', () => {
+    const result = validateSmeMetricsApiResponse(null);
+    expect(result.success).toBe(false);
+  });
+
+  it('returns success:false for missing required fields', () => {
+    const result = validateSmeMetricsApiResponse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── validateBulkMetricsResponse helper ───────────────────────────────────────
+
+describe('validateBulkMetricsResponse', () => {
+  const validBulkResponse = {
+    results: [
+      { tenantId: 't1', userId: 'u1', status: 'success', data: { open: 0, funded: 0, settled: 0, defaulted: 0 }, error: null },
+    ],
+    meta: { total: 1, succeeded: 1, failed: 0, timestamp: '2026-01-01T00:00:00.000Z' },
+  };
+
+  it('returns success:true for a valid bulk response', () => {
+    const result = validateBulkMetricsResponse(validBulkResponse);
+    expect(result.success).toBe(true);
+  });
+
+  it('returns success:false for invalid bulk response', () => {
+    const result = validateBulkMetricsResponse({ results: 'bad', meta: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it('returns success:false for null input', () => {
+    const result = validateBulkMetricsResponse(null);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── parseValidationErrors ─────────────────────────────────────────────────────
+
+describe('parseValidationErrors', () => {
+  it('returns empty object for no issues', () => {
+    const fakeError = { issues: [] };
+    expect(parseValidationErrors(fakeError)).toEqual({});
+  });
+
+  it('groups messages by field path', () => {
+    const fakeError = {
+      issues: [
+        { path: ['operations', '0', 'tenantId'], message: 'tenantId must not be empty' },
+        { path: ['operations', '0', 'tenantId'], message: 'Another error' },
+        { path: ['operations'], message: 'array error' },
+      ],
+    };
+    const result = parseValidationErrors(fakeError);
+    expect(result['operations.0.tenantId']).toContain('tenantId must not be empty');
+    expect(result['operations.0.tenantId']).toContain('Another error');
+    expect(result['operations']).toContain('array error');
+  });
+
+  it('handles top-level (empty path) issues', () => {
+    const fakeError = {
+      issues: [{ path: [], message: 'root error' }],
+    };
+    const result = parseValidationErrors(fakeError);
+    expect(result['']).toContain('root error');
+  });
+});
+
+// ── validateBulkMetricsBody middleware ────────────────────────────────────────
+
+describe('validateBulkMetricsBody middleware', () => {
+  it('calls next() and sets req.validated on valid body', () => {
+    const req = { body: { operations: [{ tenantId: 't1', userId: 'u1' }] } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(req.validated).toEqual({ operations: [{ tenantId: 't1', userId: 'u1' }] });
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('trims tenantId/userId in req.validated', () => {
+    const req = { body: { operations: [{ tenantId: '  t1  ', userId: '  u1  ' }] } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.validated.operations[0].tenantId).toBe('t1');
+    expect(req.validated.operations[0].userId).toBe('u1');
+  });
+
+  it('returns 400 with fieldErrors for empty operations array', () => {
+    const req = { body: { operations: [] } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+    expect(res._body.fieldErrors).toBeDefined();
+  });
+
+  it('returns 400 for missing operations field', () => {
+    const req = { body: {} };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+    expect(res._body.fieldErrors).toBeDefined();
+  });
+
+  it('returns 400 for over-cap array (26 items)', () => {
+    const ops = Array.from({ length: 26 }, (_, i) => ({ tenantId: 't1', userId: `u${i}` }));
+    const req = { body: { operations: ops } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+  });
+
+  it('returns 400 for unknown top-level key', () => {
+    const req = { body: { operations: [{ tenantId: 't1', userId: 'u1' }], rogue: true } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+  });
+
+  it('returns 400 for unknown per-item key', () => {
+    const req = { body: { operations: [{ tenantId: 't1', userId: 'u1', extra: 'x' }] } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+  });
+
+  it('error response has RFC 7807 shape', () => {
+    const req = { body: {} };
+    const res = makeRes();
+    validateBulkMetricsBody(req, res, makeNext());
+
+    expect(res._body.type).toBe('https://liquifact.io/problems/validation-error');
+    expect(res._body.title).toBe('Validation Error');
+    expect(res._body.status).toBe(400);
+    expect(res._body.detail).toBeDefined();
+    expect(res._body.fieldErrors).toBeDefined();
+  });
+
+  it('returns 400 for non-array operations', () => {
+    const req = { body: { operations: 'not-an-array' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateBulkMetricsBody(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+  });
+});
+
+// ── validateGetMetricsQuery middleware ────────────────────────────────────────
+
+describe('validateGetMetricsQuery middleware', () => {
+  it('calls next() and sets req.validatedQuery on valid empty query', () => {
+    const req = { query: {} };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(req.validatedQuery).toBeDefined();
+    expect(req.validatedQuery.cursor).toBeUndefined();
+    expect(req.validatedQuery.limit).toBeUndefined();
+  });
+
+  it('coerces limit string to integer in validatedQuery', () => {
+    const req = { query: { limit: '20' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.validatedQuery.limit).toBe(20);
+  });
+
+  it('passes cursor through in validatedQuery', () => {
+    const req = { query: { cursor: 'abc123' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.validatedQuery.cursor).toBe('abc123');
+  });
+
+  it('strips unknown query params from validatedQuery', () => {
+    const req = { query: { limit: '5', page: '2', sort: 'asc' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.validatedQuery.page).toBeUndefined();
+    expect(req.validatedQuery.sort).toBeUndefined();
+    expect(req.validatedQuery.limit).toBe(5);
+  });
+
+  it('returns 400 for empty cursor string', () => {
+    const req = { query: { cursor: '' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(400);
+    expect(res._body.fieldErrors).toBeDefined();
+  });
+
+  it('does not error for non-numeric limit (yields undefined)', () => {
+    const req = { query: { limit: 'abc' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    // non-numeric limit is coerced to undefined rather than erroring
+    expect(next).toHaveBeenCalled();
+    expect(req.validatedQuery.limit).toBeUndefined();
+  });
+
+  it('clamps oversized limit to 100 in validatedQuery', () => {
+    const req = { query: { limit: '999' } };
+    const res = makeRes();
+    const next = makeNext();
+
+    validateGetMetricsQuery(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.validatedQuery.limit).toBe(100);
+  });
+});
+
+// ── bulkMetricsResultItemSchema ───────────────────────────────────────────────
+
+describe('bulkMetricsResultItemSchema', () => {
+  it('accepts a success item', () => {
+    const result = bulkMetricsResultItemSchema.safeParse({
+      tenantId: 't1', userId: 'u1', status: 'success',
+      data: { open: 1, funded: 0, settled: 0, defaulted: 0 }, error: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an error item with null data', () => {
+    const result = bulkMetricsResultItemSchema.safeParse({
+      tenantId: 't1', userId: 'u1', status: 'error', data: null, error: 'boom',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown status value', () => {
+    const result = bulkMetricsResultItemSchema.safeParse({
+      tenantId: 't1', userId: 'u1', status: 'pending', data: null, error: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing status', () => {
+    const result = bulkMetricsResultItemSchema.safeParse({
+      tenantId: 't1', userId: 'u1', data: null, error: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #920

Introduces declarative Zod schemas for all metrics request/response payloads, enforced at the route boundary. Behaviour is otherwise unchanged.

### Changes

**`src/schemas/metrics.js`**
- `getMetricsQuerySchema` — validates GET /api/sme/metrics query params, coerces limit to clamped integer, strips unknown params
- `validateGetMetricsQuery` middleware (attaches clean values to req.validatedQuery)
- Response schemas: smeMetricsDataSchema, smeMetricsMetaBaseSchema, smeMetricsMetaSchema, smeMetricsApiResponseSchema, bulkMetricsResultItemSchema, bulkMetricsResponseSchema
- Response helpers: validateSmeMetricsApiResponse, validateBulkMetricsResponse
- Constants: GET_METRICS_LIMIT_MIN (1), GET_METRICS_LIMIT_MAX (100)

**`src/routes/sme/metrics.js`**
- Added missing DTO imports: toSmeMetricsResponse, toSmeMetricsMeta, toSmeMetricsApiResponse (were used but never imported)
- Added validateGetMetricsQuery middleware on GET /metrics
- Uses req.validatedQuery with raw-query fallback for backward compatibility

**`tests/unit/metrics.schema.test.js`** — 103 new tests covering all schemas, middleware, helpers, and constants.

### Test results

```
PASS tests/unit/metrics.schema.test.js
Tests: 103 passed, 103 total
```

Existing metrics tests (dto/metrics, metricsValidation): 101/101 pass. Pre-existing escrowRead.js parse error causes two unrelated integration suites to fail on main — not introduced by this PR.