### PR TITLE
feat: implement robust input validation and schema hardening for SME …

### DIFF
--- a/docs/changelog-metrics.md
+++ b/docs/changelog-metrics.md
@@ -5,6 +5,43 @@ This document tracks all notable changes to the metrics API endpoints, data sche
 > **⚠️ Contribution Policy:** 
 > Any Pull Request (PR) that alters, introduces, deprecates, or removes any metrics API endpoint or data payload MUST append a corresponding entry to this file before it can be merged.
 
+## - SME Metrics Request Input Validation
+
+### Added
+- Machine-readable error codes on all SME metrics validation failures. Failure
+  responses now carry a top-level `code` of `METRICS_VALIDATION_ERROR` plus a
+  `fieldCodes` map that mirrors `fieldErrors` but holds stable codes drawn from
+  the new `METRICS_VALIDATION_CODES` taxonomy (`FIELD_REQUIRED`,
+  `FIELD_TYPE_INVALID`, `FIELD_TOO_SHORT`, `FIELD_TOO_LONG`,
+  `VALUE_BELOW_MINIMUM`, `VALUE_ABOVE_MAXIMUM`, `VALUE_NOT_INTEGER`,
+  `ARRAY_TOO_SMALL`, `ARRAY_TOO_LARGE`, `UNKNOWN_FIELD`,
+  `FIELD_FORMAT_INVALID`, `FIELD_INVALID`).
+- Length bound on the `cursor` query param for `GET /api/sme/metrics`
+  (max 512 characters); previously unbounded.
+- New module `src/constants/metricsValidationCodes.js` defining the taxonomy and
+  the Zod-issue-to-code mapping.
+- See [metrics-validation.md](./metrics-validation.md) for the full contract.
+
+### Changed
+- **Breaking (error responses only):** `limit` on `GET /api/sme/metrics` is now
+  validated instead of silently repaired. Previously `limit=999` was clamped to
+  100, `limit=abc` was ignored (falling back to the default page size), and
+  `limit=0`/`limit=-5` were clamped into range — all returning `200`. These now
+  return a structured `400`. Successful requests with an in-range integer
+  `limit` (1–100) are unaffected, as are requests that omit `limit`.
+  This aligns the SME metrics route with the pre-existing behaviour of the
+  indexer query schema.
+- `limit` must now be a bare integer: `20abc`, `1e5`, `10.5`, `0x10` and
+  whitespace-only values are rejected rather than partially parsed.
+
+### Unchanged
+- `type`, `title`, `status`, `detail` and `fieldErrors` keep their previous
+  values and shapes on `POST /api/sme/metrics/bulk`, so existing clients that
+  read only those fields are unaffected.
+- Unknown query parameters continue to be stripped (not rejected).
+- The 25-operation bulk cap and the 128-character `tenantId`/`userId` bounds are
+  unchanged in value; they are now reported with explicit codes.
+
 ## - Indexer Metrics & Regression Testing
 
 ### Added

--- a/docs/metrics-validation.md
+++ b/docs/metrics-validation.md
@@ -1,0 +1,127 @@
+# Metrics Request Input Validation
+
+How the SME metrics endpoints validate and bound incoming request data, and what
+a client receives when validation fails.
+
+- Schemas: [`src/schemas/metrics.js`](../src/schemas/metrics.js)
+- Error codes: [`src/constants/metricsValidationCodes.js`](../src/constants/metricsValidationCodes.js)
+- Routes: [`src/routes/sme/metrics.js`](../src/routes/sme/metrics.js)
+
+## Design rule
+
+**Reject, don't repair.** Validation runs in middleware ahead of every handler,
+so a malformed payload never reaches `invoiceService` or the database. Where the
+old code quietly substituted a value for bad input — clamping an oversized
+`limit`, or dropping a non-numeric one — it now returns a structured `400`. A
+silently repaired request is indistinguishable from a correct one to the caller,
+which hides client bugs and makes a request's effective parameters unauditable.
+
+The one deliberate exception is **unknown query parameters**, which are stripped
+rather than rejected: proxies, load balancers and analytics tooling routinely
+append their own (`utm_source`, and similar), and rejecting them would break
+legitimate traffic. Unknown fields in a request *body* are rejected, because
+nothing appends to a JSON body in transit.
+
+## Bounds
+
+| Endpoint | Field | Type | Bound |
+| --- | --- | --- | --- |
+| `GET /api/sme/metrics` | `cursor` | string, optional | 1–512 chars (trimmed) |
+| `GET /api/sme/metrics` | `limit` | integer string, optional | 1–100 inclusive |
+| `POST /api/sme/metrics/bulk` | `operations` | array, required | 1–25 items |
+| `POST /api/sme/metrics/bulk` | `operations[].tenantId` | string, required | 1–128 chars (trimmed) |
+| `POST /api/sme/metrics/bulk` | `operations[].userId` | string, required | 1–128 chars (trimmed) |
+
+Bounds are exported as constants (`GET_METRICS_LIMIT_MIN`,
+`GET_METRICS_LIMIT_MAX`, `GET_METRICS_CURSOR_MAX_LENGTH`,
+`MAX_BULK_OPERATIONS`, `BULK_METRICS_ID_MAX_LENGTH`) so tests and callers assert
+against the same source as the schema.
+
+Lengths are measured **after** trimming, so surrounding whitespace does not
+consume a field's budget. Type coercion is off: `tenantId: 123` is a type error,
+not the string `"123"`.
+
+`limit` must be a bare, optionally-signed integer. A regex gate (`/^-?\d+$/`)
+runs before numeric parsing, so `20abc`, `1e5`, `10.5`, `0x10`, `Infinity` and
+whitespace-only values are all rejected — `parseInt` would have accepted the
+first two and `Number` the fourth.
+
+## Failure response
+
+Validation failures are RFC 7807 `problem+json` documents:
+
+```json
+{
+  "type": "https://liquifact.io/problems/validation-error",
+  "title": "Validation Error",
+  "status": 400,
+  "detail": "Request body contains invalid or missing fields.",
+  "code": "METRICS_VALIDATION_ERROR",
+  "fieldErrors": {
+    "operations.0.userId": ["userId must not exceed 128 characters"]
+  },
+  "fieldCodes": {
+    "operations.0.userId": ["FIELD_TOO_LONG"]
+  }
+}
+```
+
+`fieldErrors` and `fieldCodes` share the same keys — a dotted path to the
+offending field, so array items are addressable (`operations.2.tenantId`).
+Unknown-key issues are expanded to one entry per offending key, so the response
+names *which* field was rejected rather than only its parent object.
+
+### Why both maps
+
+`fieldErrors` carries human-readable messages whose wording is free to change.
+`fieldCodes` carries stable codes. Clients should branch on codes; messages are
+for display and logs. Before this, distinguishing "wrong type" from "too long"
+required string-matching a message, which breaks silently on any rewording.
+
+### Codes
+
+| Code | Meaning |
+| --- | --- |
+| `FIELD_REQUIRED` | Required field absent or `undefined` |
+| `FIELD_TYPE_INVALID` | Present but wrong JSON type |
+| `FIELD_TOO_SHORT` | String below minimum length (includes empty/whitespace-only) |
+| `FIELD_TOO_LONG` | String above maximum length |
+| `VALUE_BELOW_MINIMUM` | Number below its minimum |
+| `VALUE_ABOVE_MAXIMUM` | Number above its maximum |
+| `VALUE_NOT_INTEGER` | Non-integer where an integer is required |
+| `ARRAY_TOO_SMALL` | Array below minimum item count |
+| `ARRAY_TOO_LARGE` | Array above maximum item count |
+| `UNKNOWN_FIELD` | Field not declared in the schema |
+| `FIELD_FORMAT_INVALID` | String failed a format/pattern check |
+| `FIELD_INVALID` | Fallback for anything not covered above |
+
+The top-level `code` is always `METRICS_VALIDATION_ERROR`; the table above lists
+per-field codes. Array and string size failures map to distinct codes, so a
+26-item `operations` array (`ARRAY_TOO_LARGE`) is never confused with a
+129-character id (`FIELD_TOO_LONG`).
+
+Codes are a bounded, frozen set. A schema raising a custom Zod issue can name
+its own code via `params.metricsCode`, but an unrecognised value is discarded
+and falls back to normal classification, so a typo cannot reach the wire.
+
+## Status codes
+
+`400` for validation failures, from both the body and query validators. Note
+that `src/middleware/metricsErrorHandler.js` maps its own
+`VALIDATION_ERROR` code to `422`; that handler covers a different set of
+metrics routes and is not in this path. The SME metrics validators return `400`,
+matching the documented Swagger contract and the pre-existing behaviour.
+
+## Tests
+
+| File | Scope |
+| --- | --- |
+| [`tests/unit/metricsValidationCodes.test.js`](../tests/unit/metricsValidationCodes.test.js) | Zod-issue-to-code mapping, both Zod 3 (`type`) and Zod 4 (`origin`) size spellings, fallbacks |
+| [`tests/unit/metrics.inputHardening.test.js`](../tests/unit/metrics.inputHardening.test.js) | Bounds at exact boundaries, wrong types, unknown fields, `fieldCodes` assembly |
+| [`tests/sme.metrics.validation.test.js`](../tests/sme.metrics.validation.test.js) | End-to-end HTTP behaviour, plus assertions that the store is never queried on invalid input |
+| [`tests/unit/metrics.schema.test.js`](../tests/unit/metrics.schema.test.js) | Pre-existing schema surface (updated for the new `limit` semantics) |
+| [`tests/sme.metrics.test.js`](../tests/sme.metrics.test.js) | Pre-existing route behaviour (updated for the new `limit` semantics) |
+
+Boundary coverage is symmetric: each bound is tested at the last accepted value
+and the first rejected one (128/129 chars, 512/513 chars, 1 and 100 for `limit`,
+25/26 operations).

--- a/package.json
+++ b/package.json
@@ -107,6 +107,12 @@
         "functions": 95,
         "lines": 95,
         "statements": 95
+      },
+      "src/constants/metricsValidationCodes.js": {
+        "branches": 95,
+        "functions": 95,
+        "lines": 95,
+        "statements": 95
       }
     }
   },

--- a/src/constants/metricsValidationCodes.js
+++ b/src/constants/metricsValidationCodes.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * @fileoverview Machine-readable error codes for metrics request validation.
+ *
+ * ## Why this exists
+ * Before this module, a metrics validation failure returned only human-readable
+ * strings in `fieldErrors` (e.g. `"tenantId must not exceed 128 characters"`).
+ * Clients that wanted to react differently to a *type* error than to a *range*
+ * error had to string-match those messages, which silently breaks whenever the
+ * wording changes.
+ *
+ * Every metrics validation failure now carries a stable code from
+ * {@link METRICS_VALIDATION_CODES}, both at the top level of the problem
+ * document (`code`) and per-field (`fieldCodes`). Message wording remains free
+ * to change; the codes are the contract.
+ *
+ * @module constants/metricsValidationCodes
+ */
+
+/**
+ * Bounded set of per-issue validation codes.
+ *
+ * These describe *why a specific field failed*, and are reported in the
+ * `fieldCodes` extension of the problem document.
+ *
+ * @readonly
+ * @enum {string}
+ */
+const METRICS_VALIDATION_CODES = Object.freeze({
+  /** A required field was absent or `undefined`. */
+  FIELD_REQUIRED: 'FIELD_REQUIRED',
+  /** The field was present but of the wrong JSON type. */
+  FIELD_TYPE_INVALID: 'FIELD_TYPE_INVALID',
+  /** A string was shorter than the allowed minimum (includes empty strings). */
+  FIELD_TOO_SHORT: 'FIELD_TOO_SHORT',
+  /** A string exceeded its maximum allowed length. */
+  FIELD_TOO_LONG: 'FIELD_TOO_LONG',
+  /** A numeric value fell below the allowed minimum. */
+  VALUE_BELOW_MINIMUM: 'VALUE_BELOW_MINIMUM',
+  /** A numeric value exceeded the allowed maximum. */
+  VALUE_ABOVE_MAXIMUM: 'VALUE_ABOVE_MAXIMUM',
+  /** A numeric value was not an integer where one was required. */
+  VALUE_NOT_INTEGER: 'VALUE_NOT_INTEGER',
+  /** An array had fewer items than the allowed minimum. */
+  ARRAY_TOO_SMALL: 'ARRAY_TOO_SMALL',
+  /** An array exceeded the allowed maximum item count. */
+  ARRAY_TOO_LARGE: 'ARRAY_TOO_LARGE',
+  /** The payload contained a field not declared in the schema. */
+  UNKNOWN_FIELD: 'UNKNOWN_FIELD',
+  /** A string did not match its required format/pattern. */
+  FIELD_FORMAT_INVALID: 'FIELD_FORMAT_INVALID',
+  /** Fallback for any issue not covered by a more specific code. */
+  FIELD_INVALID: 'FIELD_INVALID',
+});
+
+/**
+ * Top-level `code` used on the problem document for a metrics validation
+ * failure. Distinct from the per-field codes above.
+ *
+ * @type {string}
+ */
+const METRICS_VALIDATION_ERROR_CODE = 'METRICS_VALIDATION_ERROR';
+
+/**
+ * Fast membership set over {@link METRICS_VALIDATION_CODES} values, used to
+ * validate a schema-declared `params.metricsCode` before trusting it.
+ *
+ * @type {Set<string>}
+ */
+const KNOWN_CODES = new Set(Object.values(METRICS_VALIDATION_CODES));
+
+/**
+ * Problem type URI for metrics validation failures.
+ *
+ * Kept identical to the pre-existing value so the wire format of `type` does
+ * not change for current clients.
+ *
+ * @type {string}
+ */
+const METRICS_VALIDATION_PROBLEM_TYPE =
+  'https://liquifact.io/problems/validation-error';
+
+/**
+ * Maps a Zod issue to a stable {@link METRICS_VALIDATION_CODES} member.
+ *
+ * A schema raising a `custom` issue may declare its own code through
+ * `params.metricsCode`; it is honoured only when it names a known code, so a
+ * typo degrades to the normal classification rather than reaching the wire.
+ *
+ * Zod reports a missing field as an `invalid_type` issue whose `received` is
+ * `'undefined'`, so that case is disambiguated into `FIELD_REQUIRED` before the
+ * generic type branch. `too_small` / `too_big` are split by `origin` (Zod 4) or
+ * `type` (Zod 3) so a 26-item array does not report the same code as a
+ * 129-character string.
+ *
+ * @param {object} issue - A single issue from a `ZodError`.
+ * @returns {string} A member of {@link METRICS_VALIDATION_CODES}.
+ */
+function codeForIssue(issue) {
+  if (!issue || typeof issue !== 'object') {
+    return METRICS_VALIDATION_CODES.FIELD_INVALID;
+  }
+
+  // A schema that raises a `custom` issue can name its own code via
+  // `params.metricsCode`, so hand-rolled refinements are not flattened into the
+  // generic FIELD_INVALID bucket.
+  const declared = issue.params && issue.params.metricsCode;
+  if (typeof declared === 'string' && KNOWN_CODES.has(declared)) {
+    return declared;
+  }
+
+  // Zod 4 renamed `type` to `origin` on size issues; support both.
+  const origin = issue.origin || issue.type;
+
+  switch (issue.code) {
+    case 'invalid_type':
+      return issue.received === 'undefined' || issue.input === undefined
+        ? METRICS_VALIDATION_CODES.FIELD_REQUIRED
+        : METRICS_VALIDATION_CODES.FIELD_TYPE_INVALID;
+
+    case 'unrecognized_keys':
+      return METRICS_VALIDATION_CODES.UNKNOWN_FIELD;
+
+    case 'too_small':
+      if (origin === 'array' || origin === 'set') {
+        return METRICS_VALIDATION_CODES.ARRAY_TOO_SMALL;
+      }
+      if (origin === 'number' || origin === 'int' || origin === 'bigint') {
+        return METRICS_VALIDATION_CODES.VALUE_BELOW_MINIMUM;
+      }
+      return METRICS_VALIDATION_CODES.FIELD_TOO_SHORT;
+
+    case 'too_big':
+      if (origin === 'array' || origin === 'set') {
+        return METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE;
+      }
+      if (origin === 'number' || origin === 'int' || origin === 'bigint') {
+        return METRICS_VALIDATION_CODES.VALUE_ABOVE_MAXIMUM;
+      }
+      return METRICS_VALIDATION_CODES.FIELD_TOO_LONG;
+
+    case 'not_multiple_of':
+      return METRICS_VALIDATION_CODES.VALUE_NOT_INTEGER;
+
+    case 'invalid_format':
+    case 'invalid_string':
+      return METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID;
+
+    default:
+      return METRICS_VALIDATION_CODES.FIELD_INVALID;
+  }
+}
+
+module.exports = {
+  METRICS_VALIDATION_CODES,
+  METRICS_VALIDATION_ERROR_CODE,
+  METRICS_VALIDATION_PROBLEM_TYPE,
+  codeForIssue,
+};

--- a/src/routes/sme/metrics.js
+++ b/src/routes/sme/metrics.js
@@ -69,7 +69,11 @@ const {
  *         name: cursor
  *         schema:
  *           type: string
- *         description: Opaque cursor from the previous page's `nextCursor` field.
+ *           minLength: 1
+ *           maxLength: 512
+ *         description: |
+ *           Opaque cursor from the previous page's `nextCursor` field.
+ *           Rejected with `400` when empty or longer than 512 characters.
  *       - in: query
  *         name: limit
  *         schema:
@@ -77,7 +81,10 @@ const {
  *           minimum: 1
  *           maximum: 100
  *           default: 20
- *         description: Items per page (1–100, default 20).
+ *         description: |
+ *           Items per page (1–100, default 20). Must be a bare integer.
+ *           Non-integer (`abc`, `1e5`, `20abc`) or out-of-range (`0`, `101`)
+ *           values are rejected with `400` rather than silently clamped.
  *     responses:
  *       200:
  *         description: Metrics retrieved successfully
@@ -134,7 +141,11 @@ const {
  *                   type: string
  *                   format: date-time
  *       400:
- *         description: Bad Request — missing tenant context, invalid cursor, or invalid query params
+ *         description: |
+ *           Bad Request — missing tenant context, invalid cursor, or invalid
+ *           query params. Query-validation failures are returned as an RFC 7807
+ *           problem document carrying `code: METRICS_VALIDATION_ERROR` and a
+ *           `fieldErrors` map keyed by parameter name.
  *       401:
  *         description: Unauthorized
  */
@@ -153,17 +164,13 @@ router.get(
       const rawMetrics = await invoiceService.getSmeInvoiceCounts(tenantId, userId);
       const data = toSmeMetricsResponse(rawMetrics);
 
-      // Prefer schema-validated (and coerced) query values; fall back to raw
-      // query strings to preserve backward compatibility.
+      // Only schema-validated query values are consumed here. `validateGetMetricsQuery`
+      // runs ahead of this handler and rejects the request outright on malformed
+      // input, so an unvalidated raw query string can never reach the store.
       const validatedQuery = req.validatedQuery || {};
-      const cursor =
-        validatedQuery.cursor !== undefined
-          ? validatedQuery.cursor
-          : req.query.cursor;
+      const { cursor } = validatedQuery;
       const limit =
-        validatedQuery.limit !== undefined
-          ? String(validatedQuery.limit)
-          : req.query.limit;
+        validatedQuery.limit !== undefined ? String(validatedQuery.limit) : undefined;
 
       const usePagination = cursor !== undefined || limit !== undefined;
 
@@ -245,6 +252,7 @@ router.get(
  *           schema:
  *             type: object
  *             required: [operations]
+ *             additionalProperties: false
  *             properties:
  *               operations:
  *                 type: array
@@ -252,13 +260,16 @@ router.get(
  *                 minItems: 1
  *                 items:
  *                   type: object
+ *                   additionalProperties: false
  *                   required: [tenantId, userId]
  *                   properties:
  *                     tenantId:
  *                       type: string
+ *                       minLength: 1
  *                       maxLength: 128
  *                     userId:
  *                       type: string
+ *                       minLength: 1
  *                       maxLength: 128
  *     responses:
  *       200:
@@ -298,7 +309,44 @@ router.get(
  *                     timestamp:
  *                       type: string
  *       400:
- *         description: Validation error (empty array, over-cap, missing fields)
+ *         description: |
+ *           Validation error — empty or over-cap `operations` array, missing or
+ *           wrongly-typed `tenantId`/`userId`, an ID longer than 128 characters,
+ *           or any unknown field at either level.
+ *
+ *           Returned as an RFC 7807 problem document with a machine-readable
+ *           `code` of `METRICS_VALIDATION_ERROR`, a `fieldErrors` map of
+ *           human-readable messages, and a parallel `fieldCodes` map of stable
+ *           per-field codes (`FIELD_REQUIRED`, `FIELD_TYPE_INVALID`,
+ *           `FIELD_TOO_LONG`, `ARRAY_TOO_LARGE`, `UNKNOWN_FIELD`, …).
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 type:
+ *                   type: string
+ *                 title:
+ *                   type: string
+ *                 status:
+ *                   type: integer
+ *                 detail:
+ *                   type: string
+ *                 code:
+ *                   type: string
+ *                   example: METRICS_VALIDATION_ERROR
+ *                 fieldErrors:
+ *                   type: object
+ *                   additionalProperties:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                 fieldCodes:
+ *                   type: object
+ *                   additionalProperties:
+ *                     type: array
+ *                     items:
+ *                       type: string
  *       401:
  *         description: Unauthorized
  *       409:

--- a/src/schemas/metrics.js
+++ b/src/schemas/metrics.js
@@ -28,11 +28,27 @@
  * - `validateSmeMetricsApiResponse` — validate a GET response against the schema
  * - `validateBulkMetricsResponse`   — validate a bulk response against the schema
  *
+ * ## Input hardening
+ * Every metrics write/read boundary rejects, rather than silently repairs,
+ * malformed input:
+ *  - unknown fields are rejected on bodies (`.strict()`) and stripped on query
+ *    params (`.strip()`);
+ *  - all strings are length-bounded (`tenantId`/`userId` ≤ 128, `cursor` ≤ 512);
+ *  - all numbers are range-bounded (`limit` 1–100, integers only);
+ *  - failures carry a machine-readable `code` plus per-field `fieldCodes` drawn
+ *    from `METRICS_VALIDATION_CODES`, so clients never string-match messages.
+ *
  * @module schemas/metrics
  */
 
 const { z } = require('zod');
 const { createQueryValidator } = require('./validationHelper');
+const {
+  METRICS_VALIDATION_CODES,
+  METRICS_VALIDATION_ERROR_CODE,
+  METRICS_VALIDATION_PROBLEM_TYPE,
+  codeForIssue,
+} = require('../constants/metricsValidationCodes');
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -45,42 +61,82 @@ const GET_METRICS_LIMIT_MIN = 1;
 /** Maximum allowed `limit` query param for paginated GET requests. */
 const GET_METRICS_LIMIT_MAX = 100;
 
+/**
+ * Maximum accepted length of the opaque `cursor` query param.
+ *
+ * Cursors this service issues are far shorter; the bound exists so an
+ * arbitrarily long attacker-supplied string is rejected at the boundary
+ * instead of being handed to the cursor decoder.
+ */
+const GET_METRICS_CURSOR_MAX_LENGTH = 512;
+
+/** Maximum accepted length of `tenantId` / `userId` in a bulk operation. */
+const BULK_METRICS_ID_MAX_LENGTH = 128;
+
 // ── Request schemas ──────────────────────────────────────────────────────────
 
 /**
  * Query-parameter schema for `GET /api/sme/metrics`.
  *
  * Both `cursor` and `limit` are optional.
- *  - `cursor` — opaque pagination cursor; non-empty when present.
- *  - `limit`  — coerced from raw query string to an integer clamped 1–100.
- *               Non-numeric or absent values yield `undefined` (no error).
+ *  - `cursor` — opaque pagination cursor; non-empty and at most
+ *    {@link GET_METRICS_CURSOR_MAX_LENGTH} characters when present.
+ *  - `limit`  — parsed from the raw query string to an integer that must lie
+ *    within 1–100 inclusive. Absent values yield `undefined` (no error).
  *
- * Unknown query parameters are stripped via `.strip()`.
+ * ### Rejected rather than coerced
+ * A malformed or out-of-range `limit` is now a hard `400`. Previously
+ * `limit=abc` was silently treated as absent and `limit=9999` was silently
+ * clamped to 100, which meant a caller could not tell that the value they sent
+ * had been discarded. Both now surface a structured error with a machine-
+ * readable code so the mistake is visible at the boundary.
+ *
+ * Unknown query parameters are stripped via `.strip()` (they are ignored, not
+ * rejected, because proxies and analytics tooling routinely append their own).
  *
  * @type {z.ZodObject}
  */
 const getMetricsQuerySchema = z
   .object({
     cursor: z
-      .string()
+      .string({ message: 'cursor must be a string' })
       .trim()
       .min(1, { message: 'cursor must not be empty when provided' })
+      .max(GET_METRICS_CURSOR_MAX_LENGTH, {
+        message: `cursor must not exceed ${GET_METRICS_CURSOR_MAX_LENGTH} characters`,
+      })
       .optional(),
     limit: z
-      .string()
+      .string({ message: 'limit must be a string' })
       .optional()
-      .transform((val) => {
+      .transform((val, ctx) => {
         if (val === undefined) { return undefined; }
-        const parsed = parseInt(val, 10);
-        if (isNaN(parsed)) { return undefined; }
-        return Math.min(Math.max(parsed, GET_METRICS_LIMIT_MIN), GET_METRICS_LIMIT_MAX);
+
+        const trimmed = val.trim();
+        // Reject anything that is not a bare, optionally-signed integer.
+        // `parseInt` alone would accept '20abc' and '1e5'; `Number` would
+        // accept '0x10' and ' '.
+        if (!/^-?\d+$/.test(trimmed)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            params: { metricsCode: METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID },
+            message: `limit must be an integer between ${GET_METRICS_LIMIT_MIN} and ${GET_METRICS_LIMIT_MAX}`,
+          });
+          return z.NEVER;
+        }
+
+        return Number(trimmed);
       })
       .pipe(
         z
           .number()
-          .int()
-          .min(GET_METRICS_LIMIT_MIN)
-          .max(GET_METRICS_LIMIT_MAX)
+          .int({ message: 'limit must be an integer' })
+          .min(GET_METRICS_LIMIT_MIN, {
+            message: `limit must be at least ${GET_METRICS_LIMIT_MIN}`,
+          })
+          .max(GET_METRICS_LIMIT_MAX, {
+            message: `limit must not exceed ${GET_METRICS_LIMIT_MAX}`,
+          })
           .optional()
       ),
   })
@@ -97,12 +153,16 @@ const bulkMetricsOperationSchema = z
       .string({ message: 'tenantId is required' })
       .trim()
       .min(1, { message: 'tenantId must not be empty' })
-      .max(128, { message: 'tenantId must not exceed 128 characters' }),
+      .max(BULK_METRICS_ID_MAX_LENGTH, {
+        message: `tenantId must not exceed ${BULK_METRICS_ID_MAX_LENGTH} characters`,
+      }),
     userId: z
       .string({ message: 'userId is required' })
       .trim()
       .min(1, { message: 'userId must not be empty' })
-      .max(128, { message: 'userId must not exceed 128 characters' }),
+      .max(BULK_METRICS_ID_MAX_LENGTH, {
+        message: `userId must not exceed ${BULK_METRICS_ID_MAX_LENGTH} characters`,
+      }),
   })
   .strict();
 
@@ -231,6 +291,48 @@ function parseValidationErrors(zodError) {
   return fieldErrors;
 }
 
+/**
+ * Maps a Zod `ZodError` to a field-keyed map of machine-readable codes.
+ *
+ * Mirrors the shape of {@link parseValidationErrors} — same keys, same
+ * ordering — but each entry holds stable {@link METRICS_VALIDATION_CODES}
+ * members instead of human-readable messages, so clients can branch on the
+ * failure kind without string-matching wording that is free to change.
+ *
+ * Unknown-key issues are additionally expanded so each offending key gets its
+ * own entry (Zod reports them as one issue on the parent object, which would
+ * otherwise hide *which* field was rejected).
+ *
+ * @param {z.ZodError} zodError
+ * @returns {Object<string, string[]>}
+ */
+function parseValidationFieldCodes(zodError) {
+  const fieldCodes = {};
+
+  const push = (path, code) => {
+    if (!fieldCodes[path]) {
+      fieldCodes[path] = [];
+    }
+    if (!fieldCodes[path].includes(code)) {
+      fieldCodes[path].push(code);
+    }
+  };
+
+  for (const issue of zodError.issues) {
+    const path = issue.path.join('.');
+    push(path, codeForIssue(issue));
+
+    // Surface each unrecognised key individually, e.g. `operations.0.extra`.
+    if (issue.code === 'unrecognized_keys' && Array.isArray(issue.keys)) {
+      for (const key of issue.keys) {
+        push(path ? `${path}.${key}` : key, METRICS_VALIDATION_CODES.UNKNOWN_FIELD);
+      }
+    }
+  }
+
+  return fieldCodes;
+}
+
 // ── Middleware ───────────────────────────────────────────────────────────────
 
 /**
@@ -244,6 +346,7 @@ function parseValidationErrors(zodError) {
 const validateGetMetricsQuery = createQueryValidator(getMetricsQuerySchema, {
   title: 'Invalid Query Parameters',
   detail: 'One or more query parameters are invalid.',
+  code: METRICS_VALIDATION_ERROR_CODE,
 });
 
 /**
@@ -251,6 +354,28 @@ const validateGetMetricsQuery = createQueryValidator(getMetricsQuerySchema, {
  *
  * On success, attaches parsed value to `req.validated`.
  * On failure, returns a 400 RFC 7807 Problem Details response.
+ *
+ * ### Failure response shape
+ *
+ * ```json
+ * {
+ *   "type": "https://liquifact.io/problems/validation-error",
+ *   "title": "Validation Error",
+ *   "status": 400,
+ *   "detail": "Request body contains invalid or missing fields.",
+ *   "code": "METRICS_VALIDATION_ERROR",
+ *   "fieldErrors": { "operations.0.userId": ["userId is required"] },
+ *   "fieldCodes": { "operations.0.userId": ["FIELD_REQUIRED"] }
+ * }
+ * ```
+ *
+ * `code` and `fieldCodes` are additive: `type`, `title`, `status`, `detail` and
+ * `fieldErrors` keep their previous values and shapes, so existing clients are
+ * unaffected.
+ *
+ * A non-object body (`null`, an array, a bare string — reachable when a client
+ * sends `Content-Type: application/json` with a scalar payload) is rejected
+ * here rather than propagating an untyped value into the handler.
  *
  * @param {import('express').Request} req
  * @param {import('express').Response} res
@@ -265,13 +390,16 @@ function validateBulkMetricsBody(req, res, next) {
   }
 
   const fieldErrors = parseValidationErrors(result.error);
+  const fieldCodes = parseValidationFieldCodes(result.error);
 
   return res.status(400).json({
-    type: 'https://liquifact.io/problems/validation-error',
+    type: METRICS_VALIDATION_PROBLEM_TYPE,
     title: 'Validation Error',
     status: 400,
     detail: 'Request body contains invalid or missing fields.',
+    code: METRICS_VALIDATION_ERROR_CODE,
     fieldErrors,
+    fieldCodes,
   });
 }
 
@@ -323,7 +451,15 @@ module.exports = {
 
   // Utilities / constants
   parseValidationErrors,
+  parseValidationFieldCodes,
   MAX_BULK_OPERATIONS,
   GET_METRICS_LIMIT_MIN,
   GET_METRICS_LIMIT_MAX,
+  GET_METRICS_CURSOR_MAX_LENGTH,
+  BULK_METRICS_ID_MAX_LENGTH,
+
+  // Error-code taxonomy (re-exported for convenience)
+  METRICS_VALIDATION_CODES,
+  METRICS_VALIDATION_ERROR_CODE,
+  METRICS_VALIDATION_PROBLEM_TYPE,
 };

--- a/tests/sme.metrics.test.js
+++ b/tests/sme.metrics.test.js
@@ -288,7 +288,7 @@ describe('SME Metrics API', () => {
       expect(res.body.meta.nextCursor).toBeNull();
     });
 
-    test('clamps limit to maximum of 100', async () => {
+    test('accepts limit at the maximum of 100', async () => {
       const invoices = Array.from({ length: 50 }, (_, i) => ({
         invoice_id: `clamp_${i}`,
         sme_id: userId,
@@ -300,13 +300,21 @@ describe('SME Metrics API', () => {
       await db('invoices').insert(invoices);
 
       const res = await request(app)
-        .get('/api/sme/metrics?limit=999')
+        .get('/api/sme/metrics?limit=100')
         .set('Authorization', `Bearer ${token}`);
 
       expect(res.status).toBe(200);
       expect(res.body.meta.limit).toBe(100);
       expect(res.body.meta.invoices).toHaveLength(50);
       expect(res.body.meta.hasMore).toBe(false);
+    });
+
+    test('rejects limit above the maximum instead of clamping it', async () => {
+      const res = await request(app)
+        .get('/api/sme/metrics?limit=999')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(400);
     });
 
     test('rejects malformed cursor with 400', async () => {
@@ -457,40 +465,38 @@ describe('SME Metrics API', () => {
 
   // ── Validation-failure: invalid (non-throwing) limit values ────────────
 
-  describe('validation-failure — invalid limit values are clamped, not rejected', () => {
+  describe('validation-failure — invalid limit values are rejected, not repaired', () => {
     beforeEach(async () => {
       await db('invoices').insert([
         { invoice_id: 'lv1', sme_id: userId, tenant_id: tenantId, status: 'verified', amount: 100, customer: 'LV1' },
       ]);
     });
 
-    test('non-numeric limit falls back to the default page size', async () => {
+    // These previously returned 200 by silently substituting a default or
+    // clamped page size, which hid the bad input from the caller. Malformed and
+    // out-of-range values now fail closed with a structured 400.
+    test('non-numeric limit is rejected rather than falling back to a default', async () => {
       const res = await request(app)
         .get('/api/sme/metrics?limit=not-a-number')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(res.status).toBe(200);
-      expect(res.body.meta.limit).toBe(20);
+      expect(res.status).toBe(400);
     });
 
-    test('zero limit is falsy and falls back to the default page size (not clamped to 1)', async () => {
-      // `parseInt('0', 10) || 20` treats 0 as falsy, so this takes the same
-      // default-fallback path as a non-numeric limit rather than clamping to 1.
+    test('zero limit is rejected as below the minimum', async () => {
       const res = await request(app)
         .get('/api/sme/metrics?limit=0')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(res.status).toBe(200);
-      expect(res.body.meta.limit).toBe(20);
+      expect(res.status).toBe(400);
     });
 
-    test('negative limit is clamped up to the minimum of 1', async () => {
+    test('negative limit is rejected rather than clamped up to 1', async () => {
       const res = await request(app)
         .get('/api/sme/metrics?limit=-5')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(res.status).toBe(200);
-      expect(res.body.meta.limit).toBe(1);
+      expect(res.status).toBe(400);
     });
   });
 

--- a/tests/sme.metrics.validation.test.js
+++ b/tests/sme.metrics.validation.test.js
@@ -1,0 +1,420 @@
+/**
+ * Route-level input-validation tests for the SME metrics endpoints.
+ *
+ * Asserts that malformed payloads are rejected at the HTTP boundary with a
+ * structured 400 carrying a machine-readable error code — i.e. that the
+ * hardening in `src/schemas/metrics.js` is actually wired into the routes and
+ * runs before any handler logic touches the store.
+ *
+ * Bypasses the global knex mock to run against an in-memory SQLite database,
+ * matching `tests/sme.metrics.bulk.test.js`.
+ */
+
+'use strict';
+
+jest.mock('../src/db/knex', () => {
+  const knex = jest.requireActual('knex');
+  const config = jest.requireActual('../knexfile')['test'];
+  return knex(config);
+});
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { createApp } = require('../src/app');
+const db = require('../src/db/knex');
+const invoiceService = require('../src/services/invoiceService');
+const {
+  METRICS_VALIDATION_CODES,
+  METRICS_VALIDATION_ERROR_CODE,
+  MAX_BULK_OPERATIONS,
+  BULK_METRICS_ID_MAX_LENGTH,
+  GET_METRICS_CURSOR_MAX_LENGTH,
+} = require('../src/schemas/metrics');
+
+const JWT_SECRET =
+  process.env.JWT_SECRET || 'test-secret-at-least-32-characters-long-string-for-jest';
+const app = createApp();
+
+const str = (n) => 'a'.repeat(n);
+
+describe('SME metrics input validation', () => {
+  const userId = 'validation_user';
+  const tenantId = 'validation_tenant';
+  const token = jwt.sign({ id: userId, tenantId }, JWT_SECRET);
+  const validOp = { tenantId, userId };
+
+  const postBulk = (body) =>
+    request(app)
+      .post('/api/sme/metrics/bulk')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body);
+
+  const getMetrics = (query) =>
+    request(app).get(`/api/sme/metrics${query}`).set('Authorization', `Bearer ${token}`);
+
+  beforeAll(async () => {
+    await db.migrate.latest({ directory: './migrations' });
+  });
+
+  beforeEach(async () => {
+    await db('invoices').del();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  // ── POST /metrics/bulk ─────────────────────────────────────────────────────
+
+  describe('POST /api/sme/metrics/bulk', () => {
+    describe('structured error contract', () => {
+      test('returns a 400 problem document with a machine-readable code', async () => {
+        const res = await postBulk({});
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+        expect(res.body.type).toBe('https://liquifact.io/problems/validation-error');
+        expect(res.body.title).toBe('Validation Error');
+        expect(res.body.status).toBe(400);
+        expect(res.body.detail).toEqual(expect.any(String));
+        expect(res.body.fieldErrors).toBeDefined();
+        expect(res.body.fieldCodes).toBeDefined();
+      });
+
+      test('never leaks a stack trace in the error body', async () => {
+        const res = await postBulk({ operations: 'nope' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.stack).toBeUndefined();
+      });
+    });
+
+    describe('missing fields', () => {
+      test('rejects a missing operations array as FIELD_REQUIRED', async () => {
+        const res = await postBulk({});
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes.operations).toContain(
+          METRICS_VALIDATION_CODES.FIELD_REQUIRED
+        );
+      });
+
+      test('rejects a missing tenantId with a path-qualified code', async () => {
+        const res = await postBulk({ operations: [{ userId }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.tenantId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_REQUIRED
+        );
+      });
+
+      test('rejects a missing userId with a path-qualified code', async () => {
+        const res = await postBulk({ operations: [{ tenantId }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.userId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_REQUIRED
+        );
+      });
+    });
+
+    describe('wrong types', () => {
+      test('rejects a numeric tenantId as FIELD_TYPE_INVALID', async () => {
+        const res = await postBulk({ operations: [{ tenantId: 42, userId }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.tenantId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_TYPE_INVALID
+        );
+      });
+
+      test('rejects a boolean userId as FIELD_TYPE_INVALID', async () => {
+        const res = await postBulk({ operations: [{ tenantId, userId: true }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.userId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_TYPE_INVALID
+        );
+      });
+
+      test('rejects a non-array operations value', async () => {
+        const res = await postBulk({ operations: 'not-an-array' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes.operations).toBeDefined();
+      });
+
+      test('rejects a nested object where a string id is expected', async () => {
+        const res = await postBulk({ operations: [{ tenantId: { $ne: null }, userId }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+      });
+
+      test('rejects a JSON array as the request body', async () => {
+        const res = await postBulk([validOp]);
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+      });
+    });
+
+    describe('unknown fields', () => {
+      test('rejects an unknown top-level key and names it', async () => {
+        const res = await postBulk({ operations: [validOp], extra: 'field' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes.extra).toEqual([
+          METRICS_VALIDATION_CODES.UNKNOWN_FIELD,
+        ]);
+      });
+
+      test('rejects an unknown per-item key and names its full path', async () => {
+        const res = await postBulk({ operations: [{ ...validOp, isAdmin: true }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.isAdmin']).toEqual([
+          METRICS_VALIDATION_CODES.UNKNOWN_FIELD,
+        ]);
+      });
+    });
+
+    describe('oversized strings', () => {
+      test(`accepts an id at exactly ${BULK_METRICS_ID_MAX_LENGTH} characters`, async () => {
+        const res = await postBulk({
+          operations: [{ tenantId, userId: str(BULK_METRICS_ID_MAX_LENGTH) }],
+        });
+
+        expect(res.status).toBe(200);
+      });
+
+      test('rejects a userId one character over the bound as FIELD_TOO_LONG', async () => {
+        const res = await postBulk({
+          operations: [{ tenantId, userId: str(BULK_METRICS_ID_MAX_LENGTH + 1) }],
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.userId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+        );
+      });
+
+      test('rejects a grossly oversized tenantId', async () => {
+        const res = await postBulk({
+          operations: [{ tenantId: str(10000), userId }],
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.tenantId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+        );
+      });
+
+      test('rejects an empty tenantId as FIELD_TOO_SHORT', async () => {
+        const res = await postBulk({ operations: [{ tenantId: '   ', userId }] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes['operations.0.tenantId']).toContain(
+          METRICS_VALIDATION_CODES.FIELD_TOO_SHORT
+        );
+      });
+    });
+
+    describe('array boundaries', () => {
+      test('rejects an empty operations array as ARRAY_TOO_SMALL', async () => {
+        const res = await postBulk({ operations: [] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes.operations).toContain(
+          METRICS_VALIDATION_CODES.ARRAY_TOO_SMALL
+        );
+      });
+
+      test(`accepts exactly ${MAX_BULK_OPERATIONS} operations`, async () => {
+        const operations = Array.from({ length: MAX_BULK_OPERATIONS }, (_, i) => ({
+          tenantId,
+          userId: `user_${i}`,
+        }));
+        const res = await postBulk({ operations });
+
+        expect(res.status).toBe(200);
+        expect(res.body.results).toHaveLength(MAX_BULK_OPERATIONS);
+      });
+
+      test('rejects one operation over the cap as ARRAY_TOO_LARGE', async () => {
+        const operations = Array.from({ length: MAX_BULK_OPERATIONS + 1 }, (_, i) => ({
+          tenantId,
+          userId: `user_${i}`,
+        }));
+        const res = await postBulk({ operations });
+
+        expect(res.status).toBe(400);
+        expect(res.body.fieldCodes.operations).toContain(
+          METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE
+        );
+      });
+    });
+
+    describe('validation runs before the store is touched', () => {
+      test('does not query invoices when the body is malformed', async () => {
+        const spy = jest.spyOn(invoiceService, 'getSmeInvoiceCounts');
+
+        const res = await postBulk({ operations: [{ tenantId: 42, userId: null }] });
+
+        expect(res.status).toBe(400);
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test('does not query invoices when an id is oversized', async () => {
+        const spy = jest.spyOn(invoiceService, 'getSmeInvoiceCounts');
+
+        const res = await postBulk({
+          operations: [{ tenantId, userId: str(BULK_METRICS_ID_MAX_LENGTH + 1) }],
+        });
+
+        expect(res.status).toBe(400);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('valid payloads still succeed', () => {
+      test('accepts a well-formed request and returns counts', async () => {
+        await db('invoices').insert([
+          {
+            invoice_id: 'v1',
+            sme_id: userId,
+            tenant_id: tenantId,
+            status: 'funded',
+            amount: 100,
+            customer: 'C1',
+          },
+        ]);
+
+        const res = await postBulk({ operations: [validOp] });
+
+        expect(res.status).toBe(200);
+        expect(res.body.results[0].status).toBe('success');
+        expect(res.body.results[0].data.funded).toBe(1);
+      });
+
+      test('trims surrounding whitespace on ids', async () => {
+        const res = await postBulk({
+          operations: [{ tenantId: `  ${tenantId}  `, userId: `  ${userId}  ` }],
+        });
+
+        expect(res.status).toBe(200);
+        // Trimmed ids match the caller's tenant, so this is not a cross-tenant reject.
+        expect(res.body.results[0].status).toBe('success');
+      });
+    });
+  });
+
+  // ── GET /metrics ───────────────────────────────────────────────────────────
+
+  describe('GET /api/sme/metrics', () => {
+    describe('limit validation', () => {
+      test.each(['1', '20', '100'])('accepts in-range limit=%s', async (value) => {
+        const res = await getMetrics(`?limit=${value}`);
+
+        expect(res.status).toBe(200);
+      });
+
+      test('rejects limit=0 with a 400', async () => {
+        const res = await getMetrics('?limit=0');
+
+        expect(res.status).toBe(400);
+      });
+
+      test('rejects limit=101 rather than clamping it to 100', async () => {
+        const res = await getMetrics('?limit=101');
+
+        expect(res.status).toBe(400);
+      });
+
+      test('rejects a grossly oversized limit', async () => {
+        const res = await getMetrics('?limit=999999');
+
+        expect(res.status).toBe(400);
+      });
+
+      test('rejects a negative limit', async () => {
+        const res = await getMetrics('?limit=-5');
+
+        expect(res.status).toBe(400);
+      });
+
+      test.each(['abc', '20abc', '1e5', '10.5', '0x10'])(
+        'rejects malformed limit=%s rather than ignoring it',
+        async (value) => {
+          const res = await getMetrics(`?limit=${value}`);
+
+          expect(res.status).toBe(400);
+        }
+      );
+
+      test('returns a machine-readable code on limit rejection', async () => {
+        const res = await getMetrics('?limit=999');
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+      });
+
+      test('does not query the store when limit is out of range', async () => {
+        const spy = jest.spyOn(invoiceService, 'getSmeInvoiceCounts');
+
+        const res = await getMetrics('?limit=99999');
+
+        expect(res.status).toBe(400);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('cursor validation', () => {
+      test('rejects an empty cursor', async () => {
+        const res = await getMetrics('?cursor=');
+
+        expect(res.status).toBe(400);
+      });
+
+      test(`accepts a cursor-shaped value at the ${GET_METRICS_CURSOR_MAX_LENGTH}-char bound`, async () => {
+        const res = await getMetrics(`?cursor=${str(GET_METRICS_CURSOR_MAX_LENGTH)}`);
+
+        // The bound is not what rejects this; an opaque-but-undecodable cursor
+        // is still a 400, so assert only that it is not a 5xx.
+        expect(res.status).toBeLessThan(500);
+      });
+
+      test('rejects an oversized cursor', async () => {
+        const res = await getMetrics(`?cursor=${str(GET_METRICS_CURSOR_MAX_LENGTH + 1)}`);
+
+        expect(res.status).toBe(400);
+      });
+
+      test('does not query the store when the cursor is oversized', async () => {
+        const spy = jest.spyOn(invoiceService, 'getSmeInvoiceCounts');
+
+        const res = await getMetrics(`?cursor=${str(5000)}`);
+
+        expect(res.status).toBe(400);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('unknown params', () => {
+      test('ignores unknown query params rather than rejecting them', async () => {
+        const res = await getMetrics('?utm_source=email&sortBy=date');
+
+        expect(res.status).toBe(200);
+      });
+
+      test('returns the unpaginated shape when only unknown params are supplied', async () => {
+        const res = await getMetrics('?utm_source=email');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toBeDefined();
+        expect(res.body.meta.invoices).toBeUndefined();
+      });
+    });
+  });
+});

--- a/tests/unit/metrics.inputHardening.test.js
+++ b/tests/unit/metrics.inputHardening.test.js
@@ -1,0 +1,538 @@
+'use strict';
+
+/**
+ * @fileoverview Input-hardening tests for the metrics request schemas.
+ *
+ * Complements `tests/unit/metrics.schema.test.js` (which covers the general
+ * schema surface) by focusing specifically on the hardening guarantees:
+ *
+ *  1. Unknown fields are rejected on bodies and stripped on query params.
+ *  2. Wrong JSON types are rejected rather than coerced.
+ *  3. Strings are length-bounded and numbers range-bounded, including at the
+ *     exact boundary values on both sides.
+ *  4. Every failure carries a machine-readable top-level `code` and a
+ *     per-field `fieldCodes` map.
+ */
+
+const {
+  getMetricsQuerySchema,
+  bulkMetricsSchema,
+  bulkMetricsOperationSchema,
+  validateBulkMetricsBody,
+  validateGetMetricsQuery,
+  parseValidationFieldCodes,
+  MAX_BULK_OPERATIONS,
+  GET_METRICS_LIMIT_MIN,
+  GET_METRICS_LIMIT_MAX,
+  GET_METRICS_CURSOR_MAX_LENGTH,
+  BULK_METRICS_ID_MAX_LENGTH,
+  METRICS_VALIDATION_CODES,
+  METRICS_VALIDATION_ERROR_CODE,
+  METRICS_VALIDATION_PROBLEM_TYPE,
+} = require('../../src/schemas/metrics');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRes() {
+  const res = {
+    _statusCode: null,
+    _body: undefined,
+    status: jest.fn(function (code) { this._statusCode = code; return this; }),
+    json: jest.fn(function (body) { this._body = body; return this; }),
+  };
+  return res;
+}
+
+const makeNext = () => jest.fn();
+
+/** Runs the bulk body middleware and returns the rejection body. */
+function rejectBulk(body) {
+  const res = makeRes();
+  const next = makeNext();
+  validateBulkMetricsBody({ body }, res, next);
+  expect(next).not.toHaveBeenCalled();
+  expect(res._statusCode).toBe(400);
+  return res._body;
+}
+
+const str = (n) => 'a'.repeat(n);
+const validOp = { tenantId: 't1', userId: 'u1' };
+
+// ── Exported bounds ──────────────────────────────────────────────────────────
+
+describe('exported bounds', () => {
+  it('exposes the documented numeric values', () => {
+    expect(MAX_BULK_OPERATIONS).toBe(25);
+    expect(GET_METRICS_LIMIT_MIN).toBe(1);
+    expect(GET_METRICS_LIMIT_MAX).toBe(100);
+    expect(GET_METRICS_CURSOR_MAX_LENGTH).toBe(512);
+    expect(BULK_METRICS_ID_MAX_LENGTH).toBe(128);
+  });
+});
+
+// ── Structured 400 contract ──────────────────────────────────────────────────
+
+describe('structured 400 contract', () => {
+  it('includes a machine-readable top-level code', () => {
+    const body = rejectBulk({});
+    expect(body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+    expect(body.code).toBe('METRICS_VALIDATION_ERROR');
+  });
+
+  it('preserves the pre-existing RFC 7807 fields unchanged', () => {
+    const body = rejectBulk({});
+    expect(body.type).toBe(METRICS_VALIDATION_PROBLEM_TYPE);
+    expect(body.title).toBe('Validation Error');
+    expect(body.status).toBe(400);
+    expect(body.detail).toBe('Request body contains invalid or missing fields.');
+    expect(body.fieldErrors).toBeDefined();
+  });
+
+  it('reports fieldErrors and fieldCodes under the same keys', () => {
+    const body = rejectBulk({ operations: [{ userId: 'u1' }] });
+    expect(Object.keys(body.fieldCodes)).toEqual(
+      expect.arrayContaining(Object.keys(body.fieldErrors))
+    );
+  });
+
+  it('emits only codes drawn from the bounded taxonomy', () => {
+    const body = rejectBulk({ operations: [{ tenantId: 42, userId: str(200), bogus: 1 }] });
+    const known = Object.values(METRICS_VALIDATION_CODES);
+    for (const codes of Object.values(body.fieldCodes)) {
+      for (const code of codes) {
+        expect(known).toContain(code);
+      }
+    }
+  });
+
+  it('does not leak a stack trace', () => {
+    const body = rejectBulk({});
+    expect(body.stack).toBeUndefined();
+  });
+});
+
+// ── Missing fields ───────────────────────────────────────────────────────────
+
+describe('missing fields', () => {
+  it('flags an absent operations array as FIELD_REQUIRED', () => {
+    const body = rejectBulk({});
+    expect(body.fieldCodes.operations).toContain(METRICS_VALIDATION_CODES.FIELD_REQUIRED);
+  });
+
+  it('flags an absent tenantId at its exact path', () => {
+    const body = rejectBulk({ operations: [{ userId: 'u1' }] });
+    expect(body.fieldCodes['operations.0.tenantId']).toContain(
+      METRICS_VALIDATION_CODES.FIELD_REQUIRED
+    );
+  });
+
+  it('flags an absent userId at its exact path', () => {
+    const body = rejectBulk({ operations: [{ tenantId: 't1' }] });
+    expect(body.fieldCodes['operations.0.userId']).toContain(
+      METRICS_VALIDATION_CODES.FIELD_REQUIRED
+    );
+  });
+
+  it('reports the correct index when a later item is incomplete', () => {
+    const body = rejectBulk({ operations: [validOp, validOp, { tenantId: 't1' }] });
+    expect(body.fieldCodes['operations.2.userId']).toContain(
+      METRICS_VALIDATION_CODES.FIELD_REQUIRED
+    );
+    expect(body.fieldCodes['operations.0.userId']).toBeUndefined();
+  });
+
+  it('reports every missing field across multiple items at once', () => {
+    const body = rejectBulk({ operations: [{ userId: 'u1' }, { tenantId: 't2' }] });
+    expect(body.fieldCodes['operations.0.tenantId']).toBeDefined();
+    expect(body.fieldCodes['operations.1.userId']).toBeDefined();
+  });
+});
+
+// ── Wrong types ──────────────────────────────────────────────────────────────
+
+describe('wrong types', () => {
+  it.each([
+    ['a number', 42],
+    ['a boolean', true],
+    ['an object', { nested: 'x' }],
+    ['an array', ['x']],
+    ['null', null],
+  ])('rejects tenantId given %s as FIELD_TYPE_INVALID', (_label, value) => {
+    const body = rejectBulk({ operations: [{ tenantId: value, userId: 'u1' }] });
+    expect(body.fieldCodes['operations.0.tenantId']).toContain(
+      METRICS_VALIDATION_CODES.FIELD_TYPE_INVALID
+    );
+  });
+
+  it('does not coerce a numeric-looking string id into a number', () => {
+    const result = bulkMetricsOperationSchema.safeParse({ tenantId: '123', userId: '456' });
+    expect(result.success).toBe(true);
+    expect(result.data.tenantId).toBe('123');
+    expect(typeof result.data.tenantId).toBe('string');
+  });
+
+  it.each([
+    ['a string', 'not-an-array'],
+    ['a number', 7],
+    ['an object', { 0: validOp }],
+    ['null', null],
+  ])('rejects operations given %s', (_label, value) => {
+    const body = rejectBulk({ operations: value });
+    expect(body.fieldCodes.operations).toBeDefined();
+  });
+
+  it.each([
+    ['null', null],
+    ['an array', [validOp]],
+    ['a string', 'payload'],
+    ['a number', 5],
+  ])('rejects a non-object body (%s)', (_label, value) => {
+    const body = rejectBulk(value);
+    expect(body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+  });
+
+  it('rejects a non-object item inside operations', () => {
+    const body = rejectBulk({ operations: ['just-a-string'] });
+    expect(body.fieldCodes['operations.0']).toBeDefined();
+  });
+});
+
+// ── Unknown fields ───────────────────────────────────────────────────────────
+
+describe('unknown fields', () => {
+  it('rejects an unknown top-level key as UNKNOWN_FIELD', () => {
+    const body = rejectBulk({ operations: [validOp], rogue: true });
+    const codes = Object.values(body.fieldCodes).flat();
+    expect(codes).toContain(METRICS_VALIDATION_CODES.UNKNOWN_FIELD);
+  });
+
+  it('names the offending top-level key in fieldCodes', () => {
+    const body = rejectBulk({ operations: [validOp], rogue: true });
+    expect(body.fieldCodes.rogue).toEqual([METRICS_VALIDATION_CODES.UNKNOWN_FIELD]);
+  });
+
+  it('names the offending per-item key with its full path', () => {
+    const body = rejectBulk({ operations: [{ ...validOp, isAdmin: true }] });
+    expect(body.fieldCodes['operations.0.isAdmin']).toEqual([
+      METRICS_VALIDATION_CODES.UNKNOWN_FIELD,
+    ]);
+  });
+
+  it('names every unknown key when several are present', () => {
+    const body = rejectBulk({ operations: [validOp], a: 1, b: 2 });
+    expect(body.fieldCodes.a).toBeDefined();
+    expect(body.fieldCodes.b).toBeDefined();
+  });
+
+  it('rejects a prototype-pollution-shaped key rather than applying it', () => {
+    const body = rejectBulk({
+      operations: [validOp],
+      constructor: { prototype: { polluted: true } },
+    });
+    expect(body.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+    expect({}.polluted).toBeUndefined();
+  });
+});
+
+// ── String length bounds ─────────────────────────────────────────────────────
+
+describe('string length bounds', () => {
+  describe('tenantId / userId', () => {
+    it.each(['tenantId', 'userId'])('accepts %s at exactly 128 characters', (field) => {
+      const op = { ...validOp, [field]: str(BULK_METRICS_ID_MAX_LENGTH) };
+      expect(bulkMetricsOperationSchema.safeParse(op).success).toBe(true);
+    });
+
+    it.each(['tenantId', 'userId'])('rejects %s at 129 characters as FIELD_TOO_LONG', (field) => {
+      const op = { ...validOp, [field]: str(BULK_METRICS_ID_MAX_LENGTH + 1) };
+      const body = rejectBulk({ operations: [op] });
+      expect(body.fieldCodes[`operations.0.${field}`]).toContain(
+        METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+      );
+    });
+
+    it('rejects a grossly oversized id', () => {
+      const body = rejectBulk({ operations: [{ ...validOp, userId: str(100000) }] });
+      expect(body.fieldCodes['operations.0.userId']).toContain(
+        METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+      );
+    });
+
+    it.each(['tenantId', 'userId'])('accepts %s at the 1-character minimum', (field) => {
+      const op = { ...validOp, [field]: 'x' };
+      expect(bulkMetricsOperationSchema.safeParse(op).success).toBe(true);
+    });
+
+    it.each(['tenantId', 'userId'])('rejects an empty %s as FIELD_TOO_SHORT', (field) => {
+      const body = rejectBulk({ operations: [{ ...validOp, [field]: '' }] });
+      expect(body.fieldCodes[`operations.0.${field}`]).toContain(
+        METRICS_VALIDATION_CODES.FIELD_TOO_SHORT
+      );
+    });
+
+    it.each(['tenantId', 'userId'])('rejects a whitespace-only %s', (field) => {
+      const body = rejectBulk({ operations: [{ ...validOp, [field]: '   ' }] });
+      expect(body.fieldCodes[`operations.0.${field}`]).toContain(
+        METRICS_VALIDATION_CODES.FIELD_TOO_SHORT
+      );
+    });
+
+    it('measures length after trimming, so padding does not consume the budget', () => {
+      const padded = `  ${str(BULK_METRICS_ID_MAX_LENGTH)}  `;
+      const result = bulkMetricsOperationSchema.safeParse({ ...validOp, userId: padded });
+      expect(result.success).toBe(true);
+      expect(result.data.userId).toHaveLength(BULK_METRICS_ID_MAX_LENGTH);
+    });
+  });
+
+  describe('cursor', () => {
+    it('accepts a cursor at exactly 512 characters', () => {
+      const result = getMetricsQuerySchema.safeParse({
+        cursor: str(GET_METRICS_CURSOR_MAX_LENGTH),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a cursor at 513 characters', () => {
+      const result = getMetricsQuerySchema.safeParse({
+        cursor: str(GET_METRICS_CURSOR_MAX_LENGTH + 1),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a grossly oversized cursor', () => {
+      const result = getMetricsQuerySchema.safeParse({ cursor: str(50000) });
+      expect(result.success).toBe(false);
+    });
+
+    it('reports an oversized cursor as FIELD_TOO_LONG', () => {
+      const result = getMetricsQuerySchema.safeParse({
+        cursor: str(GET_METRICS_CURSOR_MAX_LENGTH + 1),
+      });
+      expect(parseValidationFieldCodes(result.error).cursor).toContain(
+        METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+      );
+    });
+
+    it('rejects a non-string cursor', () => {
+      expect(getMetricsQuerySchema.safeParse({ cursor: 42 }).success).toBe(false);
+    });
+  });
+});
+
+// ── Numeric range bounds ─────────────────────────────────────────────────────
+
+describe('limit range bounds', () => {
+  it.each(['1', '2', '50', '99', '100'])('accepts in-range limit %s', (value) => {
+    const result = getMetricsQuerySchema.safeParse({ limit: value });
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBe(Number(value));
+  });
+
+  it('accepts the exact lower boundary', () => {
+    const result = getMetricsQuerySchema.safeParse({ limit: String(GET_METRICS_LIMIT_MIN) });
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBe(GET_METRICS_LIMIT_MIN);
+  });
+
+  it('accepts the exact upper boundary', () => {
+    const result = getMetricsQuerySchema.safeParse({ limit: String(GET_METRICS_LIMIT_MAX) });
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBe(GET_METRICS_LIMIT_MAX);
+  });
+
+  it('rejects one below the lower boundary as VALUE_BELOW_MINIMUM', () => {
+    const result = getMetricsQuerySchema.safeParse({ limit: '0' });
+    expect(result.success).toBe(false);
+    expect(parseValidationFieldCodes(result.error).limit).toContain(
+      METRICS_VALIDATION_CODES.VALUE_BELOW_MINIMUM
+    );
+  });
+
+  it('rejects one above the upper boundary as VALUE_ABOVE_MAXIMUM', () => {
+    const result = getMetricsQuerySchema.safeParse({ limit: '101' });
+    expect(result.success).toBe(false);
+    expect(parseValidationFieldCodes(result.error).limit).toContain(
+      METRICS_VALIDATION_CODES.VALUE_ABOVE_MAXIMUM
+    );
+  });
+
+  it.each(['-1', '-5', '-100'])('rejects negative limit %s', (value) => {
+    expect(getMetricsQuerySchema.safeParse({ limit: value }).success).toBe(false);
+  });
+
+  it.each([
+    ['non-numeric text', 'abc'],
+    ['trailing garbage', '20abc'],
+    ['leading garbage', 'abc20'],
+    ['exponent notation', '1e5'],
+    ['a float', '10.5'],
+    ['hex notation', '0x10'],
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+    ['a separator', '1,2'],
+    ['Infinity', 'Infinity'],
+    ['NaN', 'NaN'],
+  ])('rejects malformed limit (%s)', (_label, value) => {
+    expect(getMetricsQuerySchema.safeParse({ limit: value }).success).toBe(false);
+  });
+
+  it('reports a malformed limit as FIELD_FORMAT_INVALID', () => {
+    const result = getMetricsQuerySchema.safeParse({ limit: 'abc' });
+    expect(result.success).toBe(false);
+    expect(parseValidationFieldCodes(result.error).limit).toContain(
+      METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID
+    );
+  });
+
+  it('rejects an absurdly large integer rather than clamping it', () => {
+    expect(getMetricsQuerySchema.safeParse({ limit: '999999999999999999999' }).success).toBe(
+      false
+    );
+  });
+
+  it('tolerates surrounding whitespace around a valid integer', () => {
+    const result = getMetricsQuerySchema.safeParse({ limit: ' 20 ' });
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBe(20);
+  });
+
+  it('treats an omitted limit as undefined without error', () => {
+    const result = getMetricsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBeUndefined();
+  });
+});
+
+// ── Array bounds ─────────────────────────────────────────────────────────────
+
+describe('operations array bounds', () => {
+  it('rejects an empty array as ARRAY_TOO_SMALL', () => {
+    const body = rejectBulk({ operations: [] });
+    expect(body.fieldCodes.operations).toContain(METRICS_VALIDATION_CODES.ARRAY_TOO_SMALL);
+  });
+
+  it('accepts exactly one item', () => {
+    expect(bulkMetricsSchema.safeParse({ operations: [validOp] }).success).toBe(true);
+  });
+
+  it('accepts exactly MAX_BULK_OPERATIONS items', () => {
+    const operations = Array.from({ length: MAX_BULK_OPERATIONS }, () => ({ ...validOp }));
+    expect(bulkMetricsSchema.safeParse({ operations }).success).toBe(true);
+  });
+
+  it('rejects MAX_BULK_OPERATIONS + 1 items as ARRAY_TOO_LARGE', () => {
+    const operations = Array.from({ length: MAX_BULK_OPERATIONS + 1 }, () => ({ ...validOp }));
+    const body = rejectBulk({ operations });
+    expect(body.fieldCodes.operations).toContain(METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE);
+  });
+
+  it('rejects a grossly oversized array', () => {
+    const operations = Array.from({ length: 5000 }, () => ({ ...validOp }));
+    const body = rejectBulk({ operations });
+    expect(body.fieldCodes.operations).toContain(METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE);
+  });
+});
+
+// ── Query middleware ─────────────────────────────────────────────────────────
+
+describe('validateGetMetricsQuery middleware', () => {
+  it('passes a valid query through and exposes coerced values', () => {
+    const req = { query: { limit: '20' }, originalUrl: '/api/sme/metrics?limit=20' };
+    const next = makeNext();
+    validateGetMetricsQuery(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(req.validatedQuery.limit).toBe(20);
+  });
+
+  it('forwards an AppError carrying the metrics validation code', () => {
+    const req = { query: { limit: '999' }, originalUrl: '/api/sme/metrics?limit=999' };
+    const next = makeNext();
+    validateGetMetricsQuery(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeDefined();
+    expect(err.status).toBe(400);
+    expect(err.code).toBe(METRICS_VALIDATION_ERROR_CODE);
+    expect(err.fieldErrors).toBeDefined();
+  });
+
+  it('strips unknown query params instead of rejecting them', () => {
+    const req = { query: { limit: '5', utm_source: 'email' }, originalUrl: '/x' };
+    const next = makeNext();
+    validateGetMetricsQuery(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(req.validatedQuery.utm_source).toBeUndefined();
+    expect(req.validatedQuery.limit).toBe(5);
+  });
+});
+
+// ── parseValidationFieldCodes ────────────────────────────────────────────────
+
+describe('parseValidationFieldCodes', () => {
+  it('returns an empty object when there are no issues', () => {
+    expect(parseValidationFieldCodes({ issues: [] })).toEqual({});
+  });
+
+  it('groups codes by joined field path', () => {
+    const codes = parseValidationFieldCodes({
+      issues: [
+        { code: 'invalid_type', received: 'undefined', path: ['operations', 0, 'userId'] },
+      ],
+    });
+    expect(codes['operations.0.userId']).toEqual([
+      METRICS_VALIDATION_CODES.FIELD_REQUIRED,
+    ]);
+  });
+
+  it('deduplicates a repeated code on the same path', () => {
+    const issue = { code: 'too_big', origin: 'string', path: ['userId'] };
+    const codes = parseValidationFieldCodes({ issues: [issue, issue] });
+    expect(codes.userId).toEqual([METRICS_VALIDATION_CODES.FIELD_TOO_LONG]);
+  });
+
+  it('keeps distinct codes on the same path', () => {
+    const codes = parseValidationFieldCodes({
+      issues: [
+        { code: 'too_big', origin: 'string', path: ['userId'] },
+        { code: 'invalid_format', path: ['userId'] },
+      ],
+    });
+    expect(codes.userId).toHaveLength(2);
+  });
+
+  it('uses an empty-string key for root-level issues', () => {
+    const codes = parseValidationFieldCodes({
+      issues: [{ code: 'invalid_type', received: 'array', input: [], path: [] }],
+    });
+    expect(codes['']).toContain(METRICS_VALIDATION_CODES.FIELD_TYPE_INVALID);
+  });
+
+  it('expands unrecognized_keys into one entry per offending key', () => {
+    const codes = parseValidationFieldCodes({
+      issues: [{ code: 'unrecognized_keys', keys: ['a', 'b'], path: [] }],
+    });
+    expect(codes.a).toEqual([METRICS_VALIDATION_CODES.UNKNOWN_FIELD]);
+    expect(codes.b).toEqual([METRICS_VALIDATION_CODES.UNKNOWN_FIELD]);
+  });
+
+  it('prefixes expanded unknown keys with their parent path', () => {
+    const codes = parseValidationFieldCodes({
+      issues: [{ code: 'unrecognized_keys', keys: ['extra'], path: ['operations', 0] }],
+    });
+    expect(codes['operations.0.extra']).toEqual([
+      METRICS_VALIDATION_CODES.UNKNOWN_FIELD,
+    ]);
+  });
+
+  it('tolerates an unrecognized_keys issue with no keys array', () => {
+    const codes = parseValidationFieldCodes({
+      issues: [{ code: 'unrecognized_keys', path: [] }],
+    });
+    expect(codes['']).toContain(METRICS_VALIDATION_CODES.UNKNOWN_FIELD);
+  });
+});

--- a/tests/unit/metrics.schema.test.js
+++ b/tests/unit/metrics.schema.test.js
@@ -103,30 +103,28 @@ describe('getMetricsQuerySchema', () => {
     });
   });
 
-  describe('limit clamping and coercion', () => {
-    it('clamps limit above max to 100', () => {
+  describe('limit bounds and coercion', () => {
+    // Input hardening: an out-of-range or malformed `limit` is now rejected
+    // outright. It was previously clamped (999 -> 100) or silently dropped
+    // ('abc' -> undefined), which hid the caller's mistake from them.
+    it('rejects limit above max instead of clamping to 100', () => {
       const result = getMetricsQuerySchema.safeParse({ limit: '999' });
-      expect(result.success).toBe(true);
-      expect(result.data.limit).toBe(100);
+      expect(result.success).toBe(false);
     });
 
-    it('clamps limit below min to 1', () => {
+    it('rejects limit below min instead of clamping to 1', () => {
       const result = getMetricsQuerySchema.safeParse({ limit: '-5' });
-      expect(result.success).toBe(true);
-      expect(result.data.limit).toBe(1);
+      expect(result.success).toBe(false);
     });
 
-    it('treats non-numeric limit as undefined (no error)', () => {
+    it('rejects non-numeric limit instead of treating it as undefined', () => {
       const result = getMetricsQuerySchema.safeParse({ limit: 'abc' });
-      expect(result.success).toBe(true);
-      expect(result.data.limit).toBeUndefined();
+      expect(result.success).toBe(false);
     });
 
-    it('treats limit=0 as 1 after clamping (max(parsed, 1))', () => {
+    it('rejects limit=0 as below the minimum', () => {
       const result = getMetricsQuerySchema.safeParse({ limit: '0' });
-      expect(result.success).toBe(true);
-      // 0 parsed => Math.max(0, 1) = 1
-      expect(result.data.limit).toBe(1);
+      expect(result.success).toBe(false);
     });
 
     it('accepts limit at boundary value 1', () => {

--- a/tests/unit/metricsValidationCodes.test.js
+++ b/tests/unit/metricsValidationCodes.test.js
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the metrics validation error-code taxonomy.
+ *
+ * These tests exercise `codeForIssue` against hand-built Zod issue objects so
+ * the mapping is pinned independently of any particular Zod version's issue
+ * wording. Both the Zod 4 (`origin`) and Zod 3 (`type`) spellings of size
+ * issues are covered, because `codeForIssue` supports both.
+ */
+
+'use strict';
+
+const {
+  METRICS_VALIDATION_CODES,
+  METRICS_VALIDATION_ERROR_CODE,
+  METRICS_VALIDATION_PROBLEM_TYPE,
+  codeForIssue,
+} = require('../../src/constants/metricsValidationCodes');
+
+describe('METRICS_VALIDATION_CODES', () => {
+  it('is frozen so codes cannot drift at runtime', () => {
+    expect(Object.isFrozen(METRICS_VALIDATION_CODES)).toBe(true);
+  });
+
+  it('maps every key to itself so codes are self-describing on the wire', () => {
+    for (const [key, value] of Object.entries(METRICS_VALIDATION_CODES)) {
+      expect(value).toBe(key);
+    }
+  });
+
+  it('exposes the documented code set', () => {
+    expect(Object.keys(METRICS_VALIDATION_CODES).sort()).toEqual(
+      [
+        'ARRAY_TOO_LARGE',
+        'ARRAY_TOO_SMALL',
+        'FIELD_FORMAT_INVALID',
+        'FIELD_INVALID',
+        'FIELD_REQUIRED',
+        'FIELD_TOO_LONG',
+        'FIELD_TOO_SHORT',
+        'FIELD_TYPE_INVALID',
+        'UNKNOWN_FIELD',
+        'VALUE_ABOVE_MAXIMUM',
+        'VALUE_BELOW_MINIMUM',
+        'VALUE_NOT_INTEGER',
+      ].sort()
+    );
+  });
+
+  it('exposes a stable top-level code and problem type', () => {
+    expect(METRICS_VALIDATION_ERROR_CODE).toBe('METRICS_VALIDATION_ERROR');
+    // Unchanged from the pre-hardening wire format.
+    expect(METRICS_VALIDATION_PROBLEM_TYPE).toBe(
+      'https://liquifact.io/problems/validation-error'
+    );
+  });
+});
+
+describe('codeForIssue', () => {
+  describe('missing vs wrongly-typed fields', () => {
+    it('maps an absent field to FIELD_REQUIRED via `received`', () => {
+      expect(
+        codeForIssue({ code: 'invalid_type', received: 'undefined', path: ['userId'] })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_REQUIRED);
+    });
+
+    it('maps an absent field to FIELD_REQUIRED via `input` (Zod 4)', () => {
+      expect(
+        codeForIssue({ code: 'invalid_type', input: undefined, path: ['userId'] })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_REQUIRED);
+    });
+
+    it('distinguishes a present-but-wrong-type field as FIELD_TYPE_INVALID', () => {
+      expect(
+        codeForIssue({ code: 'invalid_type', received: 'number', input: 42, path: ['userId'] })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_TYPE_INVALID);
+    });
+  });
+
+  describe('unknown fields', () => {
+    it('maps unrecognized_keys to UNKNOWN_FIELD', () => {
+      expect(
+        codeForIssue({ code: 'unrecognized_keys', keys: ['extra'], path: [] })
+      ).toBe(METRICS_VALIDATION_CODES.UNKNOWN_FIELD);
+    });
+  });
+
+  describe('string bounds', () => {
+    it('maps a too-short string to FIELD_TOO_SHORT', () => {
+      expect(codeForIssue({ code: 'too_small', origin: 'string', path: ['userId'] })).toBe(
+        METRICS_VALIDATION_CODES.FIELD_TOO_SHORT
+      );
+    });
+
+    it('maps an oversized string to FIELD_TOO_LONG', () => {
+      expect(codeForIssue({ code: 'too_big', origin: 'string', path: ['userId'] })).toBe(
+        METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+      );
+    });
+
+    it('honours the Zod 3 `type` spelling for strings', () => {
+      expect(codeForIssue({ code: 'too_big', type: 'string', path: ['userId'] })).toBe(
+        METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+      );
+    });
+  });
+
+  describe('array bounds', () => {
+    it('maps an empty array to ARRAY_TOO_SMALL, not FIELD_TOO_SHORT', () => {
+      expect(
+        codeForIssue({ code: 'too_small', origin: 'array', path: ['operations'] })
+      ).toBe(METRICS_VALIDATION_CODES.ARRAY_TOO_SMALL);
+    });
+
+    it('maps an over-cap array to ARRAY_TOO_LARGE, not FIELD_TOO_LONG', () => {
+      expect(
+        codeForIssue({ code: 'too_big', origin: 'array', path: ['operations'] })
+      ).toBe(METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE);
+    });
+
+    it('honours the Zod 3 `type` spelling for arrays', () => {
+      expect(codeForIssue({ code: 'too_big', type: 'array', path: ['operations'] })).toBe(
+        METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE
+      );
+    });
+
+    it('treats sets like arrays', () => {
+      expect(codeForIssue({ code: 'too_small', origin: 'set', path: ['x'] })).toBe(
+        METRICS_VALIDATION_CODES.ARRAY_TOO_SMALL
+      );
+    });
+  });
+
+  describe('numeric bounds', () => {
+    it('maps a below-minimum number to VALUE_BELOW_MINIMUM', () => {
+      expect(codeForIssue({ code: 'too_small', origin: 'number', path: ['limit'] })).toBe(
+        METRICS_VALIDATION_CODES.VALUE_BELOW_MINIMUM
+      );
+    });
+
+    it('maps an above-maximum number to VALUE_ABOVE_MAXIMUM', () => {
+      expect(codeForIssue({ code: 'too_big', origin: 'number', path: ['limit'] })).toBe(
+        METRICS_VALIDATION_CODES.VALUE_ABOVE_MAXIMUM
+      );
+    });
+
+    it('treats int and bigint origins as numeric', () => {
+      expect(codeForIssue({ code: 'too_big', origin: 'int', path: ['limit'] })).toBe(
+        METRICS_VALIDATION_CODES.VALUE_ABOVE_MAXIMUM
+      );
+      expect(codeForIssue({ code: 'too_small', origin: 'bigint', path: ['limit'] })).toBe(
+        METRICS_VALIDATION_CODES.VALUE_BELOW_MINIMUM
+      );
+    });
+
+    it('maps not_multiple_of to VALUE_NOT_INTEGER', () => {
+      expect(codeForIssue({ code: 'not_multiple_of', path: ['limit'] })).toBe(
+        METRICS_VALIDATION_CODES.VALUE_NOT_INTEGER
+      );
+    });
+  });
+
+  describe('format issues', () => {
+    it('maps invalid_format to FIELD_FORMAT_INVALID', () => {
+      expect(
+        codeForIssue({ code: 'invalid_format', format: 'integer', path: ['limit'] })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID);
+    });
+
+    it('maps the Zod 3 invalid_string code to FIELD_FORMAT_INVALID', () => {
+      expect(codeForIssue({ code: 'invalid_string', path: ['cursor'] })).toBe(
+        METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID
+      );
+    });
+  });
+
+  describe('schema-declared codes', () => {
+    it('honours a known code declared via params.metricsCode', () => {
+      expect(
+        codeForIssue({
+          code: 'custom',
+          params: { metricsCode: METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID },
+          path: ['limit'],
+        })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_FORMAT_INVALID);
+    });
+
+    it('ignores an unknown declared code so typos never reach the wire', () => {
+      expect(
+        codeForIssue({ code: 'custom', params: { metricsCode: 'NOT_A_REAL_CODE' }, path: ['x'] })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_INVALID);
+    });
+
+    it('ignores a non-string declared code', () => {
+      expect(
+        codeForIssue({ code: 'custom', params: { metricsCode: 42 }, path: ['x'] })
+      ).toBe(METRICS_VALIDATION_CODES.FIELD_INVALID);
+    });
+
+    it('does not let a declared code mask a genuine size classification', () => {
+      expect(
+        codeForIssue({ code: 'too_big', origin: 'array', path: ['operations'] })
+      ).toBe(METRICS_VALIDATION_CODES.ARRAY_TOO_LARGE);
+    });
+  });
+
+  describe('fallbacks', () => {
+    it('falls back to FIELD_INVALID for an unrecognised issue code', () => {
+      expect(codeForIssue({ code: 'some_future_zod_code', path: ['x'] })).toBe(
+        METRICS_VALIDATION_CODES.FIELD_INVALID
+      );
+    });
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['a string', 'nope'],
+      ['a number', 7],
+    ])('falls back to FIELD_INVALID for %s', (_label, input) => {
+      expect(codeForIssue(input)).toBe(METRICS_VALIDATION_CODES.FIELD_INVALID);
+    });
+
+    it('falls back when size origin is unrecognised', () => {
+      expect(codeForIssue({ code: 'too_big', origin: 'date', path: ['x'] })).toBe(
+        METRICS_VALIDATION_CODES.FIELD_TOO_LONG
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #653 
What I changed
New: [src/constants/metricsValidationCodes.js](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/constants/metricsValidationCodes.js)
A frozen 12-code taxonomy (FIELD_REQUIRED, FIELD_TYPE_INVALID, FIELD_TOO_LONG, ARRAY_TOO_LARGE, UNKNOWN_FIELD, …) plus codeForIssue(), which maps a Zod issue to a stable code. Two details worth review:

It splits too_small/too_big by origin so a 26-item array reports ARRAY_TOO_LARGE, not the same code as a 129-char string.
It reads both origin (Zod 4) and type (Zod 3) since the repo has both versions in the tree.
[src/schemas/metrics.js](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/schemas/metrics.js)

limit now rejects instead of repairing. A regex gate (/^-?\d+$/) runs before parsing, so 20abc, 1e5, 0x10 are rejected — parseInt accepted the first two.
cursor bounded to 512 chars (was unbounded).
New parseValidationFieldCodes() emits a fieldCodes map alongside fieldErrors, and expands unknown-key issues per offending key so the response names which field was rejected.
Bulk failures now carry code: METRICS_VALIDATION_ERROR.
[src/routes/sme/metrics.js](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/routes/sme/metrics.js) — dropped the raw-req.query fallback in the GET handler; it was dead code (the validator always sets validatedQuery) that only weakened the guarantee. Swagger updated.

Two things to flag
1. This is a behavioural break on error responses. Five existing tests pinned the old lenient behaviour — limit=999 → clamped to 100, limit=abc → default page size, limit=0/-5 → clamped, all returning 200. The issue asks for out-of-range values to be rejected, so I updated those tests rather than working around them. Successful in-range requests are unchanged, and type/title/status/detail/fieldErrors keep their shapes.

Supporting evidence this is the right call: src/schemas/indexerQuery.js already rejects 0, 101, -1 and abc with passing tests on the same Zod version — this brings metrics in line with an existing repo convention.

2. I could not run the test suite. node_modules is empty and you declined the install, so npm run lint, npm test and npm run build were never executed. What I did verify:

All 8 touched files pass node --check.
codeForIssue logic verified by executing it directly against 21 synthesized Zod issues — all pass (it has no dependencies).
The Zod addIssue + z.NEVER pattern is copied from indexerQuery.js, which has passing tests for exactly this path.
The schema behaviour itself is unverified against real Zod. The issue asks for the full test output in the PR description — you'll need to run the suite to produce that. I'd expect tests/sme.metrics.validation.test.js to be where problems surface first, since it's the only new file that boots the real app.

I also added a coverage gate for the new constants module but deliberately left src/schemas/metrics.js without one — asserting a 95% threshold I hadn't measured would be a number I can't back.

Docs: new [docs/metrics-validation.md](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/docs/metrics-validation.md), plus an entry in [docs/changelog-metrics.md](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/docs/changelog-metrics.md) — that file carries a mandatory contribution policy requiring one for any metrics payload change.

One inconsistency I noticed but did not touch: src/middleware/metricsErrorHandler.js maps its VALIDATION_ERROR to 422, while these validators return 400. Different routes, so no conflict, but it's a latent contract wrinkle across the metrics surface if you want it unified separately