### PR TITLE
test: add snapshot coverage for RFC7807 error response bodies (400/404/409/500)

### DIFF
--- a/tests/__snapshots__/persistence.errors.snapshot.test.js.snap
+++ b/tests/__snapshots__/persistence.errors.snapshot.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Persistence error-response body snapshots 400 validation error (retention policy create) 1`] = `
+{
+  "detail": "name is required, type must be one of [invoice, document]",
+  "instance": "urn:uuid:snap-test-request-id",
+  "status": 400,
+  "title": "Validation Error",
+  "type": "https://liquifact.com/probs/validation-error",
+}
+`;
+
+exports[`Persistence error-response body snapshots 404 not found (retention policy lookup) 1`] = `
+{
+  "detail": "Retention policy not found",
+  "instance": "urn:uuid:snap-test-request-id",
+  "status": 404,
+  "title": "Policy Not Found",
+  "type": "https://liquifact.com/probs/not-found",
+}
+`;
+
+exports[`Persistence error-response body snapshots 409 conflict (retention policy already exists) 1`] = `
+{
+  "detail": "Policy 'default-invoice-policy' already exists for this tenant",
+  "instance": "urn:uuid:snap-test-request-id",
+  "status": 409,
+  "title": "Policy Already Exists",
+  "type": "https://liquifact.com/probs/conflict",
+}
+`;
+
+exports[`Persistence error-response body snapshots 500 internal server error (retention policy fetch failure) 1`] = `
+{
+  "detail": "Failed to fetch retention policies",
+  "instance": "urn:uuid:snap-test-request-id",
+  "status": 500,
+  "title": "Internal Server Error",
+  "type": "https://liquifact.com/probs/internal-server-error",
+}
+`;

--- a/tests/persistence.errors.snapshot.test.js
+++ b/tests/persistence.errors.snapshot.test.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Snapshot tests for persistence error-response bodies.
+ *
+ * Locks the exact RFC 7807 shape of the persistence-layer error
+ * responses (400/404/409/500) used across the retention/policy routes,
+ * so accidental drift in field names or values is caught by CI.
+ *
+ * @module tests/persistence.errors.snapshot.test
+ */
+
+"use strict";
+
+const request = require("supertest");
+const express = require("express");
+const AppError = require("../src/errors/AppError");
+const { problemJsonHandler } = require("../src/middleware/problemJson");
+
+function buildApp(errorFactory) {
+  const app = express();
+  app.use((req, res, next) => {
+    req.id = "snap-test-request-id";
+    next();
+  });
+  app.get("/trigger", (req, res, next) => {
+    next(errorFactory());
+  });
+  app.use(problemJsonHandler);
+  return app;
+}
+
+describe("Persistence error-response body snapshots", () => {
+  test("400 validation error (retention policy create)", async () => {
+    const app = buildApp(
+      () =>
+        new AppError({
+          type: "https://liquifact.com/probs/validation-error",
+          title: "Validation Error",
+          status: 400,
+          detail: "name is required, type must be one of [invoice, document]",
+        }),
+    );
+    const response = await request(app).get("/trigger").expect(400);
+    expect(response.headers["content-type"]).toBe(
+      "application/problem+json; charset=utf-8",
+    );
+    expect(response.body).toMatchSnapshot();
+  });
+
+  test("404 not found (retention policy lookup)", async () => {
+    const app = buildApp(
+      () =>
+        new AppError({
+          type: "https://liquifact.com/probs/not-found",
+          title: "Policy Not Found",
+          status: 404,
+          detail: "Retention policy not found",
+        }),
+    );
+    const response = await request(app).get("/trigger").expect(404);
+    expect(response.headers["content-type"]).toBe(
+      "application/problem+json; charset=utf-8",
+    );
+    expect(response.body).toMatchSnapshot();
+  });
+
+  test("409 conflict (retention policy already exists)", async () => {
+    const app = buildApp(
+      () =>
+        new AppError({
+          type: "https://liquifact.com/probs/conflict",
+          title: "Policy Already Exists",
+          status: 409,
+          detail: "Policy 'default-invoice-policy' already exists for this tenant",
+        }),
+    );
+    const response = await request(app).get("/trigger").expect(409);
+    expect(response.headers["content-type"]).toBe(
+      "application/problem+json; charset=utf-8",
+    );
+    expect(response.body).toMatchSnapshot();
+  });
+
+  test("500 internal server error (retention policy fetch failure)", async () => {
+    const app = buildApp(
+      () =>
+        new AppError({
+          type: "https://liquifact.com/probs/internal-server-error",
+          title: "Internal Server Error",
+          status: 500,
+          detail: "Failed to fetch retention policies",
+        }),
+    );
+    const response = await request(app).get("/trigger").expect(500);
+    expect(response.headers["content-type"]).toBe(
+      "application/problem+json; charset=utf-8",
+    );
+    expect(response.body).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
Adds snapshot test coverage for RFC7807 error-response bodies on retention policy endpoints, covering all four status codes required by the issue: 400 (validation), 404 (not found), 409 (conflict), 500 (internal server error).

Closes #987

## What was verified
- New test file runs clean in isolation: `npx jest tests/persistence.errors.snapshot.test.js --runInBand --forceExit` -> 4/4 passing, 4/4 snapshots written
- Snapshots confirmed deterministic (fixed instance value, no random/timestamp fields) and correctly omit stack traces
- New file is fully lint-clean (npm run lint produces zero output scoped to this file)
- git diff --cached --stat confirms only the two new files are part of this change

## Pre-existing issues found (out of scope, not touched in this PR)
While running the full suite to validate this change, found several pre-existing, unrelated breakages that prevent npx jest from completing a full run:
- src/metrics.js:95 - circular-import ReferenceError affecting escrow.tokenMeta.test.js and invest.fund.test.js
- tests/escrow.legalhold.test.js - Babel parse error (duplicate 'request' identifier)
- tests/maturityReminders.test.js - Babel parse error (unexpected token)
- src/services/auditLog.js:102 - uncaught throw during teardown crashes the whole Jest process

None of these are related to or touched by this PR. Flagging for visibility; happy to open separate issues if useful.
