### PR TITLE
refactor(kyc-webhooks): centralize error handling in shared middleware

### DIFF
--- a/src/errors/KycWebhookError.js
+++ b/src/errors/KycWebhookError.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * @fileoverview Structured error for KYC webhook handlers.
+ *
+ * Carries an HTTP status and a machine-readable error code through the
+ * Express error chain so that {@link module:middleware/kycWebhookErrorHandler}
+ * can produce a consistent structured response without per-handler
+ * duplication.
+ *
+ * @module errors/KycWebhookError
+ */
+
+/**
+ * Lightweight error class that pairs an HTTP status with an application
+ * error code for KYC webhook ingestion and listing endpoints.
+ */
+class KycWebhookError extends Error {
+  /**
+   * @param {string} message  - Human-readable error description.
+   * @param {number} status   - HTTP status code (400, 401, 403, 500, 503).
+   * @param {string} code     - Machine-readable error code (e.g. 'missing_secret').
+   */
+  constructor(message, status, code) {
+    super(message);
+    this.name = 'KycWebhookError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+module.exports = KycWebhookError;

--- a/src/middleware/kycWebhookErrorHandler.js
+++ b/src/middleware/kycWebhookErrorHandler.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * @fileoverview Shared error-handling middleware for KYC webhook routes.
+ *
+ * Intercepts {@link KycWebhookError} instances thrown by route handlers and
+ * produces a consistent structured error response envelope:
+ *
+ *   { error: { code, message, correlation_id, retryable, retry_hint } }
+ *
+ * Non-KycWebhookError values are forwarded to the next error handler in the
+ * Express chain.
+ *
+ * @module middleware/kycWebhookErrorHandler
+ */
+
+const KycWebhookError = require('../errors/KycWebhookError');
+const logger = require('../logger');
+
+/**
+ * HTTP status codes that are considered retryable.
+ * @type {Set<number>}
+ */
+const RETRYABLE_STATUSES = new Set([429, 503]);
+
+/**
+ * Error codes that are explicitly retryable regardless of status.
+ * @type {Set<string>}
+ */
+const RETRYABLE_CODES = new Set(['missing_secret', 'CIRCUIT_OPEN']);
+
+/**
+ * Maps a KycWebhookError to a retry hint string.
+ *
+ * @param {KycWebhookError} err - The intercepted error.
+ * @returns {string} Client-facing retry guidance.
+ */
+function resolveRetryHint(err) {
+  if (RETRYABLE_CODES.has(err.code)) {
+    return 'Retry the request in a few moments.';
+  }
+  if (err.status === 429) {
+    return 'Wait for the rate limit window to reset before retrying.';
+  }
+  if (err.status === 503) {
+    return 'Retry the request in a few moments.';
+  }
+  return '';
+}
+
+/**
+ * Express error-handling middleware for KYC webhook routes.
+ *
+ * Only handles {@link KycWebhookError} instances; all other errors are
+ * forwarded to the next error handler.
+ *
+ * @param {Error}   req  - Express request.
+ * @param {import('express').Request}   req  - Express request.
+ * @param {import('express').Response}  res  - Express response.
+ * @param {import('express').NextFunction} next - Next error handler.
+ * @returns {void}
+ */
+function kycWebhookErrorHandler(err, req, res, next) {
+  if (!(err instanceof KycWebhookError)) {
+    return next(err);
+  }
+
+  const correlationId = req.correlationId || req.id || 'unknown';
+  const retryable = RETRYABLE_CODES.has(err.code) || RETRYABLE_STATUSES.has(err.status);
+
+  logger.warn(
+    {
+      err: err.message,
+      code: err.code,
+      status: err.status,
+      correlationId,
+    },
+    'kyc-webhook error',
+  );
+
+  // Store the error code so the post-response metrics hook can read it.
+  req._kycErrorCode = err.code;
+
+  res.status(err.status).json({
+    error: {
+      code: err.code,
+      message: err.message,
+      correlation_id: correlationId,
+      retryable,
+      retry_hint: resolveRetryHint(err),
+    },
+  });
+}
+
+module.exports = kycWebhookErrorHandler;

--- a/src/routes/kyc.js
+++ b/src/routes/kyc.js
@@ -4,8 +4,12 @@ const express = require('express');
 const db = require('../db/knex');
 const kycService = require('../services/kycService');
 const logger = require('../logger');
-const responseHelper = require('../utils/responseHelper');
+const { verifySignature, parseJsonPayload } = require('../middleware/kycWebhookValidation');
+const { kycWebhookSchema, parseValidationErrors, kycWebhookListResponseSchema } = require('../schemas/kycWebhook');
 const { decodeCursor, encodeCursor, CursorError } = require('../utils/cursorPagination');
+const asyncHandler = require('../utils/asyncHandler');
+const KycWebhookError = require('../errors/KycWebhookError');
+const kycWebhookErrorHandler = require('../middleware/kycWebhookErrorHandler');
 const {
   kycWebhookRequestDurationSeconds,
   kycWebhookRequestsTotal,
@@ -48,7 +52,7 @@ const SORT_FIELD = KYC_WEBHOOK_PAGINATION.SORT_FIELD;
  * POST /api/kyc/webhook
  * Inbound KYC webhook ingestion endpoint.
  */
-router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
+router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, asyncHandler(async (req, res) => {
   const startTime = process.hrtime.bigint();
   let statusClass = KYC_WEBHOOK_METRICS.STATUS_CLASS_2XX;
   let cause = KYC_WEBHOOK_METRICS.CAUSE_NONE;
@@ -64,6 +68,10 @@ router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
     }
   };
 
+  res.on('finish', () => {
+    finish(res.statusCode, req._kycErrorCode || null);
+  });
+
   const config = kycService.getKycProviderConfig();
   const secret = config.apiSecret;
   const signatureHeader = req.header(HTTP_HEADERS.X_SIGNATURE) || '';
@@ -71,28 +79,24 @@ router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
 
   if (!secret) {
     logger.warn({ route: '/api/kyc/webhook' }, 'KYC webhook secret is not configured');
-    finish(503, 'missing_secret');
-    return res.status(503).json({ error: 'KYC webhook ingestion is not configured' });
+    throw new KycWebhookError(KYC_WEBHOOK_MESSAGES.MISSING_SECRET, 503, KYC_WEBHOOK_ERROR_CODES.MISSING_SECRET);
   }
 
   if (!signatureHeader) {
-    finish(401, 'missing_signature');
-    return res.status(401).json({ error: 'Missing X-Signature header' });
+    throw new KycWebhookError(KYC_WEBHOOK_MESSAGES.MISSING_SIGNATURE, 401, KYC_WEBHOOK_ERROR_CODES.MISSING_SIGNATURE);
   }
 
   const verification = verifySignature(secret, rawBody, signatureHeader);
   if (!verification.valid) {
     logger.warn({ error: verification.error }, 'Invalid KYC webhook signature');
-    finish(401, 'invalid_signature');
-    return res.status(401).json({ error: 'Invalid webhook signature' });
+    throw new KycWebhookError(KYC_WEBHOOK_MESSAGES.INVALID_SIGNATURE, 401, KYC_WEBHOOK_ERROR_CODES.INVALID_SIGNATURE);
   }
 
   let payload;
   try {
     payload = parseJsonPayload(rawBody);
   } catch (error) {
-    finish(400, 'invalid_payload');
-    return res.status(400).json({ error: error.message });
+    throw new KycWebhookError(error.message, 400, KYC_WEBHOOK_ERROR_CODES.INVALID_PAYLOAD);
   }
 
   const payloadTenantId = payload.tenantId || payload.tenant_id || null;
@@ -119,12 +123,11 @@ router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
       );
     }
 
-    finish(errStatus, errorCode);
-    return res.status(errStatus).json(errBody);
+    throw new KycWebhookError(errBody.error || 'Validation failed', errStatus, errorCode);
   }
 
   if (payloadTenantId && !requestTenantId) {
-    return res.status(400).json({ error: 'Missing tenant context.' });
+    throw new KycWebhookError(KYC_WEBHOOK_MESSAGES.MISSING_TENANT_CONTEXT, 400, KYC_WEBHOOK_ERROR_CODES.MISSING_TENANT_CONTEXT);
   }
 
   // Normalise provider aliases (snake_case / legacy field names) into the
@@ -145,16 +148,13 @@ router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
     // metrics cause) that other tests/consumers already depend on, while still
     // gaining schema-driven validation of length, format, and unknown fields.
     if (fieldErrors.smeId) {
-      finish(400, 'missing_sme_id');
-      return res.status(400).json({ error: 'Missing or invalid smeId', details: fieldErrors });
+      throw new KycWebhookError('Missing or invalid smeId', 400, KYC_WEBHOOK_ERROR_CODES.MISSING_SME_ID);
     }
     if (fieldErrors.status) {
-      finish(400, 'missing_status');
-      return res.status(400).json({ error: 'Missing or invalid status', details: fieldErrors });
+      throw new KycWebhookError('Missing or invalid status', 400, KYC_WEBHOOK_ERROR_CODES.MISSING_STATUS);
     }
 
-    finish(400, 'invalid_payload');
-    return res.status(400).json({ error: 'Invalid KYC webhook payload', details: fieldErrors });
+    throw new KycWebhookError('Invalid KYC webhook payload', 400, KYC_WEBHOOK_ERROR_CODES.INVALID_PAYLOAD);
   }
 
   const smeId = parsedPayload.data.smeId;
@@ -172,8 +172,7 @@ router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
       { smeId, status },
       'KYC webhook received status outside PROVIDER_STATUS_MAP; rejecting (fail-closed)',
     );
-    finish(400, 'unknown_status');
-    return res.status(400).json({ error: `Unknown provider status: ${status}` });
+    throw new KycWebhookError(`Unknown provider status: ${status}`, 400, KYC_WEBHOOK_ERROR_CODES.UNKNOWN_STATUS);
   }
 
   try {
@@ -193,130 +192,120 @@ router.post(KYC_WEBHOOK_ROUTES.WEBHOOK, async (req, res) => {
       KYC_WEBHOOK_MESSAGES.SUCCESS_INGESTION
     );
 
-    finish(200);
     return res.status(200).json({ success: true, smeId: record.smeId, status: record.status });
   } catch (error) {
     logger.error({ smeId, error: error.message }, KYC_WEBHOOK_MESSAGES.FAILED_INGESTION);
-    finish(500, KYC_WEBHOOK_ERROR_CODES.PERSISTENCE_ERROR);
-    return res.status(500).json({ error: error.message });
+    throw new KycWebhookError(error.message, 500, KYC_WEBHOOK_ERROR_CODES.PERSISTENCE_ERROR);
   }
-});
+}));
 
 /**
  * GET /api/kyc/webhooks
  *
  * Cursor-paginated listing of KYC records (the kyc-webhooks listing endpoint).
  */
-router.get(KYC_WEBHOOK_ROUTES.WEBHOOKS, async (req, res, next) => {
-  try {
-    const { cursor, status } = req.query;
-    const rawLimit = req.query.limit;
+router.get(KYC_WEBHOOK_ROUTES.WEBHOOKS, asyncHandler(async (req, res) => {
+  const { cursor, status } = req.query;
+  const rawLimit = req.query.limit;
 
-    // Validate limit
-    if (rawLimit !== undefined) {
-      const v = parseInt(rawLimit, 10);
-      if (isNaN(v) || v < 1 || v > MAX_LIMIT) {
-        return res.status(400).json(
-          responseHelper.error(
-            `limit must be an integer between 1 and ${MAX_LIMIT}`,
-            KYC_WEBHOOK_ERROR_CODES.INVALID_PAGINATION
-          )
-        );
-      }
-    }
-
-    const limit = rawLimit !== undefined
-      ? Math.min(parseInt(rawLimit, 10), MAX_LIMIT)
-      : DEFAULT_LIMIT;
-
-    // Decode cursor
-    let cursorData = null;
-    if (cursor) {
-      try {
-        cursorData = decodeCursor(cursor, SORT_FIELD);
-      } catch (err) {
-        if (err instanceof CursorError) {
-          return res.status(400).json(
-            responseHelper.error(err.message, KYC_WEBHOOK_ERROR_CODES.INVALID_CURSOR)
-          );
-        }
-        return next(err);
-      }
-    }
-
-    // Build query
-    let query = db(KYC_WEBHOOK_DB.TABLE_KYC_RECORDS)
-      .select(
-        'sme_id as smeId',
-        'status',
-        'provider_record_id as recordId',
-        'verified_at as verifiedAt',
-        'updated_at as updatedAt'
-      )
-      .orderBy('updated_at', KYC_WEBHOOK_PAGINATION.DEFAULT_ORDER)
-      .orderBy('sme_id', KYC_WEBHOOK_PAGINATION.DEFAULT_ORDER)
-      .limit(limit + 1);
-
-    if (status) {
-      query = query.where('status', status);
-    }
-
-    if (cursorData) {
-      query = query.where(function () {
-        this.where('updated_at', '<', cursorData.sortValue)
-          .orWhere(function () {
-            this.where('updated_at', cursorData.sortValue)
-              .andWhere('sme_id', '<', cursorData.id);
-          });
-      });
-    }
-
-    const rows = await query;
-
-    const hasMore = rows.length > limit;
-    const pageRows = hasMore ? rows.slice(0, limit) : rows;
-
-    let nextCursor = null;
-    if (hasMore) {
-      const last = pageRows[pageRows.length - 1];
-      nextCursor = encodeCursor({
-        sortField: SORT_FIELD,
-        sortValue: last.updatedAt instanceof Date
-          ? last.updatedAt.toISOString()
-          : last.updatedAt,
-        id: String(last.smeId),
-      });
-    }
-
-    const responseBody = {
-      data: pageRows,
-      meta: {
-        limit,
-        hasMore,
-        nextCursor,
-      },
-    };
-
-    // Validate the outgoing shape at the boundary (issue #905) — a shape
-    // drift here reflects a bug in the query projection above, not a client
-    // error, so it is logged and surfaced as a 500 rather than shipped as-is.
-    const parsedResponse = kycWebhookListResponseSchema.safeParse(responseBody);
-    if (!parsedResponse.success) {
-      logger.error(
-        { errors: parseValidationErrors(parsedResponse.error) },
-        'KYC webhooks list response failed schema validation',
-      );
-      return res.status(500).json(
-        responseHelper.error('Failed to build KYC webhooks response', 'INTERNAL_ERROR')
+  // Validate limit
+  if (rawLimit !== undefined) {
+    const v = parseInt(rawLimit, 10);
+    if (isNaN(v) || v < 1 || v > MAX_LIMIT) {
+      throw new KycWebhookError(
+        `limit must be an integer between 1 and ${MAX_LIMIT}`,
+        400,
+        KYC_WEBHOOK_ERROR_CODES.INVALID_PAGINATION,
       );
     }
-
-    return res.status(200).json(parsedResponse.data);
-  } catch (error) {
-    logger.error({ err: error.message }, 'Failed to list KYC webhooks');
-    return next(error);
   }
-});
+
+  const limit = rawLimit !== undefined
+    ? Math.min(parseInt(rawLimit, 10), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  // Decode cursor
+  let cursorData = null;
+  if (cursor) {
+    try {
+      cursorData = decodeCursor(cursor, SORT_FIELD);
+    } catch (err) {
+      if (err instanceof CursorError) {
+        throw new KycWebhookError(err.message, 400, KYC_WEBHOOK_ERROR_CODES.INVALID_CURSOR);
+      }
+      throw err;
+    }
+  }
+
+  // Build query
+  let query = db(KYC_WEBHOOK_DB.TABLE_KYC_RECORDS)
+    .select(
+      'sme_id as smeId',
+      'status',
+      'provider_record_id as recordId',
+      'verified_at as verifiedAt',
+      'updated_at as updatedAt'
+    )
+    .orderBy('updated_at', KYC_WEBHOOK_PAGINATION.DEFAULT_ORDER)
+    .orderBy('sme_id', KYC_WEBHOOK_PAGINATION.DEFAULT_ORDER)
+    .limit(limit + 1);
+
+  if (status) {
+    query = query.where('status', status);
+  }
+
+  if (cursorData) {
+    query = query.where(function () {
+      this.where('updated_at', '<', cursorData.sortValue)
+        .orWhere(function () {
+          this.where('updated_at', cursorData.sortValue)
+            .andWhere('sme_id', '<', cursorData.id);
+        });
+    });
+  }
+
+  const rows = await query;
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+
+  let nextCursor = null;
+  if (hasMore) {
+    const last = pageRows[pageRows.length - 1];
+    nextCursor = encodeCursor({
+      sortField: SORT_FIELD,
+      sortValue: last.updatedAt instanceof Date
+        ? last.updatedAt.toISOString()
+        : last.updatedAt,
+      id: String(last.smeId),
+    });
+  }
+
+  const responseBody = {
+    data: pageRows,
+    meta: {
+      limit,
+      hasMore,
+      nextCursor,
+    },
+  };
+
+  // Validate the outgoing shape at the boundary (issue #905) — a shape
+  // drift here reflects a bug in the query projection above, not a client
+  // error, so it is logged and surfaced as a 500 rather than shipped as-is.
+  const parsedResponse = kycWebhookListResponseSchema.safeParse(responseBody);
+  if (!parsedResponse.success) {
+    logger.error(
+      { errors: parseValidationErrors(parsedResponse.error) },
+      'KYC webhooks list response failed schema validation',
+    );
+    throw new KycWebhookError('Failed to build KYC webhooks response', 500, 'INTERNAL_ERROR');
+  }
+
+  return res.status(200).json(parsedResponse.data);
+}));
+
+router.use(kycWebhookErrorHandler);
 
 module.exports = router;
 module.exports.isKycWebhookEnabled = isKycWebhookEnabled;

--- a/tests/kyc.webhook.errorMiddleware.test.js
+++ b/tests/kyc.webhook.errorMiddleware.test.js
@@ -1,0 +1,285 @@
+'use strict';
+
+/**
+ * @fileoverview Tests for the KYC webhook error-handling middleware.
+ *
+ * Covers:
+ *  - KycWebhookError → consistent structured response envelope
+ *  - Retryable flag mapping (503/missing_secret → true, others → false)
+ *  - Retry hint resolution per status/code
+ *  - correlation_id passthrough
+ *  - Non-KycWebhookError forwarded to next()
+ *  - req._kycErrorCode set for metrics hooks
+ *  - Edge cases: missing correlationId, undefined code
+ */
+
+const express = require('express');
+const request = require('supertest');
+const KycWebhookError = require('../src/errors/KycWebhookError');
+const kycWebhookErrorHandler = require('../src/middleware/kycWebhookErrorHandler');
+
+/**
+ * Builds a minimal Express app that exercises the error middleware.
+ *
+ * @param {Function} handler - Route handler that throws or calls next(err).
+ * @returns {import('express').Express} Configured app.
+ */
+function buildTestApp(handler) {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate correlation ID middleware
+  app.use((req, _res, next) => {
+    req.correlationId = req.headers['x-correlation-id'] || 'test-corr-123';
+    next();
+  });
+
+  app.get('/test', handler);
+  app.use(kycWebhookErrorHandler);
+
+  // Fallback error handler for non-KycWebhookError errors
+  app.use((err, _req, res, _next) => {
+    res.status(500).json({ fallback: true, message: err.message });
+  });
+
+  return app;
+}
+
+describe('kycWebhookErrorHandler', () => {
+  describe('structured response envelope', () => {
+    test('returns error.code, error.message, correlation_id, retryable, retry_hint', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Invalid webhook signature', 401, 'invalid_signature');
+      });
+
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({
+        error: {
+          code: 'invalid_signature',
+          message: 'Invalid webhook signature',
+          correlation_id: 'test-corr-123',
+          retryable: false,
+          retry_hint: '',
+        },
+      });
+    });
+
+    test('preserves HTTP status from KycWebhookError', async () => {
+      const statuses = [400, 401, 403, 500, 503];
+
+      for (const status of statuses) {
+        const app = buildTestApp(() => {
+          throw new KycWebhookError(`Error ${status}`, status, `code_${status}`);
+        });
+
+        const res = await request(app).get('/test');
+        expect(res.status).toBe(status);
+      }
+    });
+  });
+
+  describe('retryable flag', () => {
+    test('503 missing_secret is retryable', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Service unavailable', 503, 'missing_secret');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retryable).toBe(true);
+    });
+
+    test('429 is retryable', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Rate limited', 429, 'RATE_LIMITED');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retryable).toBe(true);
+    });
+
+    test('401 is not retryable', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Unauthorized', 401, 'missing_signature');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retryable).toBe(false);
+    });
+
+    test('400 is not retryable', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Bad request', 400, 'invalid_payload');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retryable).toBe(false);
+    });
+
+    test('500 is not retryable', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Internal error', 500, 'persistence_error');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retryable).toBe(false);
+    });
+  });
+
+  describe('retry_hint', () => {
+    test('missing_secret returns retry hint', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Service unavailable', 503, 'missing_secret');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retry_hint).toBe('Retry the request in a few moments.');
+    });
+
+    test('429 returns rate limit hint', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Rate limited', 429, 'RATE_LIMITED');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retry_hint).toBe('Wait for the rate limit window to reset before retrying.');
+    });
+
+    test('non-retryable error returns empty hint', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Bad request', 400, 'invalid_payload');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.retry_hint).toBe('');
+    });
+  });
+
+  describe('correlation_id', () => {
+    test('uses req.correlationId when present', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Error', 400, 'test_code');
+      });
+
+      const res = await request(app)
+        .get('/test')
+        .set('x-correlation-id', 'custom-id-abc');
+
+      expect(res.body.error.correlation_id).toBe('custom-id-abc');
+    });
+
+    test('falls back to req.id when correlationId is absent', async () => {
+      const app = express();
+      app.use(express.json());
+      app.get('/test', (req, res, next) => {
+        req.id = 'request-id-456';
+        next(new KycWebhookError('Error', 400, 'test_code'));
+      });
+      app.use(kycWebhookErrorHandler);
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.correlation_id).toBe('request-id-456');
+    });
+
+    test('falls back to "unknown" when neither is set', async () => {
+      const app = express();
+      app.use(express.json());
+      app.get('/test', (_req, res, next) => {
+        next(new KycWebhookError('Error', 400, 'test_code'));
+      });
+      app.use(kycWebhookErrorHandler);
+
+      const res = await request(app).get('/test');
+      expect(res.body.error.correlation_id).toBe('unknown');
+    });
+  });
+
+  describe('req._kycErrorCode', () => {
+    test('sets req._kycErrorCode for metrics hooks', async () => {
+      let capturedErrorCode;
+      const app = express();
+      app.use(express.json());
+      app.get('/test', (_req, res, next) => {
+        next(new KycWebhookError('Error', 500, 'persistence_error'));
+      });
+      app.use(kycWebhookErrorHandler);
+      app.use((err, req, _res, next) => {
+        capturedErrorCode = req._kycErrorCode;
+        next(err);
+      });
+
+      await request(app).get('/test');
+      expect(capturedErrorCode).toBe('persistence_error');
+    });
+  });
+
+  describe('non-KycWebhookError forwarding', () => {
+    test('forwards non-KycWebhookError to next handler', async () => {
+      const app = buildTestApp(() => {
+        throw new Error('generic error');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+      expect(res.body.fallback).toBe(true);
+      expect(res.body.message).toBe('generic error');
+    });
+
+    test('forwards AppError to next handler', async () => {
+      const AppError = require('../src/errors/AppError');
+      const app = buildTestApp(() => {
+        throw new AppError({ title: 'Not Found', status: 404, detail: 'Resource not found' });
+      });
+
+      const res = await request(app).get('/test');
+      // Should reach fallback handler, not kycWebhookErrorHandler
+      expect(res.body.fallback).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles error with undefined code gracefully', async () => {
+      const app = buildTestApp(() => {
+        const err = new KycWebhookError('Error', 400, undefined);
+        throw err;
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBeUndefined();
+      expect(res.body.error.retryable).toBe(false);
+    });
+
+    test('handles error with empty message', async () => {
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('', 400, 'test_code');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toBe('');
+    });
+
+    test('logs warning with error details', async () => {
+      const logger = require('../src/logger');
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      const app = buildTestApp(() => {
+        throw new KycWebhookError('Test error', 400, 'test_code');
+      });
+
+      await request(app).get('/test');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'test_code',
+          status: 400,
+        }),
+        'kyc-webhook error',
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Closes #958

## Summary

Centralizes kyc-webhooks error handling into shared middleware, removing per-handler duplication and producing consistent structured error responses.

## Changes

- **`src/errors/KycWebhookError.js`** (new) — Lightweight error class carrying HTTP status + machine-readable code through the Express error chain
- **`src/middleware/kycWebhookErrorHandler.js`** (new) — Shared middleware producing consistent `{error: {code, message, correlation_id, retryable, retry_hint}}` envelope for all KYC webhook errors
- **`src/routes/kyc.js`** (modified) — POST/GET handlers now throw `KycWebhookError` instead of inline `res.status().json()` calls; handlers wrapped with `asyncHandler`; metrics tracked via `res.on('finish')` reading `req._kycErrorCode` set by middleware
- **`tests/kyc.webhook.errorMiddleware.test.js`** (new) — 15 tests covering envelope shape, retryable flag mapping, retry hints, correlation_id passthrough, non-KycWebhookError forwarding, and edge cases

## Behaviour unchanged

- All HTTP status codes preserved (400, 401, 403, 500, 503)
- All error codes preserved (`missing_secret`, `missing_signature`, `invalid_signature`, etc.)
- Metrics tracking (duration, requests_total, errors_total) continues to work via `res.on('finish')` hook
- `validateKycWebhookRequest()` result pattern preserved — errors are thrown after validation

## Response format change

Error responses now include the full structured envelope:
```json
{
  "error": {
    "code": "missing_secret",
    "message": "KYC webhook ingestion is not configured",
    "correlation_id": "abc-123",
    "retryable": true,
    "retry_hint": "Retry the request in a few moments."
  }
}
Previously: { "error": "KYC webhook ingestion is not configured" }