### PR TITLE
feat(invoice-state): add readiness sub-check

### DIFF
--- a/src/services/health.invoiceState.test.js
+++ b/src/services/health.invoiceState.test.js
@@ -1,0 +1,129 @@
+/**
+ * @file Tests for the invoice-state readiness sub-check
+ * ({@link module:services/health.checkInvoiceStateHealth}).
+ *
+ * Deliberately isolated from `health.test.js`: that file's own
+ * `beforeEach` crashes (`Cannot read properties of undefined (reading
+ * 'get')` on `escrowIndexerLastCursorAdvanceTimestampSeconds.get`) for a
+ * pre-existing, unrelated reason — the global `../metrics` mock registered
+ * in `tests/mocks/setup.js` (`setupFilesAfterEnv`) only provides
+ * `footprintCache*`/KYC-webhook counters, and this repo's Jest config has
+ * `"transform": {}` (no babel-jest), so `jest.mock()` calls are not
+ * hoisted; `health.test.js`'s own, more complete local
+ * `jest.mock('../metrics', ...)` factory does not take precedence over the
+ * one already registered by the global setup file. Confirmed pre-existing
+ * on unmodified `main` (via `git stash`) and independently corroborated by
+ * this repo's own CI job logs, which show the `Test` job exiting non-zero
+ * even on `main`'s own recent "green" runs — this repo's CI does not fail
+ * the workflow on test failures.
+ *
+ * `checkInvoiceStateHealth` never touches `../metrics` at all (only
+ * `../config` and `../db/knex`), so a standalone file avoids that crash
+ * entirely — confirmed empirically before writing these tests.
+ */
+
+jest.mock('../config', () => ({
+  get: jest.fn(() => ({ INVOICE_STATE_ENABLED: 'true' })),
+}));
+
+const { checkInvoiceStateHealth } = require('./health');
+const cfg = require('../config');
+const db = require('../db/knex');
+
+describe('checkInvoiceStateHealth', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.INVOICE_STATE_HEALTH_TIMEOUT_MS;
+    cfg.get.mockReturnValue({ INVOICE_STATE_ENABLED: 'true' });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('returns disabled when INVOICE_STATE_ENABLED is not "true"', async () => {
+    cfg.get.mockReturnValue({ INVOICE_STATE_ENABLED: 'false' });
+
+    const result = await checkInvoiceStateHealth();
+
+    expect(result).toEqual({ status: 'disabled' });
+  });
+
+  it('returns disabled when INVOICE_STATE_ENABLED is unset', async () => {
+    cfg.get.mockReturnValue({});
+
+    const result = await checkInvoiceStateHealth();
+
+    expect(result).toEqual({ status: 'disabled' });
+  });
+
+  it('does not touch the database when disabled (fast, non-blocking)', async () => {
+    cfg.get.mockReturnValue({ INVOICE_STATE_ENABLED: 'false' });
+
+    await checkInvoiceStateHealth();
+
+    expect(db).not.toHaveBeenCalled();
+  });
+
+  it('returns healthy with a latency when enabled and the invoices table is reachable', async () => {
+    const result = await checkInvoiceStateHealth();
+
+    expect(result.status).toBe('healthy');
+    expect(result.latency).toBeGreaterThanOrEqual(0);
+    expect(db).toHaveBeenCalledWith('invoices');
+  });
+
+  it('returns unhealthy when the invoices table query rejects', async () => {
+    db.limit.mockImplementationOnce(() => Promise.reject(new Error('ECONNREFUSED')));
+
+    const result = await checkInvoiceStateHealth();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.error).toBe('ECONNREFUSED');
+    expect(result.latency).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns unhealthy on a bounded timeout when the query hangs', async () => {
+    process.env.INVOICE_STATE_HEALTH_TIMEOUT_MS = '10';
+    db.limit.mockImplementationOnce(() => new Promise(() => {}));
+
+    const result = await checkInvoiceStateHealth();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.error).toBe('INVOICE_STATE_PROBE_TIMEOUT');
+    // Bounded: the probe must resolve near the configured timeout, not hang
+    // indefinitely or wait for some unrelated default.
+    expect(result.latency).toBeLessThan(500);
+  });
+
+  it('falls back to the default 2000ms timeout when the env var is unset or invalid', async () => {
+    process.env.INVOICE_STATE_HEALTH_TIMEOUT_MS = 'not-a-number';
+    // A fast-resolving query should still complete well under the 2000ms default.
+    const result = await checkInvoiceStateHealth();
+
+    expect(result.status).toBe('healthy');
+  });
+
+  it('returns unhealthy when the state machine definitions are empty', async () => {
+    jest.resetModules();
+    jest.doMock('./invoiceStateMachine', () => ({
+      INVOICE_STATES: {},
+      VALID_TRANSITIONS: {},
+    }));
+    jest.doMock('../config', () => ({
+      get: jest.fn(() => ({ INVOICE_STATE_ENABLED: 'true' })),
+    }));
+
+    const { checkInvoiceStateHealth: freshCheck } = require('./health');
+    const result = await freshCheck();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.error).toBe('Invoice state machine definitions are empty');
+
+    jest.dontMock('./invoiceStateMachine');
+    jest.dontMock('../config');
+  });
+});

--- a/src/services/health.js
+++ b/src/services/health.js
@@ -342,6 +342,76 @@ async function checkKycHealth() {
 }
 
 /**
+ * Checks invoice-state readiness.
+ *
+ * Optional / non-blocking dependency, matching the KYC and indexer-staleness
+ * checks above: returns `'disabled'` when the `INVOICE_STATE_ENABLED` feature
+ * flag (see `src/config/index.js`, gates route mounting in `app.js`) is not
+ * `'true'`, so a deployment that doesn't run invoice-state is never held back
+ * by this check.
+ *
+ * When enabled, verifies two independent things, both fast:
+ * 1. The in-process state-machine definitions (`INVOICE_STATES`,
+ *    `VALID_TRANSITIONS` from `./invoiceStateMachine`) are non-empty — a
+ *    zero-I/O sanity check that catches a broken module load immediately,
+ *    with no timeout needed since it never leaves the process.
+ * 2. The `invoices` table (invoice-state's core dependency) is queryable,
+ *    via a bounded, timeout-guarded probe mirroring `checkDatabaseHealth`'s
+ *    `Promise.race` pattern — catches invoice-state-specific issues (e.g. a
+ *    missing/renamed column from a bad migration) that a generic `SELECT 1`
+ *    against the DB connection would not.
+ *
+ * Status values:
+ * - `'healthy'`    — state machine definitions are well-formed and the
+ *                    `invoices` table is reachable within the timeout.
+ * - `'unhealthy'`  — state machine definitions are malformed, or the table
+ *                    probe failed/timed out.
+ * - `'disabled'`   — `INVOICE_STATE_ENABLED` is not `'true'`.
+ *
+ * Tuning env var:
+ * - `INVOICE_STATE_HEALTH_TIMEOUT_MS` — milliseconds before the table probe
+ *                                       times out (default 2000).
+ *
+ * @returns {Promise<{status: string, latency?: number, error?: string}>}
+ */
+async function checkInvoiceStateHealth() {
+  if (cfg.get().INVOICE_STATE_ENABLED !== 'true') {
+    return { status: 'disabled' };
+  }
+
+  const { INVOICE_STATES, VALID_TRANSITIONS } = require('./invoiceStateMachine');
+  if (
+    !INVOICE_STATES ||
+    Object.keys(INVOICE_STATES).length === 0 ||
+    !VALID_TRANSITIONS ||
+    Object.keys(VALID_TRANSITIONS).length === 0
+  ) {
+    return { status: 'unhealthy', error: 'Invoice state machine definitions are empty' };
+  }
+
+  const timeoutMs = parseInt(process.env.INVOICE_STATE_HEALTH_TIMEOUT_MS, 10) || 2000;
+  const start = Date.now();
+  let timeoutId;
+
+  try {
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('INVOICE_STATE_PROBE_TIMEOUT')), timeoutMs);
+      if (timeoutId.unref) {
+        timeoutId.unref();
+      }
+    });
+
+    await Promise.race([db('invoices').select('id').limit(1), timeoutPromise]);
+    clearTimeout(timeoutId);
+
+    return { status: 'healthy', latency: Date.now() - start };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    return { status: 'unhealthy', latency: Date.now() - start, error: error.message };
+  }
+}
+
+/**
  * Checks escrow indexer staleness.
  * Returns 'disabled' when the indexer is not enabled.
  * Returns 'stale' when the cursor hasn't advanced within the configured threshold.
@@ -424,19 +494,21 @@ async function checkStorageHealth() {
  * @returns {Promise<{healthy: boolean, checks: Object}>}
  */
 async function performHealthChecks() {
-  const [soroban, database, kyc, indexerStaleness, storage] = await Promise.all([
+  const [soroban, database, kyc, indexerStaleness, storage, invoiceState] = await Promise.all([
     checkSorobanHealth(),
     checkDatabaseHealth(),
     checkKycHealth(),
     checkIndexerStaleness(),
     checkStorageHealth(),
+    checkInvoiceStateHealth(),
   ]);
 
-  const checks = { soroban, database, kyc, indexerStaleness, storage };
+  const checks = { soroban, database, kyc, indexerStaleness, storage, invoiceState };
   const healthy =
     (soroban.status === 'healthy' || soroban.status === 'unknown') &&
     (kyc.status === 'healthy' || kyc.status === 'disabled') &&
     (indexerStaleness.status === 'healthy' || indexerStaleness.status === 'disabled') &&
+    (invoiceState.status === 'healthy' || invoiceState.status === 'disabled') &&
     // Storage is in-memory or opted out → non-blocking. Missing config or
     // unreachable buckets → blocking for `/ready` because uploads will fail.
     storage.status !== 'not_configured' &&
@@ -540,7 +612,7 @@ async function performReadinessChecks() {
  * This makes the list stable and sortable for cursor-based pagination.
  *
  * The check order is fixed to: soroban → database → kyc → indexerStaleness →
- * storage → reconciliation, which matches `performHealthChecks` /
+ * storage → invoiceState → reconciliation, which matches `performHealthChecks` /
  * `performReadinessChecks`.
  *
  * @param {Object}  [options]
@@ -552,12 +624,13 @@ async function listHealthChecks({ snapshotTime } = {}) {
   const ts = snapshotTime !== undefined ? snapshotTime : Date.now();
   const timestamp = new Date(ts).toISOString();
 
-  const [soroban, database, kyc, indexerStaleness, storage, reconciliation] = await Promise.all([
+  const [soroban, database, kyc, indexerStaleness, storage, invoiceState, reconciliation] = await Promise.all([
     checkSorobanHealth(),
     checkDatabaseHealth(),
     checkKycHealth(),
     checkIndexerStaleness(),
     checkStorageHealth(),
+    checkInvoiceStateHealth(),
     checkReconciliationHealth(),
   ]);
 
@@ -567,6 +640,7 @@ async function listHealthChecks({ snapshotTime } = {}) {
     { id: 'kyc', name: 'KYC Provider', status: kyc.status, timestamp, detail: kyc },
     { id: 'indexerStaleness', name: 'Escrow Indexer Staleness', status: indexerStaleness.status, timestamp, detail: indexerStaleness },
     { id: 'storage', name: 'Storage (S3)', status: storage.status, timestamp, detail: storage },
+    { id: 'invoiceState', name: 'Invoice State', status: invoiceState.status, timestamp, detail: invoiceState },
     { id: 'reconciliation', name: 'Escrow Reconciliation', status: reconciliation.status, timestamp, detail: reconciliation },
   ];
 }
@@ -577,6 +651,7 @@ module.exports = {
   checkKycHealth,
   checkStorageHealth,
   checkIndexerStaleness,
+  checkInvoiceStateHealth,
   checkReconciliationHealth,
   performHealthChecks,
   performReadinessChecks,


### PR DESCRIPTION
Closes #1110

## Summary

Adds `checkInvoiceStateHealth()` to `src/services/health.js`, an invoice-state readiness sub-check contributing to the `/ready` full-health probe (`performHealthChecks`) and the `listHealthChecks` listing utility. It follows the exact conventions already established by the KYC and indexer-staleness checks in the same file:

- **Fast, non-blocking, timeout-guarded**: a bounded `Promise.race` probe against the `invoices` table (default 2000ms, tunable via `INVOICE_STATE_HEALTH_TIMEOUT_MS`), mirroring `checkDatabaseHealth`'s exact timeout pattern.
- **Degrades gracefully when optional**: returns `{status: 'disabled'}` when the existing `INVOICE_STATE_ENABLED` feature flag (`src/config/index.js`, already gates route mounting in `app.js`) is not `'true'` — matching the KYC/indexer-staleness `'disabled'` convention exactly, so a deployment that doesn't run invoice-state is never held back.
- **Two independent signals when enabled**, both fast:
  1. The in-process state-machine definitions (`INVOICE_STATES`, `VALID_TRANSITIONS` from `./invoiceStateMachine`) are non-empty — zero-I/O, catches a broken module load immediately.
  2. The `invoices` table is queryable within the timeout — catches invoice-state-specific issues (e.g. a missing/renamed column from a bad migration) that a generic `SELECT 1` against the DB connection wouldn't.

Wired into `performHealthChecks()` (the `/ready` full-dependency probe) and `listHealthChecks()`, alongside the other optional dependencies. **Deliberately not added to `performReadinessChecks()`** (the critical-path-only `/readyz` probe) — that function already documents its philosophy as "only critical upstream dependencies that would prevent any business request from completing," and explicitly omits KYC/indexer-staleness for the same reason. Invoice-state, gated by its own opt-out flag, fits that same "optional" category.

## Tests

New file `src/services/health.invoiceState.test.js`, 8 tests, all passing:

- disabled when `INVOICE_STATE_ENABLED` is `'false'`
- disabled when the flag is unset
- doesn't touch the database at all when disabled (confirms "fast, non-blocking")
- healthy with a latency when enabled and the table is reachable
- unhealthy when the table query rejects
- unhealthy on a bounded timeout when the query hangs (asserts latency stays well under the hang duration — the actual "timeout-guarded" behavior, not just a status string)
- falls back to the 2000ms default when the timeout env var is unset/invalid
- unhealthy when the state-machine definitions are empty

```
PASS src/services/health.invoiceState.test.js
Tests: 8 passed, 8 total
```

`npx eslint src/services/health.js src/services/health.invoiceState.test.js` — clean.

## Why this test lives in its own file, and a pre-existing test-harness issue I found (and worked around, didn't fix)

I initially planned to add these tests to the existing `src/services/health.test.js`, but every one of its 41 tests currently fails identically at `beforeEach`, with `TypeError: Cannot read properties of undefined (reading 'get')` on `escrowIndexerLastCursorAdvanceTimestampSeconds.get`. Root cause: the global `tests/mocks/setup.js` (`setupFilesAfterEnv`, applies to every test file in the repo) registers its own, incomplete `jest.mock('../../src/metrics', ...)` — providing only `footprintCache*` and KYC-webhook counters. `health.test.js` registers its *own*, more complete local mock for the same module (including `escrowIndexerLastCursorAdvanceTimestampSeconds` and `readinessGauge`), but this repo's Jest config has `"transform": {}` (no babel-jest), so `jest.mock()` calls aren't hoisted — and the global setup file's mock wins instead of being overridden.

I confirmed this is:
- **Pre-existing**, via `git stash` on this exact file (fails identically with zero of my changes present).
- **Not fixed by syncing to the latest upstream `main`** (I pulled `Liquifact-Org/Liquifact-backend@main` fresh mid-session; still fails).
- **Not visible in this repo's CI status** only because CI doesn't fail the workflow on test failures — I confirmed this directly by inspecting the job logs of a currently-"✓ success" CI run on `main`: the `Test` job itself shows `Process completed with exit code 1`, and the `Lint` job shows multiple real lint errors, yet the overall workflow still reports success.
- Broader than just `health.test.js` — `tests/health.listing.test.js` and `tests/health.endpoint.test.js` also currently fail to even load (`ReferenceError: persistenceErrorHandler is not defined` in `src/routes/sme/index.js:118`, and a separate Zod schema error), both confirmed pre-existing the same way.

I did **not** attempt to fix any of this — it's a shared test-infrastructure file affecting many unrelated test suites repo-wide, well outside the scope of an invoice-state readiness check, and not something I want to risk touching blind. Instead: `checkInvoiceStateHealth` never touches `../metrics` at all (only `../config` and `../db/knex`, neither of which have this conflict), so I put its tests in a new, standalone file that never hits the broken `beforeEach` — confirmed empirically to run cleanly in isolation before I wrote the real test cases.

## Verification

- `npx jest src/services/health.invoiceState.test.js` — 8/8 passing (shown above).
- `npx eslint` — clean.
- `npm run build` (`tsc -p tsconfig.build.json`) / `npm test` (full suite) — **not independently verified**; per the above, this repo's test suite has multiple pre-existing, unrelated failures (metrics-mock precedence, an undefined `persistenceErrorHandler` reference, a Zod schema error) that block a full clean run regardless of this PR's contents. My own new code and tests are verified in isolation as shown above.
