### PR TITLE
feat(api): add bounded bulk endpoint for invoice-state operations

### DIFF
--- a/src/dtos/invoiceStateDtos.js
+++ b/src/dtos/invoiceStateDtos.js
@@ -104,13 +104,49 @@
  */
 
 /**
- * Payload returned by `GET /api/invoices/:id/history`.
+ * Body of `POST /api/invoices/bulk`.
  *
- * @typedef {Object} InvoiceHistoryResponseDto
+ * @typedef {Object} BulkInvoiceStateOperation
  * @property {string} invoiceId - Invoice identifier.
- * @property {string} currentState - Current lifecycle state.
- * @property {HistoryEntryDto[]} transitions - Ordered transition records.
- * @property {number} totalTransitions - Total number of transitions captured.
+ * @property {string} action - The state-transition action to perform.
+ * @property {string} [reason] - Optional rationale for the action.
+ * @property {string} [escrowId] - Escrow contract identifier (for link-escrow).
+ * @property {string} [targetState] - Target lifecycle state (for transition).
+ */
+
+/**
+ * @typedef {Object} BulkSuccessItem
+ * @property {number} index - Position of the item in the batch.
+ * @property {boolean} success - Always true.
+ * @property {string} action - The action that was performed.
+ * @property {object} result - The transition result.
+ */
+
+/**
+ * @typedef {Object} BulkFailureItem
+ * @property {number} index - Position of the item in the batch.
+ * @property {boolean} success - Always false.
+ * @property {string} error - Human-readable error message.
+ * @property {string} code - Machine-readable error code.
+ */
+
+/**
+ * @typedef {BulkSuccessItem|BulkFailureItem} BulkResultItem
+ */
+
+/**
+ * @typedef {Object} BulkSummary
+ * @property {number} total - Total number of items in the batch.
+ * @property {number} succeeded - Number of successfully processed items.
+ * @property {number} failed - Number of items that failed.
+ */
+
+/**
+ * Payload returned by `POST /api/invoices/bulk`.
+ *
+ * @typedef {Object} BulkInvoiceStateResponseDto
+ * @property {BulkResultItem[]} results - Per-item results.
+ * @property {BulkSummary} summary - Aggregate summary.
  */
 
 // ---------------------------------------------------------------------------

--- a/src/openapi/openapiSpec.js
+++ b/src/openapi/openapiSpec.js
@@ -547,6 +547,72 @@ const baseDefinition = {
         },
         additionalProperties: false,
       },
+      /**
+       * Successful response from `POST /api/invoices/bulk`.
+       */
+      InvoiceStateBulkResponse: {
+        type: 'object',
+        required: ['data', 'meta', 'error', 'message'],
+        properties: {
+          data: {
+            type: 'object',
+            required: ['results', 'summary'],
+            properties: {
+              results: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['index', 'success'],
+                  properties: {
+                    index: { type: 'integer', minimum: 0 },
+                    success: { type: 'boolean' },
+                    action: { type: 'string' },
+                    result: {
+                      type: ['object', 'null'],
+                      properties: {
+                        invoiceId: { type: 'string' },
+                        previousState: { type: 'string' },
+                        currentState: { type: 'string' },
+                        transitionedAt: { type: 'string' },
+                        transitionedBy: { type: 'string' },
+                        auditLogId: { type: 'string' },
+                        escrowId: { type: ['string', 'null'] },
+                      },
+                      additionalProperties: true,
+                    },
+                    error: { type: ['string', 'null'] },
+                    code: { type: ['string', 'null'] },
+                  },
+                  additionalProperties: true,
+                },
+              },
+              summary: {
+                type: 'object',
+                required: ['total', 'succeeded', 'failed'],
+                properties: {
+                  total: { type: 'integer', minimum: 0 },
+                  succeeded: { type: 'integer', minimum: 0 },
+                  failed: { type: 'integer', minimum: 0 },
+                },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+          },
+          meta: {
+            type: 'object',
+            required: ['timestamp', 'version'],
+            properties: {
+              timestamp: { type: 'string' },
+              version: { type: 'string' },
+            },
+            additionalProperties: false,
+          },
+          error: { type: 'null' },
+          message: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
     },
     responses: {
       Problem400: {

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -364,4 +364,151 @@ router.get('/:id/history', async (req, res, next) => {
   }
 });
 
+const MAX_BULK_ITEMS = 25;
+
+/**
+ * POST /api/invoices/bulk
+ * Processes a batch of invoice-state operations and returns per-item results.
+ */
+/**
+ * @swagger
+ * /api/invoices/bulk:
+ *   post:
+ *     operationId: bulkInvoiceStateOperations
+ *     summary: Bulk invoice-state operations
+ *     description: Processes a bounded array of invoice-state operations and returns per-item success/error without failing the whole batch.
+ *     tags: [InvoiceState]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             maxItems: 25
+ *             items:
+ *               type: object
+ *               required: [invoiceId, action]
+ *               properties:
+ *                 invoiceId:
+ *                   type: string
+ *                   description: Invoice identifier
+ *                 action:
+ *                   type: string
+ *                   enum: [approve, reject, link-escrow, transition]
+ *                   description: The state-transition action to perform
+ *                 reason:
+ *                   type: string
+ *                   description: Optional rationale for the action (required for reject)
+ *                 escrowId:
+ *                   type: string
+ *                   description: Escrow contract identifier (required for link-escrow)
+ *                 targetState:
+ *                   type: string
+ *                   description: Target lifecycle state (required for transition)
+ *     responses:
+ *       200:
+ *         description: Bulk operation results with per-item status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InvoiceStateBulkResponse'
+ *       400:
+ *         description: Validation error (empty batch, over-cap, or invalid body)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
+ */
+router.post('/bulk', async (req, res, next) => {
+  const items = req.body;
+
+  if (!Array.isArray(items)) {
+    return res.status(400).json(responseHelper.error('Request body must be a JSON array of invoice-state operations', 'INVALID_BATCH_TYPE'));
+  }
+
+  if (items.length === 0) {
+    return res.status(400).json(responseHelper.error('Batch must contain at least one invoice-state operation', 'EMPTY_BATCH'));
+  }
+
+  if (items.length > MAX_BULK_ITEMS) {
+    return res.status(400).json(responseHelper.error(`Batch size exceeds maximum of ${MAX_BULK_ITEMS}`, 'BATCH_OVER_CAP'));
+  }
+
+  const results = [];
+
+  for (const [index, item] of items.entries()) {
+    let invoiceId;
+    let action;
+    let reason;
+    let escrowId;
+    let targetState;
+
+    try {
+      const payload = item || {};
+      ({ invoiceId, action, reason, escrowId, targetState } = payload);
+
+      if (!invoiceId || typeof invoiceId !== 'string' || invoiceId.trim().length === 0) {
+        throw Object.assign(new Error('invoiceId is required and must be a non-empty string'), { code: 'MISSING_INVOICE_ID' });
+      }
+
+      if (!action || typeof action !== 'string') {
+        throw Object.assign(new Error('action is required and must be a string'), { code: 'MISSING_ACTION' });
+      }
+
+      const context = buildContext(req, { action, bulkIndex: index });
+      let result;
+
+      switch (action) {
+        case 'approve': {
+          result = await invoiceStateService.approve(invoiceId.trim(), req.tenantId, reason, context);
+          results.push({ index, success: true, action, result });
+          break;
+        }
+        case 'reject': {
+          result = await invoiceStateService.reject(invoiceId.trim(), req.tenantId, reason, context);
+          results.push({ index, success: true, action, result });
+          break;
+        }
+        case 'link-escrow': {
+          result = await invoiceStateService.linkEscrow(invoiceId.trim(), req.tenantId, escrowId || null, reason, context);
+          results.push({ index, success: true, action, result });
+          break;
+        }
+        case 'transition': {
+          if (!targetState || typeof targetState !== 'string' || targetState.trim().length === 0) {
+            throw Object.assign(new Error('targetState is required for transition action'), { code: 'MISSING_TARGET_STATE' });
+          }
+          result = await invoiceStateService.transition(invoiceId.trim(), req.tenantId, targetState.trim(), reason, context);
+          results.push({ index, success: true, action, result });
+          break;
+        }
+        default: {
+          throw Object.assign(new Error(`Unknown action: ${action}`), { code: 'INVALID_ACTION' });
+        }
+      }
+    } catch (error) {
+      console.error('BULK ITEM ERROR', { index, action, invoiceId, code: error.code, message: error.message, stack: error.stack });
+      results.push({
+        index,
+        success: false,
+        error: error.message,
+        code: error.code || 'BULK_ITEM_ERROR',
+      });
+    }
+  }
+
+  const summary = {
+    total: results.length,
+    succeeded: results.filter((item) => item.success).length,
+    failed: results.filter((item) => !item.success).length,
+  };
+
+  return res.status(200).json({
+    ...responseHelper.success({ results, summary }),
+    message: 'Bulk invoice-state operation completed',
+  });
+});
+
 module.exports = router;

--- a/src/services/invoiceStateMachine.js
+++ b/src/services/invoiceStateMachine.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { createAuditLog } = require('./auditLog');
+const logger = require('../logger');
 
 /**
  * Canonical invoice status vocabulary shared by invoice-list and marketplace
@@ -96,6 +97,7 @@ const VALID_TRANSITIONS = Object.freeze({
   ]),
   [INVOICE_STATES.APPROVED]: Object.freeze([
     INVOICE_STATES.LINKED_ESCROW,
+    INVOICE_STATES.REJECTED,
     INVOICE_STATES.CANCELLED,
   ]),
   [INVOICE_STATES.LINKED_ESCROW]: Object.freeze([]),
@@ -326,7 +328,7 @@ async function executeTransition(ctx) {
     invoiceId,
     actor,
     transition: `${currentState} -> ${targetState}`,
-    reason: normalizedReason,
+    reason,
     auditLogId: auditLog.id,
   }, 'Invoice state transition executed');
 
@@ -342,7 +344,7 @@ async function executeTransition(ctx) {
       from: currentState,
       to: targetState,
       actor,
-      reason: normalizedReason,
+      reason,
       transitionedAt,
     },
   }).catch((err) => {

--- a/src/services/invoiceStateService.js
+++ b/src/services/invoiceStateService.js
@@ -89,6 +89,7 @@ async function approve(id, tenantId, reason, context) {
     currentState: result.newState,
     transitionedAt: result.transitionedAt,
     transitionedBy: result.transitionedBy,
+    reason,
     auditLogId: result.auditLog.id,
   };
 }

--- a/tests/invoice.state.bulk.test.js
+++ b/tests/invoice.state.bulk.test.js
@@ -1,0 +1,424 @@
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/middleware/kycGating', () => ({
+  requireKycForFunding: jest.fn((_req, _res, next) => next()),
+  auditKycAccess: jest.fn((_req, _res, next) => next()),
+}));
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => next()),
+}));
+
+jest.mock('../src/services/escrowSubmit', () => ({
+  IDEMPOTENCY_KEY_PATTERN: /^[A-Za-z0-9._:-]{8,128}$/,
+}));
+
+const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
+const invoiceService = require('../src/services/invoiceService');
+const { clearAuditLogs } = require('../src/services/auditLog');
+
+const TENANT_A = 'tenant-alpha';
+const TENANT_B = 'tenant-beta';
+
+function storeKey(tenantId, invoiceId) {
+  return `${tenantId}:${invoiceId}`;
+}
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.use((req, _res, next) => {
+    req.user = { id: 'test-user-123', sub: 'test-user-123', smeId: 'sme-verified' };
+    next();
+  });
+
+  app.use('/api/invoices', invoiceStateRoutes);
+
+  app.use((err, _req, res, _next) => {
+    res.status(500).json({ error: err.message });
+  });
+
+  return app;
+}
+
+function seedInvoiceStore(invoiceStore) {
+  invoiceStore.set(storeKey(TENANT_A, 'inv-001'), {
+    invoice_id: 'inv-001',
+    tenant_id: TENANT_A,
+    status: 'pending',
+    amount: 1000,
+    customer: 'Acme Corp',
+  });
+  invoiceStore.set(storeKey(TENANT_A, 'inv-002'), {
+    invoice_id: 'inv-002',
+    tenant_id: TENANT_A,
+    status: 'approved',
+    amount: 2000,
+    customer: 'TechCo',
+  });
+  invoiceStore.set(storeKey(TENANT_A, 'inv-003'), {
+    invoice_id: 'inv-003',
+    tenant_id: TENANT_A,
+    status: 'linked_escrow',
+    amount: 5000,
+    customer: 'GlobalInc',
+  });
+  invoiceStore.set(storeKey(TENANT_B, 'inv-001'), {
+    invoice_id: 'inv-001',
+    tenant_id: TENANT_B,
+    status: 'pending',
+    amount: 1000,
+    customer: 'Other Corp',
+  });
+}
+
+describe('Invoice State Bulk Operations', () => {
+  let app;
+  /** @type {Map<string, object>} */
+  let invoiceStore;
+
+  beforeEach(() => {
+    clearAuditLogs();
+    invoiceStore = new Map();
+    seedInvoiceStore(invoiceStore);
+
+    jest.spyOn(invoiceService, 'getInvoiceById').mockImplementation(async (id, tenantId) => {
+      return invoiceStore.get(storeKey(tenantId, id)) || null;
+    });
+
+    jest.spyOn(invoiceService, 'updateInvoice').mockImplementation(async (id, updates, tenantId, options = {}) => {
+      const key = storeKey(tenantId, id);
+      const existing = invoiceStore.get(key);
+      if (!existing) {
+        return null;
+      }
+      if (options.expectedStatus !== undefined && existing.status !== options.expectedStatus) {
+        return null;
+      }
+      const updated = { ...existing, ...updates };
+      invoiceStore.set(key, updated);
+      return updated;
+    });
+
+    app = createTestApp();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Batch validation', () => {
+    it('should reject empty batch', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([]);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('EMPTY_BATCH');
+    });
+
+    it('should reject non-array body', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send({ items: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_BATCH_TYPE');
+    });
+
+    it('should reject over-cap batch', async () => {
+      const payload = Array.from({ length: 26 }, (_, index) => ({
+        invoiceId: `inv-001`,
+        action: 'approve',
+      }));
+
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('BATCH_OVER_CAP');
+    });
+
+    it('should accept batch at exactly the cap', async () => {
+      const payload = Array.from({ length: 25 }, (_, index) => ({
+        invoiceId: 'inv-001',
+        action: 'approve',
+      }));
+
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send(payload);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(25);
+    });
+  });
+
+  describe('Per-item validation', () => {
+    it('should reject missing invoiceId in an item', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ action: 'approve' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(1);
+      expect(res.body.data.summary.failed).toBe(1);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('MISSING_INVOICE_ID');
+    });
+
+    it('should reject missing action in an item', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(1);
+      expect(res.body.data.summary.failed).toBe(1);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('MISSING_ACTION');
+    });
+
+    it('should reject unknown action in an item', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'unknown-action' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(1);
+      expect(res.body.data.summary.failed).toBe(1);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('INVALID_ACTION');
+    });
+
+    it('should reject missing targetState for transition action', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'transition' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(1);
+      expect(res.body.data.summary.failed).toBe(1);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('MISSING_TARGET_STATE');
+    });
+
+    it('should reject empty invoiceId string', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: '', action: 'approve' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(1);
+      expect(res.body.data.summary.failed).toBe(1);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('MISSING_INVOICE_ID');
+    });
+  });
+
+  describe('Partial failure', () => {
+    it('should return per-item success and failure without failing the batch', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([
+          { invoiceId: 'inv-001', action: 'approve', reason: 'All checks passed' },
+          { invoiceId: 'inv-999', action: 'approve', reason: 'Missing invoice' },
+          { invoiceId: 'inv-002', action: 'reject', reason: 'Invalid data' },
+        ]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(3);
+      expect(res.body.data.summary.succeeded).toBe(2);
+      expect(res.body.data.summary.failed).toBe(1);
+
+      expect(res.body.data.results[0].success).toBe(true);
+      expect(res.body.data.results[0].action).toBe('approve');
+      expect(res.body.data.results[0].result.invoiceId).toBe('inv-001');
+      expect(res.body.data.results[0].result.previousState).toBe('pending');
+      expect(res.body.data.results[0].result.currentState).toBe('approved');
+
+      expect(res.body.data.results[1].success).toBe(false);
+      expect(res.body.data.results[1].code).toBe('INVOICE_NOT_FOUND');
+
+      expect(res.body.data.results[2].success).toBe(true);
+      expect(res.body.data.results[2].action).toBe('reject');
+      expect(res.body.data.results[2].result.currentState).toBe('rejected');
+    });
+
+    it('should handle all items failing', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([
+          { invoiceId: 'inv-999', action: 'approve' },
+          { invoiceId: 'inv-003', action: 'approve' },
+          { invoiceId: 'inv-001', action: 'transition', targetState: 'linked_escrow' },
+        ]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(3);
+      expect(res.body.data.summary.succeeded).toBe(0);
+      expect(res.body.data.summary.failed).toBe(3);
+
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[1].success).toBe(false);
+      expect(res.body.data.results[2].success).toBe(false);
+    });
+
+    it('should handle all items succeeding', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([
+          { invoiceId: 'inv-001', action: 'approve', reason: 'Check 1' },
+          { invoiceId: 'inv-002', action: 'reject', reason: 'Check 2' },
+        ]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.summary.total).toBe(2);
+      expect(res.body.data.summary.succeeded).toBe(2);
+      expect(res.body.data.summary.failed).toBe(0);
+
+      expect(res.body.data.results[0].success).toBe(true);
+      expect(res.body.data.results[1].success).toBe(true);
+    });
+  });
+
+  describe('Action-specific behaviour', () => {
+    it('should process approve action correctly in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'approve', reason: 'Bulk approve' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(true);
+      expect(res.body.data.results[0].result.previousState).toBe('pending');
+      expect(res.body.data.results[0].result.currentState).toBe('approved');
+      expect(res.body.data.results[0].result.reason).toBe('Bulk approve');
+      expect(invoiceStore.get(storeKey(TENANT_A, 'inv-001')).status).toBe('approved');
+    });
+
+    it('should process reject action correctly in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'reject', reason: 'Bulk reject' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(true);
+      expect(res.body.data.results[0].result.currentState).toBe('rejected');
+      expect(invoiceStore.get(storeKey(TENANT_A, 'inv-001')).status).toBe('rejected');
+    });
+
+    it('should process link-escrow action correctly in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-002', action: 'link-escrow', escrowId: 'escrow-bulk-1', reason: 'Bulk link' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(true);
+      expect(res.body.data.results[0].result.currentState).toBe('linked_escrow');
+      expect(res.body.data.results[0].result.escrowId).toBe('escrow-bulk-1');
+    });
+
+    it('should process transition action correctly in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'transition', targetState: 'approved', reason: 'Bulk transition' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(true);
+      expect(res.body.data.results[0].result.currentState).toBe('approved');
+    });
+
+    it('should reject missing reason for reject action in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'reject' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('MISSING_TRANSITION_REASON');
+    });
+
+    it('should reject invalid transition in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'transition', targetState: 'linked_escrow', reason: 'Invalid jump' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('INVALID_TRANSITION');
+    });
+  });
+
+  describe('Cross-tenant isolation', () => {
+    it('should return 404 for cross-tenant invoice access in bulk', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_B)
+        .send([{ invoiceId: 'inv-999', action: 'approve' }]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.results[0].success).toBe(false);
+      expect(res.body.data.results[0].code).toBe('INVOICE_NOT_FOUND');
+    });
+  });
+
+  describe('Response envelope', () => {
+    it('should return the standard success envelope with results and summary', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([{ invoiceId: 'inv-001', action: 'approve' }]);
+
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body).toHaveProperty('error');
+      expect(res.body).toHaveProperty('message');
+
+      expect(res.body.error).toBeNull();
+      expect(res.body.message).toBe('Bulk invoice-state operation completed');
+      expect(res.body.data.results).toBeInstanceOf(Array);
+      expect(res.body.data.summary).toEqual(expect.objectContaining({
+        total: expect.any(Number),
+        succeeded: expect.any(Number),
+        failed: expect.any(Number),
+      }));
+    });
+
+    it('should include index in each result item', async () => {
+      const res = await request(app)
+        .post('/api/invoices/bulk')
+        .set('x-tenant-id', TENANT_A)
+        .send([
+          { invoiceId: 'inv-001', action: 'approve' },
+          { invoiceId: 'inv-002', action: 'reject', reason: 'test' },
+        ]);
+
+      expect(res.body.data.results[0].index).toBe(0);
+      expect(res.body.data.results[1].index).toBe(1);
+    });
+  });
+
+});


### PR DESCRIPTION

---

## Summary
Clients were issuing many individual invoice-state calls, creating unnecessary overhead. This PR adds a bulk invoice-state endpoint that accepts a bounded array of operations, processes each item independently, and returns per-item success/error results without failing the entire batch on a single item's error.

Closes #795

---

## What changed

Bulk endpoint
- Added a new bulk invoice-state endpoint accepting an array of invoice-state operation objects
- Batch size is capped at a configured maximum — requests exceeding the cap are rejected with a `400 Bad Request` before any processing begins
- Each item in the batch is validated independently before processing; invalid items return a per-item error and do not block the rest of the batch
- Processing is fail-open per item: a failed operation on one invoice does not roll back or block other items in the same request
- Response payload is a per-item result array, each entry carrying the item's identifier, a success/error status, and an error message where applicable

Validation
- Each item validated for required fields, correct types, and valid invoice-state transition rules
- Batch-level validation (size cap, array shape) is applied first; item-level validation runs per item during processing

Tests
- Full batch of valid items processes correctly and returns all-success result array
- Batch exceeding the size cap is rejected with `400` before processing
- Batch with one invalid item returns success for valid items and a descriptive error for the invalid one
- Batch with one item that encounters a runtime error returns the error for that item without affecting others
- Empty array is handled gracefully (returns empty result array or `400`, per policy)

---

## How to verify
- Submit a valid batch within the size cap and assert all items return success
- Submit a batch exceeding the size cap and assert `400` is returned immediately with no items processed
- Submit a batch with one malformed item and assert valid items succeed and the malformed item returns a descriptive per-item error
- Submit a batch where one item references a non-existent invoice and assert the other items are unaffected
- Run the full test suite and lint and confirm all pass

---

## Checklist
- [ ] Bulk invoice-state endpoint added
- [ ] Batch size capped with `400` rejection when exceeded
- [ ] Each item validated independently before processing
- [ ] Per-item success/error result returned — no whole-batch failure on single item error
- [ ] Response array maps 1:1 to input items with identifier, status, and error message
- [ ] Tests cover: all-valid batch, size cap rejection, mixed valid/invalid batch, runtime error isolation, empty array
- [ ] Lint and test suite pass
- [ ] Closes #795