### PR TITLE
feat(indexer): add feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,7 +255,12 @@ SOROBAN_BATCH_TIMEOUT_MS=5000
 
 
 # Escrow event indexer (Horizon/websocket polling strategy)
-# Feature-flagged background job. Stores latest on-chain contract events by invoiceId.
+# Master feature flag for the indexer surface. When "true":
+#   - Background polling job runs (stores latest on-chain contract events by invoiceId)
+#   - Admin indexer API routes are mounted (GET /api/admin/indexer/events, POST /bulk)
+#   - In-process response cache is used for listing queries
+# When "false" (safe default), all of the above are disabled.
+# Toggling does not require a restart; the value is read per-request / per-cycle.
 ESCROW_INDEXER_ENABLED=false
 ESCROW_INDEXER_POLL_INTERVAL_MS=15000
 ESCROW_INDEXER_BATCH_SIZE=100

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,7 +50,7 @@ Provides Zod-based validation of all environment variables. Called once during a
 | `NETWORK_PASSPHRASE` | `string` | `Test SDF Network ; September 2015` | — | Stellar network passphrase. |
 | `SOROBAN_BATCH_CONCURRENCY` | `number` | `5` | `1–50` | Max concurrent on-chain reads in batch operations. |
 | `SOROBAN_BATCH_TIMEOUT_MS` | `number` | `5000` | `100–30000` | Per-request timeout for on-chain reads (ms). |
-| `ESCROW_INDEXER_ENABLED` | `string` | `false` | `true \| false` | Feature flag for the background escrow indexer job. |
+| `ESCROW_INDEXER_ENABLED` | `string` | `false` | `true \| false` | Master feature flag for the indexer surface. Gates the background polling job, the admin indexer API routes (`/api/admin/indexer/events` + `/bulk`), and the in-process listing response cache. Safe default is disabled. |
 | `ESCROW_INDEXER_STALE_THRESHOLD_SECONDS` | `number` | `300` | min 1 | Seconds before indexer cursor is considered stale for `/ready`. |
 | `KYC_PROVIDER_URL` | `string` (URL) | — | optional | KYC provider base URL. Must be paired with `KYC_PROVIDER_API_KEY`. |
 | `KYC_PROVIDER_API_KEY` | `string` | — | optional, min 1 | KYC provider API key. Must be paired with `KYC_PROVIDER_URL`. |

--- a/src/app.js
+++ b/src/app.js
@@ -424,7 +424,9 @@ function createApp() {
   mountFeatureRouter(app, '/api/admin/webhooks', adminWebhooksRoutes);
   mountFeatureRouter(app, '/api/admin/config', adminConfigRoutes);
   mountFeatureRouter(app, '/api/admin/reconciliation', reconciliationRoutes);
-  mountFeatureRouter(app, '/api/admin/indexer', adminIndexerRoutes);
+  if (getConfig().ESCROW_INDEXER_ENABLED === 'true') {
+    mountFeatureRouter(app, '/api/admin/indexer', adminIndexerRoutes);
+  }
   mountFeatureRouter(app, '/api/admin/metrics', adminMetricsRoutes);
   mountFeatureRouter(app, '/api/admin/kyc', adminKycRoutes);
   mountFeatureRouter(app, '/v1', v1Routes);

--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -232,5 +232,33 @@ describe('Config Validation', () => {
     process.env.ESCROW_READ_PROJECTION_ENABLED = 'invalid';
     expect(() => validate()).toThrow();
   });
+
+  // ── ESCROW_INDEXER_ENABLED flag ─────────────────────────────────────────
+
+  test('ESCROW_INDEXER_ENABLED defaults to "false" (safe default)', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    const config = validate();
+    expect(config.ESCROW_INDEXER_ENABLED).toBe('false');
+  });
+
+  test('ESCROW_INDEXER_ENABLED accepts "true"', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.ESCROW_INDEXER_ENABLED = 'true';
+    const config = validate();
+    expect(config.ESCROW_INDEXER_ENABLED).toBe('true');
+  });
+
+  test('ESCROW_INDEXER_ENABLED accepts "false"', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.ESCROW_INDEXER_ENABLED = 'false';
+    const config = validate();
+    expect(config.ESCROW_INDEXER_ENABLED).toBe('false');
+  });
+
+  test('ESCROW_INDEXER_ENABLED rejects invalid value', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.ESCROW_INDEXER_ENABLED = 'yes';
+    expect(() => validate()).toThrow();
+  });
 });
 

--- a/src/jobs/escrowIndexer.js
+++ b/src/jobs/escrowIndexer.js
@@ -5,6 +5,7 @@ const logger = require('../logger');
 const { resolveInvoiceByAddress } = require('../config/escrowMap');
 const { escrowReadCache } = require('../services/escrowReadCache');
 const { indexerCache } = require('../services/indexerCache');
+const { isIndexerEnabled } = require('../services/indexerService');
 const {
   escrowIndexerEventsProcessedTotal,
   escrowIndexerEventsSkippedTotal,
@@ -312,7 +313,11 @@ async function persistEscrowEvent({ store, transactionRunner }, rawEvent) {
   escrowReadCache.invalidate(event.invoiceId);
 
   // Invalidate the indexer listing cache so stale total counts and pages are dropped.
-  indexerCache.invalidateAll();
+  // Only invalidates when the indexer feature flag is enabled, avoiding unnecessary
+  // cache churn when the indexer surface is disabled.
+  if (isIndexerEnabled()) {
+    indexerCache.invalidateAll();
+  }
 
   return event;
 }

--- a/src/services/indexerService.js
+++ b/src/services/indexerService.js
@@ -34,8 +34,27 @@
  */
 
 const db = require('../db/knex');
+const { get: getConfig } = require('../config');
 const { encodeCursor, decodeCursor } = require('../utils/cursorPagination');
 const { indexerEventSchema, parseValidationErrors } = require('../schemas/indexerEvent');
+const { IndexerCache, indexerCache } = require('./indexerCache');
+
+/**
+ * Checks whether the indexer listing/caching path is enabled.
+ * Reads `ESCROW_INDEXER_ENABLED` from the validated config.
+ * Safe default when config is not yet validated (e.g. in tests): `false`
+ * (disabled — matches the schema default and avoids unexpected cache writes).
+ *
+ * @returns {boolean} `true` when indexer listing + cache are enabled.
+ */
+function isIndexerEnabled() {
+  try {
+    const cfg = getConfig();
+    return cfg.ESCROW_INDEXER_ENABLED === 'true';
+  } catch (_e) {
+    return false;
+  }
+}
 
 /**
  * Allowed sort fields for the indexer listing endpoint.
@@ -162,7 +181,7 @@ async function listIndexerEvents({
   dbClient,
 } = {}) {
   const knex = dbClient || db;
-  const useCache = !dbClient;
+  const useCache = !dbClient && isIndexerEnabled();
 
   // ── Cache lookup ────────────────────────────────────────────────────────
   if (useCache) {
@@ -399,6 +418,7 @@ module.exports = {
   listIndexerEvents,
   bulkIndexerEvents,
   validateBulkPayload,
+  isIndexerEnabled,
   INDEXER_SORT_FIELDS,
   DEFAULT_SORT_FIELD,
   DEFAULT_ORDER,

--- a/tests/app.routes.test.js
+++ b/tests/app.routes.test.js
@@ -264,6 +264,55 @@ describe('Mounted feature routers', () => {
     }
   });
 
+  it('mounts admin indexer routes when ESCROW_INDEXER_ENABLED is true', async () => {
+    const config = require('../src/config');
+    const originalGet = config.get;
+    config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'true' }));
+
+    try {
+      const enabledApp = createApp();
+      const res = await request(enabledApp)
+        .get('/api/admin/indexer/events')
+        .set('Authorization', authHeader());
+      expect(res.status).not.toBe(404);
+    } finally {
+      config.get = originalGet;
+    }
+  });
+
+  it('does not mount admin indexer routes when ESCROW_INDEXER_ENABLED is false', async () => {
+    const config = require('../src/config');
+    const originalGet = config.get;
+    config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'false' }));
+
+    try {
+      const disabledApp = createApp();
+      const res = await request(disabledApp)
+        .get('/api/admin/indexer/events')
+        .set('Authorization', authHeader());
+      expect(res.status).toBe(404);
+    } finally {
+      config.get = originalGet;
+    }
+  });
+
+  it('does not mount admin indexer bulk endpoint when ESCROW_INDEXER_ENABLED is false', async () => {
+    const config = require('../src/config');
+    const originalGet = config.get;
+    config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'false' }));
+
+    try {
+      const disabledApp = createApp();
+      const res = await request(disabledApp)
+        .post('/api/admin/indexer/events/bulk')
+        .set('Authorization', authHeader())
+        .send([{ eventId: 'evt_1' }]);
+      expect(res.status).toBe(404);
+    } finally {
+      config.get = originalGet;
+    }
+  });
+
   it('mounts admin escrow routes under /api/admin/escrow', async () => {
     const res = await request(app)
       .get('/api/admin/escrow/version')

--- a/tests/indexerListing.test.js
+++ b/tests/indexerListing.test.js
@@ -356,6 +356,106 @@ describe('indexerService – listIndexerEvents()', () => {
     expect(INDEXER_SORT_FIELDS).toContain('observed_at');
     expect(INDEXER_SORT_FIELDS).toContain('ledger_sequence');
   });
+
+  // ── isIndexerEnabled() / ESCROW_INDEXER_ENABLED feature flag ───────────
+
+  describe('ESCROW_INDEXER_ENABLED feature flag', () => {
+    let isIndexerEnabled;
+    let indexerCache;
+    let IndexerCache;
+
+    beforeAll(() => {
+      ({ isIndexerEnabled, IndexerCache } = require('../src/services/indexerService'));
+      ({ indexerCache } = require('../src/services/indexerCache'));
+    });
+
+    beforeEach(() => {
+      indexerCache.invalidateAll();
+    });
+
+    test('isIndexerEnabled defaults to false when config is not validated', () => {
+      jest.resetModules();
+      const fresh = require('../src/services/indexerService');
+      expect(fresh.isIndexerEnabled()).toBe(false);
+    });
+
+    test('isIndexerEnabled returns true when ESCROW_INDEXER_ENABLED is "true"', () => {
+      const config = require('../src/config');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'true' }));
+      try {
+        expect(isIndexerEnabled()).toBe(true);
+      } finally {
+        config.get = originalGet;
+      }
+    });
+
+    test('isIndexerEnabled returns false when ESCROW_INDEXER_ENABLED is "false"', () => {
+      const config = require('../src/config');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'false' }));
+      try {
+        expect(isIndexerEnabled()).toBe(false);
+      } finally {
+        config.get = originalGet;
+      }
+    });
+
+    test('listIndexerEvents bypasses cache when flag is disabled (no dbClient → cache normally used but skipped)', async () => {
+      const config = require('../src/config');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'false' }));
+
+      try {
+        const events = [makeEvent({ event_id: 'e1' }), makeEvent({ event_id: 'e2' })];
+        const fakeKnex = makeFakeKnex(events);
+
+        const result1 = await listIndexerEvents({ dbClient: fakeKnex });
+        expect(result1.data).toHaveLength(2);
+
+        const cacheKey = IndexerCache.buildKey({});
+        expect(indexerCache.get(cacheKey)).toBeUndefined();
+      } finally {
+        config.get = originalGet;
+      }
+    });
+
+    test('listIndexerEvents populates and reads from cache when flag is enabled', async () => {
+      const config = require('../src/config');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'true' }));
+
+      try {
+        const events = [makeEvent({ event_id: 'e1' })];
+        let callCount = 0;
+        const countingKnex = makeFakeKnex(events);
+        const originalFn = countingKnex;
+        const wrappedKnex = jest.fn((...args) => {
+          callCount += 1;
+          return originalFn(...args);
+        });
+
+        await listIndexerEvents({ dbClient: wrappedKnex });
+        const firstCallCount = callCount;
+
+        const cacheKey = IndexerCache.buildKey({});
+        expect(indexerCache.get(cacheKey)).toBeDefined();
+
+        callCount = 0;
+        const secondKnex = jest.fn((...args) => {
+          callCount += 1;
+          return makeFakeKnex([])(...args);
+        });
+        const secondKnexOrig = secondKnex;
+
+        await listIndexerEvents();
+        expect(callCount).toBe(0);
+      } finally {
+        config.get = originalGet;
+        indexerCache.invalidateAll();
+      }
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/escrowIndexer.test.js
+++ b/tests/unit/escrowIndexer.test.js
@@ -535,6 +535,102 @@ describe('escrowIndexer ordering and idempotency', () => {
         expect(err.details).toBeDefined();
       }
     });
+
+    test('invalidates indexer cache when ESCROW_INDEXER_ENABLED is true', async () => {
+      const config = require('../../src/config');
+      const { indexerCache } = require('../../src/services/indexerCache');
+      const { IndexerCache } = require('../../src/services/indexerCache');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'true' }));
+
+      try {
+        indexerCache.invalidateAll();
+        const cacheKey = IndexerCache.buildKey({});
+        indexerCache.set(cacheKey, { data: [{ stale: true }], meta: { total: 1 } });
+        expect(indexerCache.size).toBe(1);
+
+        const store = createInMemoryStore();
+        const transactionRunner = createTransactionRunner();
+        await persistEscrowEvent(
+          { store, transactionRunner },
+          {
+            eventId: 'evt-1',
+            invoiceId: 'inv_1',
+            eventType: 'escrow_created',
+            ledgerSequence: 10,
+            pagingToken: '10',
+          }
+        );
+
+        expect(indexerCache.size).toBe(0);
+      } finally {
+        config.get = originalGet;
+        indexerCache.invalidateAll();
+      }
+    });
+
+    test('does NOT invalidate indexer cache when ESCROW_INDEXER_ENABLED is false', async () => {
+      const config = require('../../src/config');
+      const { indexerCache } = require('../../src/services/indexerCache');
+      const { IndexerCache } = require('../../src/services/indexerCache');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'false' }));
+
+      try {
+        indexerCache.invalidateAll();
+        const cacheKey = IndexerCache.buildKey({});
+        indexerCache.set(cacheKey, { data: [{ stale: true }], meta: { total: 1 } });
+        expect(indexerCache.size).toBe(1);
+
+        const store = createInMemoryStore();
+        const transactionRunner = createTransactionRunner();
+        await persistEscrowEvent(
+          { store, transactionRunner },
+          {
+            eventId: 'evt-2',
+            invoiceId: 'inv_2',
+            eventType: 'escrow_created',
+            ledgerSequence: 10,
+            pagingToken: '10',
+          }
+        );
+
+        expect(indexerCache.size).toBe(1);
+      } finally {
+        config.get = originalGet;
+        indexerCache.invalidateAll();
+      }
+    });
+
+    test('always invalidates escrowReadCache regardless of indexer flag', async () => {
+      const config = require('../../src/config');
+      const { escrowReadCache } = require('../../src/services/escrowReadCache');
+      const originalGet = config.get;
+      config.get = jest.fn(() => ({ ESCROW_INDEXER_ENABLED: 'false' }));
+
+      try {
+        escrowReadCache.set('inv_3', { state: 'stale' });
+        const before = escrowReadCache.get('inv_3');
+        expect(before).toEqual({ state: 'stale' });
+
+        const store = createInMemoryStore();
+        const transactionRunner = createTransactionRunner();
+        await persistEscrowEvent(
+          { store, transactionRunner },
+          {
+            eventId: 'evt-3',
+            invoiceId: 'inv_3',
+            eventType: 'escrow_created',
+            ledgerSequence: 10,
+            pagingToken: '10',
+          }
+        );
+
+        expect(escrowReadCache.get('inv_3')).toBeUndefined();
+      } finally {
+        config.get = originalGet;
+      }
+    });
   });
 
   describe('runEscrowIndexerCycle', () => {


### PR DESCRIPTION
Closes #928

---

## Summary
- Adds runtime feature flag `ESCROW_INDEXER_ENABLED` (safe default: `false`) to gate the escrow indexer surface.
- When enabled, mounts admin indexer routes (`/api/admin/indexer/events` + `/bulk`) and uses the in-process listing cache.
- When disabled, routes return 404 and indexer listing bypasses cache.

## Changes
- Route gating: `/api/admin/indexer/*` mounts only when flag is `true`.
- Service gating: `listIndexerEvents` cache read/write only when flag is `true`.
- Job gating: `persistEscrowEvent` only invalidates `indexerCache` when flag is `true`.

## Verification
- `npm run lint`
- `npm test`
- `npm run build`

## Tests
- Added/updated unit + integration tests covering: flag on, flag off, and default.