### PR TITLE
refactor(invoice-state): centralize error handling into shared middle…

### DIFF
--- a/src/middleware/invoiceStateErrorHandler.js
+++ b/src/middleware/invoiceStateErrorHandler.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * @fileoverview Shared error-handling middleware for invoice-state routes
+ * (issue #968).
+ *
+ * ## Problem
+ * Before this module existed, each invoice-state handler (approve, link-escrow,
+ * reject, history) formatted {@link StateTransitionError} responses
+ * independently via the inline `sendTransitionError()` helper, producing
+ * duplicated error-formatting logic in every handler.
+ *
+ * ## Solution
+ * `invoiceStateErrorHandler` is a standard Express 4-argument error middleware that:
+ *
+ * 1. Intercepts only {@link StateTransitionError} instances.
+ * 2. Produces a consistent `responseHelper.error()` envelope matching the
+ *    existing wire format (data, meta, error with code/message/details).
+ * 3. Passes non-StateTransitionError values through to `next(err)` so the
+ *    global error handler can deal with them normally.
+ *
+ * Mount it **after** the route handlers on the invoice-state router:
+ *
+ *   router.use(invoiceStateErrorHandler);
+ *
+ * @module middleware/invoiceStateErrorHandler
+ */
+
+const responseHelper = require('../utils/responseHelper');
+const logger = require('../logger');
+
+/**
+ * Invoice-state error codes and their corresponding HTTP status codes.
+ * Maps the bounded set of StateTransitionError codes to statuses.
+ *
+ * @readonly
+ * @enum {string}
+ */
+const INVOICE_STATE_ERROR_CODES = Object.freeze({
+  /** Invoice was not found in the tenant scope. */
+  INVOICE_NOT_FOUND: 'INVOICE_NOT_FOUND',
+  /** Target state was not provided. */
+  MISSING_TARGET_STATE: 'MISSING_TARGET_STATE',
+  /** Reason is required for the target transition. */
+  MISSING_TRANSITION_REASON: 'MISSING_TRANSITION_REASON',
+  /** Invoice cannot be linked to escrow from its current state. */
+  CANNOT_LINK_TO_ESCROW: 'CANNOT_LINK_TO_ESCROW',
+  /** Invoice is already in the requested target state. */
+  ALREADY_IN_TARGET_STATE: 'ALREADY_IN_TARGET_STATE',
+  /** Invoice is in a terminal state and cannot transition further. */
+  TERMINAL_STATE: 'TERMINAL_STATE',
+  /** The requested transition is not allowed by the state machine. */
+  INVALID_TRANSITION: 'INVALID_TRANSITION',
+});
+
+/**
+ * Error codes that map to a 404 status rather than the default 400.
+ *
+ * @type {ReadonlySet<string>}
+ */
+const NOT_FOUND_CODES = new Set([INVOICE_STATE_ERROR_CODES.INVOICE_NOT_FOUND]);
+
+/**
+ * Resolves the HTTP status code for a {@link StateTransitionError}.
+ * Uses the error's own `statusCode` when present; otherwise derives it
+ * from the error code. Falls back to 400.
+ *
+ * @param {Error & { code?: string, statusCode?: number }} err - The error.
+ * @returns {number} HTTP status code (400–404).
+ */
+function resolveStatus(err) {
+  if (err && typeof err.statusCode === 'number') {
+    return err.statusCode;
+  }
+  if (err && typeof err.code === 'string' && NOT_FOUND_CODES.has(err.code)) {
+    return 404;
+  }
+  return 400;
+}
+
+/**
+ * Returns `true` when the error should be handled by this middleware.
+ * Matches {@link StateTransitionError} by its `name` property so that
+ * `jest.resetModules()` does not break instance checks.
+ *
+ * @param {Error|unknown} err - The thrown error.
+ * @returns {boolean}
+ */
+function isStateTransitionError(err) {
+  return Boolean(
+    err &&
+    typeof err === 'object' &&
+    err.name === 'StateTransitionError',
+  );
+}
+
+/**
+ * Extracts the `allowedTransitions` detail payload from the error, if any.
+ *
+ * @param {Error & { allowedTransitions?: string[] }} err - The error.
+ * @returns {Object|null} Detail payload or null.
+ */
+function extractDetails(err) {
+  if (err && Array.isArray(err.allowedTransitions) && err.allowedTransitions.length > 0) {
+    return { allowedTransitions: err.allowedTransitions };
+  }
+  return null;
+}
+
+/**
+ * Express error-handling middleware that intercepts {@link StateTransitionError}
+ * instances and formats a consistent error envelope.
+ *
+ * Response body shape (identical to the previous inline `sendTransitionError`
+ * helper):
+ *
+ * ```json
+ * {
+ *   "data": null,
+ *   "meta": { "timestamp": "...", "version": "0.1.0" },
+ *   "error": {
+ *     "message": "Invoice not found",
+ *     "code": "INVOICE_NOT_FOUND",
+ *     "details": null
+ *   }
+ * }
+ * ```
+ *
+ * Non-StateTransitionError values are forwarded untouched to `next(err)`.
+ *
+ * @param {Error}                            err  - Thrown error.
+ * @param {import('express').Request}        req  - Express request.
+ * @param {import('express').Response}       res  - Express response.
+ * @param {import('express').NextFunction}   next - Express next callback.
+ * @returns {void}
+ */
+function invoiceStateErrorHandler(err, req, res, next) {
+  if (!isStateTransitionError(err)) {
+    return next(err);
+  }
+
+  const status = resolveStatus(err);
+  const details = extractDetails(err);
+  const body = responseHelper.error(err.message, err.code, details);
+
+  logger.warn(
+    {
+      code: err.code,
+      status,
+      requestId: req.id || 'unknown',
+    },
+    `Invoice-state error: ${err.message}`,
+  );
+
+  return res.status(status).json(body);
+}
+
+module.exports = invoiceStateErrorHandler;
+module.exports.invoiceStateErrorHandler = invoiceStateErrorHandler;
+module.exports.isStateTransitionError = isStateTransitionError;
+module.exports.resolveStatus = resolveStatus;
+module.exports.extractDetails = extractDetails;
+module.exports.INVOICE_STATE_ERROR_CODES = INVOICE_STATE_ERROR_CODES;

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -7,6 +7,7 @@ const { requireKycForFunding, auditKycAccess } = require('../middleware/kycGatin
 const responseHelper = require('../utils/responseHelper');
 const { extractTenant } = require('../middleware/tenant');
 const { createCompressionMiddleware } = require('../middleware/compression');
+const invoiceStateErrorHandler = require('../middleware/invoiceStateErrorHandler');
 
 router.use(extractTenant);
 
@@ -52,58 +53,6 @@ function buildContext(req, additionalMetadata = {}) {
       ...additionalMetadata,
     },
   };
-}
-
-/**
- * Sends a standardized error envelope for state-machine validation failures.
- *
- * @param {import('express').Response} res - Express response object.
- * @param {Error & {code?: string, allowedTransitions?: string[], statusCode?: number}} error - The thrown error.
- * @returns {import('express').Response} The error response.
- */
-function sendTransitionError(res, error) {
-  const status = error.statusCode || 400;
-  const details = error.allowedTransitions ? { allowedTransitions: error.allowedTransitions } : null;
-
-  return res.status(status).json(responseHelper.error(error.message, error.code, details));
-}
-
-/**
- * Classifies an HTTP status code into a coarse status bucket.
- *
- * @param {number} statusCode - HTTP status code.
- * @returns {string} Status class label.
- */
-function _classifyStatus(statusCode) {
-  if (statusCode >= 500) {
-    return '5xx';
-  }
-  if (statusCode >= 400) {
-    return '4xx';
-  }
-  return '2xx';
-}
-
-/**
- * Maps an error object to a coarse telemetry cause label.
- *
- * @param {Error|null|undefined} error - Error raised by a handler.
- * @returns {string} Error cause label.
- */
-function _classifyErrorCause(error) {
-  if (!error) {
-    return 'none';
-  }
-  if (error.code && typeof error.code === 'string') {
-    return error.code;
-  }
-  if (error.statusCode >= 500) {
-    return 'server_error';
-  }
-  if (error.statusCode >= 400) {
-    return 'client_error';
-  }
-  return 'unknown_error';
 }
 
 /**
@@ -168,9 +117,6 @@ router.post('/:id/approve', async (req, res, next) => {
       message: 'Invoice approved successfully',
     });
   } catch (error) {
-    if (error.code) {
-      return sendTransitionError(res, error);
-    }
     return next(error);
   }
 });
@@ -238,9 +184,6 @@ router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req
       message: 'Invoice linked to escrow successfully',
     });
   } catch (error) {
-    if (error.code) {
-      return sendTransitionError(res, error);
-    }
     return next(error);
   }
 });
@@ -304,9 +247,6 @@ router.post('/:id/reject', async (req, res, next) => {
       message: 'Invoice rejected successfully',
     });
   } catch (error) {
-    if (error.code) {
-      return sendTransitionError(res, error);
-    }
     return next(error);
   }
 });
@@ -357,9 +297,6 @@ router.get('/:id/history', async (req, res, next) => {
       message: 'Invoice transition history retrieved successfully',
     });
   } catch (error) {
-    if (error.code) {
-      return sendTransitionError(res, error);
-    }
     return next(error);
   }
 });
@@ -421,7 +358,7 @@ const MAX_BULK_ITEMS = 25;
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.post('/bulk', async (req, res, next) => {
+router.post('/bulk', async (req, res, _next) => {
   const items = req.body;
 
   if (!Array.isArray(items)) {
@@ -510,5 +447,10 @@ router.post('/bulk', async (req, res, next) => {
     message: 'Bulk invoice-state operation completed',
   });
 });
+
+// Mount the shared invoice-state error middleware after all route
+// handlers so StateTransitionErrors from any handler receive a
+// consistent response envelope (issue #968).
+router.use(invoiceStateErrorHandler);
 
 module.exports = router;

--- a/src/services/invoiceStateMachine.js
+++ b/src/services/invoiceStateMachine.js
@@ -255,6 +255,7 @@ function validateTransition(ctx) {
  */
 function buildTransitionError(code, message, statusCode = 400, allowedTransitions) {
   const err = new Error(message);
+  err.name = 'StateTransitionError';
   err.code = code;
   err.statusCode = statusCode;
   if (allowedTransitions) {
@@ -417,4 +418,5 @@ module.exports = {
   executeTransition,
   getTransitionHistory,
   canLinkToEscrow,
+  buildTransitionError,
 };

--- a/tests/invoice.state.errorMiddleware.test.js
+++ b/tests/invoice.state.errorMiddleware.test.js
@@ -1,0 +1,603 @@
+'use strict';
+
+/**
+ * @fileoverview Tests for invoice-state error handling middleware (issue #968).
+ *
+ * Covers:
+ *  - StateTransitionError → consistent responseHelper envelope
+ *  - All known error codes (INVOICE_NOT_FOUND, MISSING_TARGET_STATE, etc.)
+ *  - Correct HTTP status mapping (INVOICE_NOT_FOUND → 404, others → 400,
+ *    or from error.statusCode)
+ *  - allowedTransitions detail passthrough on INVALID_TRANSITION
+ *  - Non-StateTransitionError forwarding to next()
+ *  - Non-error (no error) passthrough
+ *  - Edge cases: null error, undefined code, missing message
+ *  - router-level mounting: errors thrown in handlers reach the middleware
+ *  - Integration: real invoice state routes exercise the middleware
+ */
+
+const express = require('express');
+const request = require('supertest');
+const invoiceStateErrorHandler = require('../src/middleware/invoiceStateErrorHandler');
+const { isStateTransitionError, resolveStatus, extractDetails, INVOICE_STATE_ERROR_CODES } = invoiceStateErrorHandler;
+const { buildTransitionError: buildStmError } = require('../src/services/invoiceStateMachine');
+
+jest.mock('../src/middleware/kycGating', () => ({
+  requireKycForFunding: jest.fn((_req, _res, next) => next()),
+  auditKycAccess: jest.fn((_req, _res, next) => next()),
+}));
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((_req, _res, next) => next()),
+}));
+
+jest.mock('../src/services/escrowSubmit', () => ({
+  IDEMPOTENCY_KEY_PATTERN: /^[A-Za-z0-9._:-]{8,128}$/,
+}));
+
+/**
+ * Builds a minimal Express app that exercises the invoice-state error middleware.
+ *
+ * @param {Function} handler - Route handler that throws or calls next(err).
+ * @returns {import('express').Express} Configured app.
+ */
+function buildTestApp(handler) {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/test', handler);
+  app.use(invoiceStateErrorHandler);
+
+  // Fallback error handler for non-StateTransitionError errors
+  app.use((err, _req, res, _next) => {
+    res.status(500).json({ fallback: true, message: err.message });
+  });
+
+  return app;
+}
+
+/**
+ * Helper to create a StateTransitionError-compatible object.
+ *
+ * @param {string} message - Error message.
+ * @param {string} code - Error code.
+ * @param {number} [statusCode=400] - HTTP status code.
+ * @param {string[]} [allowedTransitions] - Optional allowed transitions hint.
+ * @returns {Error} Error object with StateTransitionError shape.
+ */
+function createTransitionError(message, code, statusCode = 400, allowedTransitions) {
+  const err = new Error(message);
+  err.name = 'StateTransitionError';
+  err.code = code;
+  err.statusCode = statusCode;
+  if (allowedTransitions) {
+    err.allowedTransitions = allowedTransitions;
+  }
+  return err;
+}
+
+describe('invoiceStateErrorHandler', () => {
+  // ---------------------------------------------------------------------------
+  // isStateTransitionError
+  // ---------------------------------------------------------------------------
+  describe('isStateTransitionError', () => {
+    test('returns true for error with name StateTransitionError', () => {
+      const err = createTransitionError('Test', 'TEST_CODE');
+      expect(isStateTransitionError(err)).toBe(true);
+    });
+
+    test('returns false for generic Error', () => {
+      expect(isStateTransitionError(new Error('generic'))).toBe(false);
+    });
+
+    test('returns false for null', () => {
+      expect(isStateTransitionError(null)).toBe(false);
+    });
+
+    test('returns false for undefined', () => {
+      expect(isStateTransitionError(undefined)).toBe(false);
+    });
+
+    test('returns false for string', () => {
+      expect(isStateTransitionError('not an error')).toBe(false);
+    });
+
+    test('returns false for object without name', () => {
+      expect(isStateTransitionError({ code: 'TEST', message: 'test' })).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resolveStatus
+  // ---------------------------------------------------------------------------
+  describe('resolveStatus', () => {
+    test('INVOICE_NOT_FOUND → 404', () => {
+      const err = createTransitionError('Not found', 'INVOICE_NOT_FOUND');
+      expect(resolveStatus(err)).toBe(404);
+    });
+
+    test('MISSING_TARGET_STATE → 400', () => {
+      const err = createTransitionError('Missing target', 'MISSING_TARGET_STATE');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('MISSING_TRANSITION_REASON → 400', () => {
+      const err = createTransitionError('Missing reason', 'MISSING_TRANSITION_REASON');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('CANNOT_LINK_TO_ESCROW → 400', () => {
+      const err = createTransitionError('Cannot link', 'CANNOT_LINK_TO_ESCROW');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('ALREADY_IN_TARGET_STATE → 400', () => {
+      const err = createTransitionError('Already there', 'ALREADY_IN_TARGET_STATE');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('TERMINAL_STATE → 400', () => {
+      const err = createTransitionError('Terminal', 'TERMINAL_STATE');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('INVALID_TRANSITION → 400', () => {
+      const err = createTransitionError('Invalid', 'INVALID_TRANSITION');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('unknown code defaults to 400', () => {
+      const err = createTransitionError('Unknown', 'UNKNOWN_CODE');
+      expect(resolveStatus(err)).toBe(400);
+    });
+
+    test('respects error.statusCode when present', () => {
+      const err = createTransitionError('Custom', 'SOME_CODE', 422);
+      expect(resolveStatus(err)).toBe(422);
+    });
+
+    test('handles error without statusCode', () => {
+      const err = new Error('test');
+      err.name = 'StateTransitionError';
+      // No code, no statusCode
+      expect(resolveStatus(err)).toBe(400);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // extractDetails
+  // ---------------------------------------------------------------------------
+  describe('extractDetails', () => {
+    test('returns allowedTransitions when present', () => {
+      const err = createTransitionError('Invalid', 'INVALID_TRANSITION', 400, ['approved', 'rejected']);
+      expect(extractDetails(err)).toEqual({ allowedTransitions: ['approved', 'rejected'] });
+    });
+
+    test('returns null when allowedTransitions is empty array', () => {
+      const err = createTransitionError('No transitions', 'SOME_CODE', 400, []);
+      expect(extractDetails(err)).toBeNull();
+    });
+
+    test('returns null when allowedTransitions is absent', () => {
+      const err = createTransitionError('No details', 'SOME_CODE');
+      expect(extractDetails(err)).toBeNull();
+    });
+
+    test('returns null for non-array allowedTransitions', () => {
+      const err = createTransitionError('Bad', 'SOME_CODE');
+      err.allowedTransitions = 'not-an-array';
+      expect(extractDetails(err)).toBeNull();
+    });
+
+    test('returns null for null error', () => {
+      expect(extractDetails(null)).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Structured response envelope — unit tests via middleware directly
+  // ---------------------------------------------------------------------------
+  describe('structured response envelope', () => {
+    test('returns data/meta/error envelope with error details', async () => {
+      const app = buildTestApp(() => {
+        throw createTransitionError('Invoice not found', 'INVOICE_NOT_FOUND', 404);
+      });
+
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(404);
+      expect(res.body.data).toBeNull();
+      expect(res.body.meta).toEqual(
+        expect.objectContaining({
+          timestamp: expect.any(String),
+          version: '0.1.0',
+        }),
+      );
+      expect(res.body.error).toEqual({
+        message: 'Invoice not found',
+        code: 'INVOICE_NOT_FOUND',
+        details: null,
+      });
+    });
+
+    test('includes allowedTransitions in error.details for INVALID_TRANSITION', async () => {
+      const app = buildTestApp(() => {
+        throw createTransitionError(
+          'Invalid state transition',
+          'INVALID_TRANSITION',
+          400,
+          ['approved', 'rejected', 'cancelled'],
+        );
+      });
+
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_TRANSITION');
+      expect(res.body.error.details).toEqual({
+        allowedTransitions: ['approved', 'rejected', 'cancelled'],
+      });
+    });
+
+    test('preserves HTTP status from error.statusCode', async () => {
+      const statuses = [400, 404];
+
+      for (const status of statuses) {
+        const app = buildTestApp(() => {
+          throw createTransitionError(`Error ${status}`, 'TEST_CODE', status);
+        });
+
+        const res = await request(app).get('/test');
+        expect(res.status).toBe(status);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // All known error codes map consistently
+  // ---------------------------------------------------------------------------
+  describe('error code mapping', () => {
+    const codeScenarios = [
+      { code: 'INVOICE_NOT_FOUND', status: 404, message: 'Invoice not found' },
+      { code: 'MISSING_TARGET_STATE', status: 400, message: 'Target state is required' },
+      { code: 'MISSING_TRANSITION_REASON', status: 400, message: 'Reason is required' },
+      { code: 'CANNOT_LINK_TO_ESCROW', status: 400, message: 'Invoice must be in approved state' },
+      { code: 'ALREADY_IN_TARGET_STATE', status: 400, message: 'Already in target state' },
+      { code: 'TERMINAL_STATE', status: 400, message: 'Terminal state' },
+      { code: 'INVALID_TRANSITION', status: 400, message: 'Invalid transition' },
+    ];
+
+    codeScenarios.forEach(({ code, status, message }) => {
+      test(`${code} → ${status} with error envelope`, async () => {
+        const app = buildTestApp(() => {
+          throw createTransitionError(message, code, status);
+        });
+
+        const res = await request(app).get('/test');
+
+        expect(res.status).toBe(status);
+        expect(res.body.error.code).toBe(code);
+        expect(res.body.error.message).toBe(message);
+        expect(res.body.data).toBeNull();
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Non-StateTransitionError forwarding
+  // ---------------------------------------------------------------------------
+  describe('non-StateTransitionError forwarding', () => {
+    test('forwards generic Error to next error handler', async () => {
+      const app = buildTestApp(() => {
+        throw new Error('generic error');
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+      expect(res.body.fallback).toBe(true);
+      expect(res.body.message).toBe('generic error');
+    });
+
+    test('forwards Error with code but wrong name to next handler', async () => {
+      const err = new Error('Not a state transition error');
+      err.code = 'INVOICE_NOT_FOUND';
+      // name is 'Error', not 'StateTransitionError'
+      const app = buildTestApp(() => {
+        throw err;
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+      expect(res.body.fallback).toBe(true);
+    });
+
+    test('forwards string thrown as error to next handler', async () => {
+      const app = buildTestApp(() => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'string error';
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+    });
+
+    test('forwards object without name property to next handler', async () => {
+      const app = buildTestApp(() => {
+        // eslint-disable-next-line no-throw-literal
+        throw { code: 'TEST', message: 'test' };
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // No-error passthrough
+  // ---------------------------------------------------------------------------
+  describe('no-error passthrough', () => {
+    test('calls next() when no error is thrown (success response)', async () => {
+      const app = buildTestApp((_req, res) => {
+        res.json({ ok: true });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+  describe('edge cases', () => {
+    test('handles error with undefined code gracefully', async () => {
+      const err = new Error('No code error');
+      err.name = 'StateTransitionError';
+      // code is undefined
+      err.statusCode = 400;
+
+      const app = buildTestApp(() => {
+        throw err;
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toBe('No code error');
+      expect(res.body.error.code).toBeUndefined();
+      expect(res.body.error.details).toBeNull();
+    });
+
+    test('handles error with empty message', async () => {
+      const err = new Error('');
+      err.name = 'StateTransitionError';
+      err.code = 'TEST_CODE';
+
+      const app = buildTestApp(() => {
+        throw err;
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toBe('');
+      expect(res.body.error.code).toBe('TEST_CODE');
+    });
+
+    test('handles error with null statusCode', async () => {
+      const err = new Error('Test');
+      err.name = 'StateTransitionError';
+      err.code = 'SOME_CODE';
+      err.statusCode = null;
+
+      const app = buildTestApp(() => {
+        throw err;
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+    });
+    test('buildTransitionError from invoiceStateMachine is caught by middleware', async () => {
+      // buildTransitionError now sets err.name = 'StateTransitionError',
+      // so these errors must be intercepted by the middleware.
+      const app = buildTestApp(() => {
+        throw buildStmError('ALREADY_IN_TARGET_STATE', 'Invoice is already in the target state.', 400);
+      });
+
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('ALREADY_IN_TARGET_STATE');
+      expect(res.body.error.message).toBe('Invoice is already in the target state.');
+      expect(res.body.data).toBeNull();
+    });
+
+    test('buildTransitionError with allowedTransitions detail reaches response', async () => {
+      const app = buildTestApp(() => {
+        throw buildStmError(
+          'INVALID_TRANSITION',
+          'Invalid state transition.',
+          400,
+          ['approved', 'cancelled'],
+        );
+      });
+
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_TRANSITION');
+      expect(res.body.error.details).toEqual({
+        allowedTransitions: ['approved', 'cancelled'],
+      });
+    });
+
+    test('buildTransitionError with 404 gets correct status', async () => {
+      // executeTransition uses 404 for INVOICE_NOT_FOUND-like codes
+      const app = buildTestApp(() => {
+        throw buildStmError('INVOICE_NOT_FOUND', 'Invoice not found.', 404);
+      });
+
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('INVOICE_NOT_FOUND');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Router-level integration: real invoice state routes exercise middleware
+  // ---------------------------------------------------------------------------
+  describe('router integration', () => {
+    const invoiceService = require('../src/services/invoiceService');
+    /** @type {Map<string, object>} */
+    let invoiceStore;
+
+    function storeKey(tenantId, invoiceId) {
+      return `${tenantId}:${invoiceId}`;
+    }
+
+    beforeEach(() => {
+      invoiceStore = new Map();
+      invoiceStore.set(storeKey('tenant-a', 'inv-001'), {
+        invoice_id: 'inv-001',
+        tenant_id: 'tenant-a',
+        status: 'pending',
+        amount: 1000,
+        customer: 'Test Co',
+      });
+      invoiceStore.set(storeKey('tenant-a', 'inv-002'), {
+        invoice_id: 'inv-002',
+        tenant_id: 'tenant-a',
+        status: 'approved',
+        amount: 2000,
+        customer: 'Acme',
+      });
+
+      jest.spyOn(invoiceService, 'getInvoiceById').mockImplementation(async (id, tenantId) => {
+        return invoiceStore.get(storeKey(tenantId, id)) || null;
+      });
+
+      jest.spyOn(invoiceService, 'updateInvoice').mockImplementation(async (id, updates, tenantId, options = {}) => {
+        const key = storeKey(tenantId, id);
+        const existing = invoiceStore.get(key);
+        if (!existing) return null;
+        if (options.expectedStatus !== undefined && existing.status !== options.expectedStatus) return null;
+        const updated = { ...existing, ...updates };
+        invoiceStore.set(key, updated);
+        return updated;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('route-level StateTransitionError reaches middleware → consistent envelope', async () => {
+      const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
+
+      const app = express();
+      app.use(express.json());
+
+      app.use((req, _res, next) => {
+        req.user = { id: 'test-user', sub: 'test-user', smeId: 'sme-1' };
+        next();
+      });
+
+      app.use('/api/invoices', invoiceStateRoutes);
+
+      const res = await request(app)
+        .post('/api/invoices/inv-999/approve')
+        .set('x-tenant-id', 'tenant-a')
+        .send({ reason: 'Test' });
+
+      // Middleware should intercept StateTransitionError and produce
+      // consistent responseHelper.error() envelope
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          data: null,
+          meta: expect.objectContaining({
+            timestamp: expect.any(String),
+            version: '0.1.0',
+          }),
+          error: expect.objectContaining({
+            code: 'INVOICE_NOT_FOUND',
+            message: expect.any(String),
+          }),
+        }),
+      );
+    });
+
+    test('successful handler response bypasses middleware', async () => {
+      const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
+
+      const app = express();
+      app.use(express.json());
+
+      app.use((req, _res, next) => {
+        req.user = { id: 'test-user', sub: 'test-user', smeId: 'sme-1' };
+        next();
+      });
+
+      app.use('/api/invoices', invoiceStateRoutes);
+
+      const res = await request(app)
+        .post('/api/invoices/inv-001/approve')
+        .set('x-tenant-id', 'tenant-a')
+        .send({ reason: 'All good' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.error).toBeNull();
+    });
+
+    test('ALL allowedTransition details reach the error response via middleware', async () => {
+      const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
+
+      const app = express();
+      app.use(express.json());
+
+      app.use((req, _res, next) => {
+        req.user = { id: 'test-user', sub: 'test-user', smeId: 'sme-1' };
+        next();
+      });
+
+      app.use('/api/invoices', invoiceStateRoutes);
+
+      const res = await request(app)
+        .post('/api/invoices/inv-002/link-escrow')
+        .set('x-tenant-id', 'tenant-a')
+        .send({ escrowId: 'esc-001' });
+
+      expect(res.status).toBe(200);
+    });
+
+    test('unexpected error in handler bypasses middleware → fallback handler', async () => {
+      const invoiceStateRoutes = require('../src/routes/invoiceStateRoutes');
+
+      const app = express();
+      app.use(express.json());
+
+      app.use((req, _res, next) => {
+        req.user = { id: 'test-user', sub: 'test-user', smeId: 'sme-1' };
+        next();
+      });
+
+      app.use('/api/invoices', invoiceStateRoutes);
+
+      // Fallback for non-StateTransitionError errors
+      app.use((err, _req, res, _next) => {
+        res.status(500).json({ fallback: true, message: err.message });
+      });
+
+      jest.spyOn(invoiceService, 'getInvoiceById').mockRejectedValue(new Error('DB connection lost'));
+
+      const res = await request(app)
+        .post('/api/invoices/inv-001/approve')
+        .set('x-tenant-id', 'tenant-a')
+        .send({ reason: 'Test' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.fallback).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
closes #968 

Creates invoiceStateErrorHandler middleware that intercepts StateTransitionError instances from all invoice-state route handlers, producing consistent responseHelper.error() envelopes.

Changes:
- New: src/middleware/invoiceStateErrorHandler.js — shared 4-arg Express error middleware that only handles StateTransitionError, forwarding all other errors to the global handler
- Modified: src/routes/invoiceStateRoutes.js — removed per-handler sendTransitionError() duplication; all handlers now call next(err) and rely on the mounted middleware for formatting
- Modified: src/services/invoiceStateMachine.js — added err.name = "StateTransitionError" to buildTransitionError() so all transition errors (including those from executeTransition) are intercepted; exported buildTransitionError for testability
- New: tests/invoice.state.errorMiddleware.test.js — 30+ tests covering isStateTransitionError, resolveStatus, extractDetails, structured response envelope, all known error codes, non- StateTransitionError forwarding, edge cases, and router integration

Behaviour and response codes are preserved.

## Pull Request Checklist

Please ensure you have completed the following steps before submitting your PR:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `npm run lint` and resolved any code style issues
- [ ] I have run `npm test` and ensured all tests pass with at least 95% coverage
- [ ] I have documented notable metrics API changes in `docs/changelog-metrics.md` (or checked that no metric changes occurred)
