### PR TITLE
feat(invoice-state): add structured request logging

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -2398,6 +2398,8 @@ module.exports = {
   invoiceStateCacheHitsTotal,
   invoiceStateCacheMissesTotal,
   invoiceStateCacheEvictionsTotal,
+  invoiceStateRequestDurationMs,
+  invoiceStateRequestCount,
   persistenceRequestDurationSeconds,
   persistenceRequestsTotal,
   persistenceRequestErrorsTotal,

--- a/src/middleware/invoiceStateMetrics.js
+++ b/src/middleware/invoiceStateMetrics.js
@@ -1,0 +1,148 @@
+'use strict';
+
+/**
+ * @fileoverview Instrumentation wrapper for invoice-state endpoints.
+ *
+ * Wraps an async Express handler so that every request records:
+ *   - request duration (histogram, labelled by route + method + status class)
+ *   - a request count (counter, labelled by route + method + status class)
+ *   - a single structured log line (no PII — route, method, and outcome only)
+ *
+ * `invoiceStateRequestDurationMs` / `invoiceStateRequestCount` already existed
+ * in `../metrics` but were never exported or wired into any route, so this
+ * previously recorded nothing. This module connects them.
+ *
+ * Modelled on `middleware/healthMetrics.js` (the same
+ * measure-on-`res.on('finish')` + bounded-label pattern, already used by the
+ * `/ready` and `/readyz` routes) rather than `middleware/configMetrics.js`,
+ * which currently imports several `../metrics` exports that don't exist.
+ *
+ * @module middleware/invoiceStateMetrics
+ */
+
+const { invoiceStateRequestDurationMs, invoiceStateRequestCount } = require('../metrics');
+const logger = require('../logger');
+
+/**
+ * Classifies an HTTP status code into a fixed, low-cardinality bucket.
+ *
+ * @param {number} statusCode - HTTP response status code.
+ * @returns {'2xx'|'3xx'|'4xx'|'5xx'|'other'}
+ */
+function normalizeStatusClass(statusCode) {
+  if (statusCode >= 500) {return '5xx';}
+  if (statusCode >= 400) {return '4xx';}
+  if (statusCode >= 300) {return '3xx';}
+  if (statusCode >= 200) {return '2xx';}
+  return 'other';
+}
+
+/**
+ * Classifies the error that ended a request into a fixed, low-cardinality
+ * label. `StateTransitionError` (thrown by `services/invoiceStateService`)
+ * already carries a bounded `code` (e.g. `INVOICE_NOT_FOUND`,
+ * `CANNOT_LINK_TO_ESCROW`) — that code IS the cause. Anything else falls
+ * back to a single `internal_error` bucket so an unexpected error's raw
+ * message (which could contain arbitrary/sensitive detail) never becomes a
+ * Prometheus label or a log field.
+ *
+ * @param {unknown} error - Error thrown by the handler, if any.
+ * @returns {string} `'none'`, a `StateTransitionError` code, or `'internal_error'`.
+ */
+function normalizeErrorCause(error) {
+  if (!error) {return 'none';}
+  if (error.name === 'StateTransitionError' && typeof error.code === 'string' && error.code) {
+    return error.code;
+  }
+  return 'internal_error';
+}
+
+/**
+ * Records metrics and a structured log for one completed invoice-state
+ * request. Kept separate from {@link instrumentInvoiceState} so it can be
+ * unit-tested in isolation against each status class without driving a full
+ * HTTP request.
+ *
+ * @param {object} params
+ * @param {string} params.route - Bounded route label (e.g. `'state'`, `'transition'`).
+ * @param {string} params.method - HTTP method (`req.method`).
+ * @param {number} params.statusCode - Final HTTP status code.
+ * @param {number} params.durationMs - Wall-clock duration in milliseconds.
+ * @param {unknown} [params.error] - Error thrown by the handler, if any.
+ * @param {import('express').Request} [params.req] - Request, for a scoped logger.
+ * @returns {void}
+ */
+function recordInvoiceStateOutcome({ route, method, statusCode, durationMs, error, req }) {
+  const statusClass = normalizeStatusClass(statusCode);
+  const errorCause = normalizeErrorCause(error);
+
+  invoiceStateRequestDurationMs.labels(route, method, statusClass, errorCause).observe(durationMs);
+  invoiceStateRequestCount.labels(route, method, statusClass, errorCause).inc();
+
+  // Structured log — safe fields only. Never log request bodies, invoice
+  // identifiers, transition reasons, or raw error messages; `route` is the
+  // bounded pattern (e.g. "/:id/state"), never the literal request path.
+  const log = (req && typeof logger.createRequestLogger === 'function')
+    ? logger.createRequestLogger(req)
+    : logger;
+  const fields = {
+    route,
+    method,
+    statusClass,
+    statusCode,
+    durationMs: Number(durationMs.toFixed(3)),
+    errorCause,
+  };
+
+  if (statusClass === '5xx') {
+    log.error(fields, 'invoice-state request failed');
+  } else if (statusClass === '4xx') {
+    log.warn(fields, 'invoice-state request rejected');
+  } else {
+    log.info(fields, 'invoice-state request completed');
+  }
+}
+
+/**
+ * Wraps an async invoice-state handler with metrics + structured logging.
+ *
+ * The wrapped handler runs normally. Duration is measured from entry to the
+ * moment the response finishes (`res.on('finish')`), so the recorded status
+ * code is the one actually sent. If the handler throws, the error is stashed
+ * on `res.locals` for the finish listener to classify, then re-thrown to the
+ * next error middleware — behaviour is otherwise unchanged.
+ *
+ * @param {string} route - Bounded route label, e.g. `'state'`, `'transition'`,
+ *   `'approve'`, `'link-escrow'`, `'reject'`, `'history'`, `'bulk'`.
+ * @param {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>} handler
+ * @returns {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => Promise<void>}
+ */
+function instrumentInvoiceState(route, handler) {
+  return async function instrumentedInvoiceStateHandler(req, res, next) {
+    const startNs = process.hrtime.bigint();
+    let recorded = false;
+
+    res.on('finish', () => {
+      if (recorded) { return; }
+      recorded = true;
+      const durationMs = Number(process.hrtime.bigint() - startNs) / 1e6;
+      recordInvoiceStateOutcome({
+        route,
+        method: req.method,
+        statusCode: res.statusCode,
+        durationMs,
+        error: res.locals && res.locals.invoiceStateMetricsError,
+        req,
+      });
+    });
+
+    try {
+      await handler(req, res, next);
+    } catch (err) {
+      if (res.locals) { res.locals.invoiceStateMetricsError = err; }
+      return next(err);
+    }
+  };
+}
+
+module.exports = { instrumentInvoiceState, recordInvoiceStateOutcome, normalizeStatusClass, normalizeErrorCause };

--- a/src/middleware/invoiceStateMetrics.test.js
+++ b/src/middleware/invoiceStateMetrics.test.js
@@ -1,0 +1,223 @@
+/**
+ * @file Tests for the invoice-state request-logging/metrics middleware
+ * ({@link module:middleware/invoiceStateMetrics}).
+ *
+ * Uses `jest.resetModules()` + `jest.doMock()` (not a plain top-of-file
+ * `jest.mock('../metrics', ...)`) because this repo's global
+ * `tests/mocks/setup.js` (`setupFilesAfterEnv`) already registers its own,
+ * incomplete `../metrics` mock, and this repo's Jest config has
+ * `"transform": {}` (no babel-jest), so plain `jest.mock()` calls in a test
+ * file are not hoisted above that global registration and do not reliably
+ * take precedence for the same module path. `jest.resetModules()` +
+ * `jest.doMock()` immediately before `require()` sidesteps that — the same
+ * technique already validated in `src/services/health.invoiceState.test.js`.
+ *
+ * `tests/invoiceState.observability.test.js` (pre-existing) attempts to
+ * cover this same concern but is a stale artifact: it references
+ * `mockInvoices` as an export of `src/routes/invoiceStateRoutes.js`, which
+ * does not exist — the current routes are DB-backed via
+ * `services/invoiceStateService`, not an in-memory map. That file currently
+ * fails even on unmodified `main` (`registry.resetMetrics is not a
+ * function`, the same setup.js precedence issue described above, compounded
+ * by the architecture mismatch). Left untouched — out of scope here.
+ */
+
+'use strict';
+
+describe('invoiceStateMetrics', () => {
+  let logger;
+  let invoiceStateRequestDurationMs;
+  let invoiceStateRequestCount;
+  let instrumentInvoiceState;
+  let recordInvoiceStateOutcome;
+  let normalizeStatusClass;
+  let normalizeErrorCause;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    invoiceStateRequestDurationMs = { labels: jest.fn().mockReturnThis(), observe: jest.fn() };
+    invoiceStateRequestCount = { labels: jest.fn().mockReturnThis(), inc: jest.fn() };
+
+    jest.doMock('../metrics', () => ({
+      invoiceStateRequestDurationMs,
+      invoiceStateRequestCount,
+    }));
+
+    logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    logger.createRequestLogger = jest.fn(() => logger);
+    jest.doMock('../logger', () => logger);
+
+    ({ instrumentInvoiceState, recordInvoiceStateOutcome, normalizeStatusClass, normalizeErrorCause } =
+      require('./invoiceStateMetrics'));
+  });
+
+  afterEach(() => {
+    jest.dontMock('../metrics');
+    jest.dontMock('../logger');
+  });
+
+  describe('normalizeStatusClass', () => {
+    it.each([
+      [200, '2xx'],
+      [201, '2xx'],
+      [301, '3xx'],
+      [400, '4xx'],
+      [404, '4xx'],
+      [500, '5xx'],
+      [503, '5xx'],
+      [0, 'other'],
+    ])('maps %i to %s', (statusCode, expected) => {
+      expect(normalizeStatusClass(statusCode)).toBe(expected);
+    });
+  });
+
+  describe('normalizeErrorCause', () => {
+    it('returns "none" when there is no error', () => {
+      expect(normalizeErrorCause(undefined)).toBe('none');
+      expect(normalizeErrorCause(null)).toBe('none');
+    });
+
+    it('returns the bounded StateTransitionError code when present', () => {
+      const error = Object.assign(new Error('Invoice not found'), {
+        name: 'StateTransitionError',
+        code: 'INVOICE_NOT_FOUND',
+      });
+      expect(normalizeErrorCause(error)).toBe('INVOICE_NOT_FOUND');
+    });
+
+    it('falls back to internal_error for an unrecognized error shape', () => {
+      expect(normalizeErrorCause(new Error('boom'))).toBe('internal_error');
+    });
+
+    it('falls back to internal_error when name matches but code is missing', () => {
+      const error = Object.assign(new Error('boom'), { name: 'StateTransitionError' });
+      expect(normalizeErrorCause(error)).toBe('internal_error');
+    });
+  });
+
+  describe('recordInvoiceStateOutcome', () => {
+    it('logs at info level for a 2xx outcome, with no PII fields', () => {
+      recordInvoiceStateOutcome({ route: 'state', method: 'GET', statusCode: 200, durationMs: 12.3456 });
+
+      expect(invoiceStateRequestDurationMs.labels).toHaveBeenCalledWith('state', 'GET', '2xx', 'none');
+      expect(invoiceStateRequestDurationMs.observe).toHaveBeenCalledWith(12.3456);
+      expect(invoiceStateRequestCount.labels).toHaveBeenCalledWith('state', 'GET', '2xx', 'none');
+      expect(invoiceStateRequestCount.inc).toHaveBeenCalled();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          route: 'state',
+          method: 'GET',
+          statusClass: '2xx',
+          statusCode: 200,
+          durationMs: 12.346,
+          errorCause: 'none',
+        },
+        'invoice-state request completed'
+      );
+      // No PII / secret-shaped fields: no invoiceId, body, reason, message, or stack.
+      const loggedFields = logger.info.mock.calls[0][0];
+      expect(Object.keys(loggedFields).sort()).toEqual(
+        ['durationMs', 'errorCause', 'method', 'route', 'statusClass', 'statusCode'].sort()
+      );
+    });
+
+    it('logs at warn level for a 4xx outcome', () => {
+      const error = Object.assign(new Error('x'), { name: 'StateTransitionError', code: 'MISSING_TARGET_STATE' });
+      recordInvoiceStateOutcome({ route: 'transition', method: 'POST', statusCode: 400, durationMs: 5, error });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ statusClass: '4xx', errorCause: 'MISSING_TARGET_STATE' }),
+        'invoice-state request rejected'
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('logs at error level for a 5xx outcome', () => {
+      recordInvoiceStateOutcome({
+        route: 'approve',
+        method: 'POST',
+        statusCode: 500,
+        durationMs: 42,
+        error: new Error('db down'),
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ statusClass: '5xx', errorCause: 'internal_error' }),
+        'invoice-state request failed'
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('uses a request-scoped logger when req is provided', () => {
+      const scopedLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+      logger.createRequestLogger.mockReturnValue(scopedLogger);
+      const req = { id: 'req-123' };
+
+      recordInvoiceStateOutcome({ route: 'state', method: 'GET', statusCode: 200, durationMs: 1, req });
+
+      expect(logger.createRequestLogger).toHaveBeenCalledWith(req);
+      expect(scopedLogger.info).toHaveBeenCalled();
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('instrumentInvoiceState', () => {
+    function fakeRes(statusCode) {
+      const listeners = {};
+      return {
+        statusCode,
+        locals: {},
+        on: jest.fn((event, cb) => { listeners[event] = cb; }),
+        _finish: () => listeners.finish && listeners.finish(),
+      };
+    }
+
+    it('records the outcome once the response finishes, with the real status code', async () => {
+      const handler = jest.fn(async (req, res) => {
+        res.statusCode = 200;
+      });
+      const wrapped = instrumentInvoiceState('state', handler);
+      const req = {};
+      const res = fakeRes(200);
+
+      await wrapped(req, res, jest.fn());
+      res._finish();
+
+      expect(handler).toHaveBeenCalledWith(req, res, expect.any(Function));
+      expect(invoiceStateRequestCount.labels).toHaveBeenCalledWith('state', undefined, '2xx', 'none');
+    });
+
+    it('stashes a thrown error on res.locals and re-throws to next, then records it on finish', async () => {
+      const boom = Object.assign(new Error('nope'), { name: 'StateTransitionError', code: 'INVOICE_NOT_FOUND' });
+      const handler = jest.fn(async () => { throw boom; });
+      const wrapped = instrumentInvoiceState('state', handler);
+      const req = { method: 'GET' };
+      const res = fakeRes(404);
+      const next = jest.fn();
+
+      await wrapped(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(boom);
+      expect(res.locals.invoiceStateMetricsError).toBe(boom);
+
+      res._finish();
+      expect(invoiceStateRequestCount.labels).toHaveBeenCalledWith('state', 'GET', '4xx', 'INVOICE_NOT_FOUND');
+    });
+
+    it('only records once even if finish fires more than once', async () => {
+      const handler = jest.fn(async (req, res) => { res.statusCode = 200; });
+      const wrapped = instrumentInvoiceState('state', handler);
+      const res = fakeRes(200);
+
+      await wrapped({}, res, jest.fn());
+      res._finish();
+      res._finish();
+
+      expect(invoiceStateRequestCount.inc).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/routes/invoiceStateRoutes.js
+++ b/src/routes/invoiceStateRoutes.js
@@ -12,6 +12,8 @@ const { invoiceStateCacheEvictionsTotal } = require('../metrics');
 const { extractTenant } = require('../middleware/tenant');
 const { createCompressionMiddleware } = require('../middleware/compression');
 const invoiceStateErrorHandler = require('../middleware/invoiceStateErrorHandler');
+const { instrumentInvoiceState } = require('../middleware/invoiceStateMetrics');
+const logger = require('../logger');
 
 router.use(extractTenant);
 
@@ -115,13 +117,7 @@ function sendTransitionError(res, error, correlationId) {
   });
 }
 
-/**
- * Classifies an HTTP status code into a coarse status bucket.
- *
- * @param {number} statusCode - HTTP status code.
- * @returns {string} Status class label.
- */
-router.get('/:id/state', cacheState, async (req, res, next) => {
+router.get('/:id/state', cacheState, instrumentInvoiceState('state', async (req, res, next) => {
   try {
     const result = await invoiceStateService.getState(req.params.id, req.tenantId);
 
@@ -132,7 +128,7 @@ router.get('/:id/state', cacheState, async (req, res, next) => {
   } catch (error) {
     return next(error);
   }
-});
+}));
 
 /**
  * @swagger
@@ -183,7 +179,7 @@ router.get('/:id/state', cacheState, async (req, res, next) => {
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.post('/:id/transition', async (req, res, next) => {
+router.post('/:id/transition', instrumentInvoiceState('transition', async (req, res, next) => {
   const { targetState, reason } = req.body || {};
 
   try {
@@ -199,7 +195,7 @@ router.post('/:id/transition', async (req, res, next) => {
   } catch (error) {
     return next(error);
   }
-});
+}));
 
 /**
  * POST /api/invoices/:id/approve
@@ -251,7 +247,7 @@ router.post('/:id/transition', async (req, res, next) => {
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.post('/:id/approve', async (req, res, next) => {
+router.post('/:id/approve', instrumentInvoiceState('approve', async (req, res, next) => {
   const { reason } = req.body || {};
 
   try {
@@ -271,7 +267,7 @@ router.post('/:id/approve', async (req, res, next) => {
     }
     return next(error);
   }
-});
+}));
 
 /**
  * @swagger
@@ -321,7 +317,7 @@ router.post('/:id/approve', async (req, res, next) => {
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req, res, next) => {
+router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, instrumentInvoiceState('link-escrow', async (req, res, next) => {
   const { escrowId, reason } = req.body || {};
 
   try {
@@ -344,7 +340,7 @@ router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req
     }
     return next(error);
   }
-});
+}));
 
 /**
  * @swagger
@@ -393,7 +389,7 @@ router.post('/:id/link-escrow', requireKycForFunding, auditKycAccess, async (req
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.post('/:id/reject', async (req, res, next) => {
+router.post('/:id/reject', instrumentInvoiceState('reject', async (req, res, next) => {
   const { reason } = req.body || {};
 
   try {
@@ -413,7 +409,7 @@ router.post('/:id/reject', async (req, res, next) => {
     }
     return next(error);
   }
-});
+}));
 
 /**
  * @swagger
@@ -452,7 +448,7 @@ router.post('/:id/reject', async (req, res, next) => {
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.get('/:id/history', async (req, res, next) => {
+router.get('/:id/history', instrumentInvoiceState('history', async (req, res, next) => {
   try {
     const result = await invoiceStateService.getHistory(req.params.id, req.tenantId);
 
@@ -467,7 +463,7 @@ router.get('/:id/history', async (req, res, next) => {
     }
     return next(error);
   }
-});
+}));
 
 const MAX_BULK_ITEMS = 25;
 
@@ -526,7 +522,7 @@ const MAX_BULK_ITEMS = 25;
  *             schema:
  *               $ref: '#/components/schemas/InvoiceStateErrorResponse'
  */
-router.post('/bulk', async (req, res, _next) => {
+router.post('/bulk', instrumentInvoiceState('bulk', async (req, res, _next) => {
   const items = req.body;
 
   if (!Array.isArray(items)) {
@@ -603,7 +599,12 @@ router.post('/bulk', async (req, res, _next) => {
         }
       }
     } catch (error) {
-      console.error('BULK ITEM ERROR', { index, action, invoiceId, code: error.code, message: error.message, stack: error.stack });
+      // Structured, PII-safe log: bounded action/code only — no invoiceId,
+      // error message, or stack trace (per #1111, never log secrets/PII).
+      logger.warn(
+        { index, action, code: error.code || 'BULK_ITEM_ERROR' },
+        'invoice-state bulk item failed'
+      );
       results.push({
         index,
         success: false,
@@ -624,7 +625,7 @@ router.post('/bulk', async (req, res, _next) => {
     correlationId: req.correlationId || req.id || null,
     message: 'Bulk invoice-state operation completed',
   });
-});
+}));
 
 // Mount the shared invoice-state error middleware after all route
 // handlers so StateTransitionErrors from any handler receive a

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -18,6 +18,13 @@ jest.mock('../../src/metrics', () => {
     kycWebhookErrorsTotal: { inc: jest.fn() },
     normalizeKycWebhookStatusClass: jest.fn().mockReturnValue('4xx'),
     normalizeKycWebhookCause: jest.fn().mockReturnValue('none'),
+
+    // Invoice-state request metrics — needed so
+    // middleware/invoiceStateMetrics.js's res.on('finish') callback (wired
+    // into every invoice-state route) doesn't crash in tests that exercise
+    // those routes without their own local metrics mock.
+    invoiceStateRequestDurationMs: { labels: jest.fn().mockReturnThis(), observe: jest.fn() },
+    invoiceStateRequestCount: { labels: jest.fn().mockReturnThis(), inc: jest.fn() },
   };
 });
 


### PR DESCRIPTION
Closes #1111

## Summary

Adds structured, PII-safe request logging (plus the metrics half of the same instrumentation) to all 7 invoice-state routes: `GET /:id/state`, `POST /:id/transition`, `POST /:id/approve`, `POST /:id/link-escrow`, `POST /:id/reject`, `GET /:id/history`, `POST /bulk`.

Every request now logs `route`, `method`, `statusClass`, `statusCode`, `durationMs`, and a bounded `errorCause` — nothing else. Level is chosen by outcome: `info` for 2xx/3xx, `warn` for 4xx, `error` for 5xx.

## What I found and built on

`src/metrics.js` already defines `invoiceStateRequestDurationMs` / `invoiceStateRequestCount` (histogram + counter, labelled `route`/`method`/`status_class`/`error_cause`) — but they were never exported from the module and never called anywhere. This PR exports them and wires them up for the first time.

I modelled the new middleware (`src/middleware/invoiceStateMetrics.js`) on `middleware/healthMetrics.js`, which uses this exact pattern (`res.on('finish')` + bounded labels) and is confirmed working — it's what actually powers the `/ready`/`/readyz` endpoints. I did **not** model it on `middleware/configMetrics.js`, which looks structurally identical but currently imports six names from `../metrics` (`configRequestDurationSeconds`, `normalizeConfigStatusClass`, etc.) that don't exist anywhere in that file — confirmed via direct byte-level search. That's a separate, pre-existing bug, unrelated to invoice-state; flagging it here since it's the same middleware family and a maintainer reviewing this PR would otherwise reasonably wonder why I didn't reuse it.

## PII safety

- The log payload is a fixed 6-key object — no request body, invoice ID, transition reason, escrow ID, raw error message, or stack trace ever reaches it.
- `error_cause` is bounded: `StateTransitionError` (thrown by `services/invoiceStateService`) already carries a fixed `code` enum (`INVOICE_NOT_FOUND`, `MISSING_TARGET_STATE`, etc.) which becomes the cause directly; any other error type collapses to a single `internal_error` bucket so an arbitrary/unexpected error message can never leak into a log field or a Prometheus label.
- `route` is the bounded pattern (`'state'`, `'transition'`, ...), never the literal request path (which would contain the real invoice ID).
- Also fixed a related, concrete violation of this same issue found in the existing `/bulk` handler: it had a raw `console.error('BULK ITEM ERROR', { ..., invoiceId, message: error.message, stack: error.stack })` per failed batch item — bypassing the structured logger entirely and logging the invoice ID and full stack trace. Replaced with `logger.warn({ index, action, code }, 'invoice-state bulk item failed')`.
- Also removed an orphaned JSDoc comment ("Classifies an HTTP status code into a coarse status bucket...") sitting directly above the `/:id/state` route with no function beneath it — leftover from what looks like an earlier, abandoned attempt at this exact feature.

## Tests

19 new tests in `src/middleware/invoiceStateMetrics.test.js`, all passing — covering `normalizeStatusClass`, `normalizeErrorCause`, `recordInvoiceStateOutcome` (log level per status class, exact field set / no-PII assertion, request-scoped logger), and `instrumentInvoiceState` (records once on `finish`, stashes+re-throws errors, doesn't double-record).

```
PASS src/middleware/invoiceStateMetrics.test.js
Tests: 19 passed, 19 total
```

## A pre-existing regression risk I found and fixed as part of this PR

Wiring real routes to the (previously unreachable) `invoiceStateRequestDurationMs`/`invoiceStateRequestCount` metrics initially broke 135 previously-passing tests across `tests/invoice.state*.test.js`, `tests/invoiceStateRateLimit.test.js`, and `tests/invoiceStateCompression.test.js` — `TypeError: Cannot read properties of undefined (reading 'labels')`. Root cause: those tests rely on the global `tests/mocks/setup.js` (`setupFilesAfterEnv`) metrics mock, which didn't (and, before this PR, had no reason to) include these two metrics. Since this crash is a direct consequence of code *I'm* adding in this PR (not a pre-existing, unrelated issue), I fixed it by adding both metrics to that shared mock, matching the shape already used there for the KYC-webhook metrics (`{ labels: jest.fn().mockReturnThis(), observe/inc: jest.fn() }`).

I verified this fix is complete and introduces no other regressions: I ran the full `tests/invoice.state*.test.js` + `tests/invoiceStateRateLimit.test.js` + `tests/invoiceStateCompression.test.js` suite (340 tests) both on unmodified `main` and with my changes, extracted the exact failing-test-name list from each via `--json`, and diffed them — **identical set of 68 pre-existing failures in both runs**, unrelated to logging/metrics (mostly concurrency/idempotency timing assertions in `tests/invoice.state.concurrency.test.js` and similar).

## A stale, already-broken test file for this exact feature (left untouched)

`tests/invoiceState.observability.test.js` already exists and appears to target this exact concern, but it's a stale artifact from a different, no-longer-existent architecture: it expects `mockInvoices` to be exported from `src/routes/invoiceStateRoutes.js` (an in-memory `Map`), but the current routes are DB-backed via `services/invoiceStateService` with no such export. It also fails on unmodified `main` for the same `setupFilesAfterEnv`-precedence reason described above (`registry.resetMetrics is not a function`). I left it untouched — reconciling or removing it isn't something I want to do blind, and it's not this issue's scope.

## Verification

- `npx jest src/middleware/invoiceStateMetrics.test.js` — 19/19 passing.
- `npx jest tests/invoice.state*.test.js tests/invoiceStateRateLimit.test.js tests/invoiceStateCompression.test.js` — 272/340 passing, the 68 failures confirmed identical to unmodified `main` (see above).
- `npx eslint` on all changed files — clean, **except** `src/metrics.js`, which has a pre-existing parse error unrelated to this PR: `Identifier '_PERSISTENCE_VALIDATION_CODES' has already been declared` (duplicated at lines 1430 and 1856). Confirmed via `git show HEAD:src/metrics.js` that this predates my change. This is severe enough to break `node src/index.js` / `npm start` entirely (not just tests or lint) — flagging prominently since it's much bigger than invoice-state, but well outside this issue's scope to fix in a 84KB+ shared file with heavy recent churn from unrelated PRs.
- `npm run build` (`tsc -p tsconfig.build.json`) — not independently re-verified given the above.
