### PR TITLE
Document the inbound kyc webhook contract

### DIFF
--- a/docs/kyc-webhook-contract.md
+++ b/docs/kyc-webhook-contract.md
@@ -1,0 +1,78 @@
+# KYC Inbound Webhook Contract
+
+This document describes the inbound KYC webhook that external KYC providers
+POST to for signalling SME verification events.
+
+Endpoint
+- POST /api/kyc/webhook
+- Content-Type: `application/json`
+
+Raw-body requirement
+- The signature is computed over the raw JSON string exactly as transmitted
+  (including whitespace). The server expects the request body to be available
+  as raw bytes (the app mounts `express.raw({ type: 'application/json' })`).
+
+Signature scheme
+- Header: `X-Signature: t=<unix_ts_seconds>,v1=<hex64_hmac>`
+- Computation: `hmac = HMAC-SHA256(secret, `${t}.${rawBody}`)`; the header
+  includes the timestamp `t` (seconds) and the hex-encoded signature `v1`.
+- The server verifies:
+  - header format and length guards,
+  - timestamp within tolerance (default 5 minutes),
+  - HMAC equality using a constant-time compare.
+
+Accepted payload shape and aliases
+- SME identifier (required):
+  - `smeId` (preferred) or `sme_id`
+- Status (required):
+  - `status` (preferred) or `kycStatus` or `kyc_status`
+- Provider record identifier (optional):
+  - `recordId` or `providerRecordId` or `provider_record_id`
+- Verified timestamp (optional):
+  - `verifiedAt` or `verified_at` (ISO 8601)
+- Tenant id (optional but required when the authenticated principal has a tenant):
+  - `tenantId` or `tenant_id`
+
+Example minimal payload
+```
+{ "smeId": "sme-123", "status": "verified" }
+```
+
+Responses
+- 200 OK — Ingested and persisted.
+  - Body: `{ "success": true, "smeId": "...", "status": "verified" }`
+- 400 Bad Request — Malformed JSON, missing or invalid fields, or provider
+  status not recognised (fail-closed). Body: `{ "error": "..." }`.
+- 401 Unauthorized — Missing or invalid `X-Signature` header.
+- 403 Forbidden — Tenant scope mismatch (`tenantId` mismatch).
+- 500 Internal Server Error — Persistence/processing failure.
+- 503 Service Unavailable — Provider secret not configured; ingestion is
+  disabled. Body: `{ "error": "KYC webhook ingestion is not configured" }`.
+
+Provider status → internal status mapping
+
+The webhook handler normalises provider-specific status strings using the
+`PROVIDER_STATUS_MAP` in `src/services/kycService.js`. The mapping is:
+
+| Provider status (example variants) | Internal status |
+|---|---|
+| pending, in_review, reviewing, queued, submitted | pending |
+| verified, approved, pass, success | verified |
+| rejected, denied, declined, failed | rejected |
+| exempted, exempt, waived | exempted |
+
+Any provider string not present in the mapping is treated as `unknown` and
+results in a 400 response (fail-closed).
+
+Notes for integrators
+- Compute the signature over the exact bytes you transmit. Any change in
+  whitespace or field ordering will change the signature.
+- Use the `t=<seconds>` value from your clock (UTC); the server allows a
+  5-minute window by default.
+- Do not include secrets in the payload; the signing secret is separate and
+  must be shared out-of-band.
+
+See also
+- Implementation: `src/routes/kyc.js`
+- Signature helpers: `src/services/webhooks.js`
+- Status mapping and persistence: `src/services/kycService.js`

--- a/tests/kyc.provider.test.js
+++ b/tests/kyc.provider.test.js
@@ -1449,3 +1449,70 @@ describe('normalizeKycWebhookCause (issue #731)', () => {
     expect(normalizeKycWebhookCause({ status: 500 })).toBe('internal');
   });
 });
+
+// Additional contract tests: field aliases and raw-body signature requirement
+describe('KYC webhook contract — aliases and raw-body signature', () => {
+  let app;
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-at-least-32-characters-long-string-for-jest';
+    app = require('express')();
+    app.use(require('express').raw({ type: 'application/json', limit: '100kb' }));
+    app.use('/api/kyc', require('../src/routes/kyc'));
+  });
+
+  it('accepts alias fields (`sme_id`, `kyc_status`, `provider_record_id`) and normalises status', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'alias-secret';
+
+    const payload = {
+      sme_id: 'sme-alias-01',
+      kyc_status: 'approved',
+      provider_record_id: 'rec_alias_01',
+      tenant_id: 'tenant-x',
+    };
+    const rawBody = JSON.stringify(payload);
+    const signature = createSignatureHeader('alias-secret', rawBody);
+    const token = jwt.sign({ sub: 'svc', tenantId: 'tenant-x' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    db.mockImplementation(() => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue([1]),
+      update: jest.fn().mockResolvedValue(1),
+    }));
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenant-x')
+      .set('X-Signature', signature)
+      .send(rawBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.smeId).toBe('sme-alias-01');
+    expect(res.body.status).toBe('verified');
+  });
+
+  it('requires signature be computed over the exact raw body bytes (whitespace matters)', async () => {
+    process.env.KYC_PROVIDER_SECRET = 'whitespace-secret';
+
+    const payload = { smeId: 'sme-space-01', status: 'approved' };
+    const rawBodyNoSpace = JSON.stringify(payload);
+    // Pretty-printed with additional whitespace
+    const rawBodyPretty = JSON.stringify(payload, null, 2);
+
+    // Signature computed over the compact form
+    const signature = createSignatureHeader('whitespace-secret', rawBodyNoSpace);
+
+    const res = await request(app)
+      .post('/api/kyc/webhook')
+      .set('Content-Type', 'application/json')
+      .set('X-Signature', signature)
+      .send(rawBodyPretty);
+
+    // Signature must not validate because the raw bytes differ
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Invalid webhook signature/);
+  });
+});


### PR DESCRIPTION
Closes #624 

## Pull Request Checklist

Please ensure you have completed the following steps before submitting your PR:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `npm run lint` and resolved any code style issues
- [ ] I have run `npm test` and ensured all tests pass with at least 95% coverage
- [ ] I have documented notable metrics API changes in `docs/changelog-metrics.md` (or checked that no metric changes occurred)

**PR Title**
- docs(kyc): document inbound webhook contract and signature scheme

**Summary**
- Adds a comprehensive inbound KYC webhook contract document, a JSDoc header in the webhook route describing the payload/aliases and signature requirements, and tests validating field aliases and that signatures must be computed over the exact raw JSON bytes.

**Branch**
- DocumentTheInboundKYCWebhookContract

**Changes**
- New file: kyc-webhook-contract.md — full contract (payload shape, aliases, raw-body requirement, X-Signature scheme, response codes, provider→internal status mapping).
- Updated: kyc.js — added JSDoc header summarising the contract, accepted aliases, raw-body and signature details, and emitted response codes.
- Updated tests: kyc.provider.test.js — added two tests:
  - Accepts alias fields (sme_id, kyc_status, provider_record_id) and verifies status normalisation.
  - Verifies signatures fail when computed over a different raw byte sequence (whitespace/pretty vs compact JSON).

**Motivation**
- The repo exposed inbound KYC webhook behavior in code but lacked a published contract for integrators. This PR documents the inbound contract and provides minimal tests to validate the contract expectations (field aliases and exact raw-body signature computation).

**Behavioral impact**
- No functional changes to runtime logic. The JSDoc header and docs only document existing behavior implemented in:
  - Signature verification: webhooks.js
  - Provider→internal mapping and persistence: kycService.js
- New tests assert and prevent regressions around payload aliases and the raw-body signature requirement.

**How to test locally**
1. Install dependencies:
```bash
npm ci
```
2. Run the unit tests:
```bash
npm test
```
3. Run linter:
```bash
npm run lint
```
4. Test the webhook manually (example curl payload signing):
- Compute signature using the scheme t=<unix_ts_seconds>,v1=<hex_hmac> where the signed input is `${t}.${rawJsonString}`.
- POST the raw JSON body (no reformatting) to POST /api/kyc/webhook with header X-Signature and appropriate auth/tenant headers.

**Files to review**
- kyc.js
- webhooks.js (signature implementation)
- kycService.js (status mapping)
- kyc-webhook-contract.md
- kyc.provider.test.js

**QA checklist**
- [ ] Run full test suite and confirm all tests pass.
- [ ] Run eslint and fix any warnings/errors if raised.
- [ ] Review kyc-webhook-contract.md for clarity and completeness.
- [ ] Verify the X-Signature examples against an independent HMAC-SHA256 tool (ensure timestamp tolerance works).
- [ ] Optional: ask integrators to validate signing from their side with a test webhook delivery.

**Notes / Observations**
- The webhook signature must be computed over the exact transmitted raw JSON bytes (including whitespace and key ordering). Integrators should send compact JSON (or sign their pretty-printed JSON exactly as transmitted).
- If the provider secret is not configured on the server, the route returns 503 and ingestion is disabled (documented in the new doc).
- Provider status mapping is defined in PROVIDER_STATUS_MAP in kycService.js; unmapped statuses are treated as unknown and rejected (400).

