### PR TITLE
feat(config): add CONFIG_RUNTIME_ENABLED feature flag

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,6 +41,15 @@ const ConfigSchema = z
     ESCROW_INDEXER_STALE_THRESHOLD_SECONDS: z.coerce.number().min(1).default(300),
     // Escrow read projection — gates the new projection/cache-based escrow read path
     ESCROW_READ_PROJECTION_ENABLED: z.enum(['true', 'false']).default('true'),
+    // Invoice state machine — gates /api/invoices state-transition endpoints.
+    // When 'false', the invoice state routes are not mounted so requests return 404.
+    // Defaults to 'true' (enabled) to preserve existing behaviour.
+    INVOICE_STATE_ENABLED: z.enum(['true', 'false']).default('true'),
+    // Runtime admin config surface — gates POST /api/admin/config and
+    // GET /api/admin/config/sections. When 'false' the router is not mounted
+    // so requests return 404, allowing the surface to be disabled without a
+    // deploy. Defaults to 'true' (enabled).
+    CONFIG_RUNTIME_ENABLED: z.enum(['true', 'false']).default('true'),
     // KYC provider — all optional, but URL+key must be provided together in non-test envs
     KYC_PROVIDER_URL: z.string().url().optional(),
     KYC_PROVIDER_API_KEY: z.string().min(1).optional(),

--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -260,5 +260,69 @@ describe('Config Validation', () => {
     process.env.ESCROW_INDEXER_ENABLED = 'yes';
     expect(() => validate()).toThrow();
   });
+
+  // ── CONFIG_RUNTIME_ENABLED flag ──────────────────────────────────────────
+
+  test('CONFIG_RUNTIME_ENABLED defaults to "true" (safe default — surface enabled)', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    const config = validate();
+    expect(config.CONFIG_RUNTIME_ENABLED).toBe('true');
+  });
+
+  test('CONFIG_RUNTIME_ENABLED accepts "true"', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.CONFIG_RUNTIME_ENABLED = 'true';
+    const config = validate();
+    expect(config.CONFIG_RUNTIME_ENABLED).toBe('true');
+  });
+
+  test('CONFIG_RUNTIME_ENABLED accepts "false" (disables /api/admin/config routes)', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.CONFIG_RUNTIME_ENABLED = 'false';
+    const config = validate();
+    expect(config.CONFIG_RUNTIME_ENABLED).toBe('false');
+  });
+
+  test('CONFIG_RUNTIME_ENABLED rejects truthy-but-not-"true" values', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    for (const val of ['1', 'yes', 'TRUE', 'enabled', 'on']) {
+      process.env.CONFIG_RUNTIME_ENABLED = val;
+      expect(() => validate()).toThrow();
+    }
+  });
+
+  test('CONFIG_RUNTIME_ENABLED rejects invalid value', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.CONFIG_RUNTIME_ENABLED = 'invalid';
+    expect(() => validate()).toThrow();
+  });
+
+  // ── INVOICE_STATE_ENABLED flag ───────────────────────────────────────────
+
+  test('INVOICE_STATE_ENABLED defaults to "true" (safe default — routes enabled)', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    const config = validate();
+    expect(config.INVOICE_STATE_ENABLED).toBe('true');
+  });
+
+  test('INVOICE_STATE_ENABLED accepts "true"', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.INVOICE_STATE_ENABLED = 'true';
+    const config = validate();
+    expect(config.INVOICE_STATE_ENABLED).toBe('true');
+  });
+
+  test('INVOICE_STATE_ENABLED accepts "false"', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.INVOICE_STATE_ENABLED = 'false';
+    const config = validate();
+    expect(config.INVOICE_STATE_ENABLED).toBe('false');
+  });
+
+  test('INVOICE_STATE_ENABLED rejects invalid value', () => {
+    process.env.JWT_SECRET = '0123456789abcdef0123456789abcdef';
+    process.env.INVOICE_STATE_ENABLED = 'yes';
+    expect(() => validate()).toThrow();
+  });
 });
 


### PR DESCRIPTION
Add CONFIG_RUNTIME_ENABLED and INVOICE_STATE_ENABLED to the Zod config schema in src/config/index.js.

Both flags were already consumed by src/app.js via getConfig() to conditionally mount their respective routers, but were not validated at startup — meaning typos or invalid values were silently ignored rather than failing fast at boot.

Changes:
- src/config/index.js: add CONFIG_RUNTIME_ENABLED (default 'true') and INVOICE_STATE_ENABLED (default 'true') to ConfigSchema using the same z.enum(['true','false']) pattern as ESCROW_INDEXER_ENABLED and ESCROW_READ_PROJECTION_ENABLED.
- src/config/index.test.js: add schema-level tests for both flags covering default value, 'true', 'false', and invalid/truthy-but- not-'true' values.

Resolves: config-42

## Pull Request Checklist

Please ensure you have completed the following steps before submitting your PR:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `npm run lint` and resolved any code style issues
- [ ] I have run `npm test` and ensured all tests pass with at least 95% coverage
- [ ] I have documented notable metrics API changes in `docs/changelog-metrics.md` (or checked that no metric changes occurred)
- [ ] closes #923
