### PR TITLE
docs(invoice-state): add troubleshooting guide

### DIFF
--- a/docs/invoice-state-troubleshooting.md
+++ b/docs/invoice-state-troubleshooting.md
@@ -1,0 +1,189 @@
+# Invoice-State Troubleshooting Guide
+
+Symptom-oriented companion to [`docs/invoice-state.md`](invoice-state.md)
+(the API/error-code reference) and
+[`docs/runbook-invoice-state.md`](runbook-invoice-state.md) (the operator
+runbook for infra-level failure modes — auth, rate limiting, DB, KYC). This
+doc is for "I made a request and got an error I don't understand" — API
+integrators and on-call engineers diagnosing a specific invoice-state
+response.
+
+For the full, authoritative error-code table (code → HTTP status → which
+endpoint(s) → meaning), see
+[`docs/invoice-state.md` §6.2](invoice-state.md#62-complete-error-code-table).
+This guide references that table rather than repeating it, and links
+straight to the source line implementing each check where useful.
+
+---
+
+## How to read an invoice-state error
+
+Every single-invoice endpoint (`/:id/state`, `/:id/transition`,
+`/:id/approve`, `/:id/reject`, `/:id/link-escrow`, `/:id/history`) returns
+errors with a machine-readable `error.code` field. **Always branch on
+`code`, never on `error.message`** — messages are for humans and can change
+without notice; codes are the stable contract.
+
+```json
+{
+  "error": {
+    "code": "TERMINAL_STATE",
+    "message": "Invoice is in a terminal state and cannot transition.",
+    "details": null
+  }
+}
+```
+
+`POST /bulk` is the one exception — see
+[Bulk operations: per-item errors are always 200](#bulk-operations-per-item-errors-are-always-200)
+below.
+
+---
+
+## Common scenarios
+
+### "I got 404 INVOICE_NOT_FOUND, but I know the invoice exists"
+
+**Cause:** invoice lookups are tenant-scoped
+(`invoiceService.resolveInvoiceForTenant`, `src/services/invoiceService.js`)
+— a real invoice belonging to a *different* tenant returns the exact same
+404 as a genuinely missing one. This is intentional: it prevents an
+attacker from distinguishing "wrong tenant" from "doesn't exist" via timing
+or response-shape differences.
+
+**Fix:** confirm the `x-tenant-id` header (or the authenticated JWT's
+tenant claim) matches the tenant that actually owns the invoice. See
+[`docs/runbook-invoice-state.md` §"Missing tenant context"](runbook-invoice-state.md#2-missing-tenant-context)
+for how tenant context is resolved.
+
+### "I got TERMINAL_STATE or INVALID_TRANSITION and I'm not sure why"
+
+**Cause:** you're attempting a transition the state machine doesn't allow
+from the invoice's *current* state. The valid transitions are:
+`pending → approved | rejected | cancelled` and
+`approved → linked_escrow | rejected | cancelled`; `linked_escrow`,
+`rejected`, and `cancelled` are terminal (see
+[`docs/invoice-states.md`](invoice-states.md) for the full diagram).
+
+**Fix:** call `GET /api/invoices/:id/state` first — the response's
+`allowedTransitions` array is the authoritative list of what you can do
+*right now*. `INVALID_TRANSITION` errors additionally echo this same list
+in `error.details.allowedTransitions`, so you don't need a second request
+just to recover from the error.
+
+### "I got MISSING_TRANSITION_REASON on approve, but not on reject"
+
+**Cause:** a `reason` is required for transitions *into* the states listed
+in `REASON_REQUIRED_TARGETS` (`src/services/invoiceStateMachine.js`) —
+currently `rejected` and `cancelled`, not `approved`. `POST /:id/approve`
+still accepts an optional `reason` (defaults to `'Invoice approved'` if
+omitted); `POST /:id/reject` requires a non-empty one.
+
+**Fix:** supply a non-empty `reason` string (max 1024 chars —
+`TRANSITION_REASON_TOO_LONG` otherwise) when rejecting or cancelling.
+
+### "I got CANNOT_LINK_TO_ESCROW"
+
+**Cause:** `POST /:id/link-escrow` requires the invoice to currently be
+`approved` — `canLinkToEscrow()` (`src/services/invoiceStateMachine.js`)
+rejects any other state, including `pending` (approve it first) and
+`linked_escrow` (already linked — this isn't idempotent).
+
+**Fix:** check `GET /:id/state` for the current status; approve the
+invoice first if it's still `pending`. If the KYC gate is also involved
+(a `403 KYC_GATE_FAILED` or `MISSING_SME_ID`, not this code), see
+[`docs/runbook-invoice-state.md` §"KYC gate rejection"](runbook-invoice-state.md#5-kyc-gate-rejection-on-link-escrow).
+
+### "I got 409 TRANSITION_CONFLICT"
+
+**Cause:** invoice-state writes use optimistic concurrency control — the
+service reads the current status, validates the transition against it,
+then writes conditionally on that status still being unchanged
+(`invoiceService.transitionInvoice`'s `expectedStatus` check). If another
+request wins the race and changes the status first, your write is
+rejected with `409` instead of silently overwriting the winner's change or
+producing a corrupted state.
+
+**Fix:** this is expected, safe-to-retry behaviour under concurrent
+writes to the same invoice, not a bug. Re-fetch `GET /:id/state` and
+retry — your request will either succeed against the new state or surface
+a state-specific error (e.g. `TERMINAL_STATE` if the winner's transition
+made the invoice terminal). If you see this *without* concurrent callers,
+that's a genuine signal worth investigating (a duplicate client retry
+storm, or a stuck/looping caller).
+
+### "My deployment doesn't emit TRANSITION_CONFLICT at all — is that a bug?"
+
+No — it means nothing has raced yet in that environment. It's naturally
+rare outside concurrent-load conditions, which is exactly why it's easy to
+miss when first building an error-handling matrix for this API — call it
+out explicitly if you're writing client-side retry logic.
+
+---
+
+## Bulk operations: per-item errors are always 200
+
+`POST /api/invoices/bulk` processes a bounded array (max 25) of operations
+sequentially and **never fails the whole batch because one item failed** —
+by design, so one bad row doesn't block 24 good ones. This makes its error
+model different enough from every other invoice-state endpoint that it
+deserves its own section:
+
+- **Batch-level validation** (checked before any item runs) still returns a
+  real HTTP error status: `400 INVALID_BATCH_TYPE` (body isn't a JSON
+  array), `400 EMPTY_BATCH` (empty array), `400 BATCH_OVER_CAP` (more than
+  25 items).
+- **Once processing starts, the HTTP response is always `200`** — even if
+  *every* item failed. Success/failure lives entirely in the response
+  body:
+
+```json
+{
+  "data": {
+    "results": [
+      { "index": 0, "success": true, "action": "approve", "result": { "...": "..." } },
+      { "index": 1, "success": false, "error": "Invoice not found", "code": "INVOICE_NOT_FOUND" }
+    ],
+    "summary": { "total": 2, "succeeded": 1, "failed": 1 }
+  }
+}
+```
+
+**If your integration only checks the HTTP status code, you will silently
+miss per-item failures.** Always check `summary.failed` and inspect
+`results[].success` / `results[].code` for each item.
+
+Per-item `code` values include the batch-scoped validation codes
+(`MISSING_INVOICE_ID`, `MISSING_ACTION`, `INVALID_ACTION`,
+`MISSING_TARGET_STATE` for a `transition` item without `targetState`) and
+any single-invoice code from the table above (`INVOICE_NOT_FOUND`,
+`TERMINAL_STATE`, `TRANSITION_CONFLICT`, etc.) — the dispatch reuses the
+exact same `approve`/`reject`/`linkEscrow`/`transition` service functions
+as the single-invoice endpoints, so a `link-escrow` item can fail with
+`CANNOT_LINK_TO_ESCROW` the same way a direct `POST /:id/link-escrow` call
+would. `BULK_ITEM_ERROR` is a defensive fallback for the (should-not-happen)
+case of a thrown error with no `.code` at all.
+
+Note: `POST /bulk` isn't yet documented in `docs/invoice-state.md`'s
+endpoint reference (§5) — flagging that as a known gap in this repo's docs
+rather than silently working around it; out of scope to fix here since
+this guide is specifically about errors, not the full request/response
+schema.
+
+---
+
+## Cross-references
+
+- [`docs/invoice-state.md`](invoice-state.md) — full API reference,
+  including the complete error-code table this guide links into.
+- [`docs/invoice-states.md`](invoice-states.md) — the state machine's
+  diagram, transition matrix, and guards.
+- [`docs/runbook-invoice-state.md`](runbook-invoice-state.md) — operator
+  runbook for infra-level failures (auth, tenant resolution, rate
+  limiting, KYC gating, DB/persistence errors) and recovery procedures.
+- `src/services/invoiceStateMachine.js` — canonical transition rules and
+  the `messageMap` every state-machine error code is drawn from.
+- `src/services/invoiceStateService.js` — `processBulkOperations` (the
+  bulk dispatch logic) and the single-invoice service functions it reuses.
+- `src/middleware/invoiceStateErrorHandler.js` — how a thrown
+  `StateTransitionError` becomes an HTTP response (`resolveStatus`).

--- a/docs/invoice-state.md
+++ b/docs/invoice-state.md
@@ -712,19 +712,43 @@ handling. Always branch on `code` rather than `message` or `detail`.
 | Code | HTTP Status | Endpoint(s) | Description |
 |------|-------------|-------------|-------------|
 | `INVOICE_NOT_FOUND` | 404 | All | Invoice does not exist or belongs to a different tenant. |
-| `MISSING_TARGET_STATE` | 400 | `/transition` | `targetState` field absent from request body. |
+| `MISSING_TARGET_STATE` | 400 | `/transition`, `/bulk` (`transition` action) | `targetState` field absent from request body. |
 | `INVALID_TARGET_STATE` | 400 | `/transition` | `targetState` is not a recognized lifecycle state value. |
+| `MISSING_CURRENT_STATE` | 400 | `/transition` | Invoice has no persisted `status` value (data integrity issue) — should not occur in practice. |
 | `INVALID_CURRENT_STATE` | 400 | `/transition` | Invoice's current state is not a recognized lifecycle state (data integrity issue). |
 | `INVALID_TRANSITION` | 400 | `/transition`, `/reject` | The `from → to` pair is not in `VALID_TRANSITIONS`. Includes `allowedTransitions` hint in `details`. |
 | `TERMINAL_STATE` | 400 | All write endpoints | Invoice is in a terminal state; further transitions are blocked. |
 | `ALREADY_IN_TARGET_STATE` | 400 | `/approve`, `/transition` | `targetState` equals the invoice's current state. |
 | `MISSING_TRANSITION_REASON` | 400 | `/transition`, `/reject`, `/link-escrow` (if cancelled) | `reason` is required for the target state but was absent or whitespace-only. |
 | `TRANSITION_REASON_TOO_LONG` | 400 | All write endpoints | `reason` exceeds 1 024 characters. |
+| `TRANSITION_CONFLICT` | 409 | `/transition`, `/approve`, `/reject`, `/link-escrow`, `/bulk` | Optimistic concurrency check failed — another request changed the invoice's status between read and write. Retry the request; it will either succeed against the new state or return a state-specific error (e.g. `TERMINAL_STATE`). |
 | `CANNOT_LINK_TO_ESCROW` | 400 | `/link-escrow` | Invoice is not in `approved` state. |
 | `MISSING_ACTOR` | 400 | All write endpoints | `req.user` is absent — the authenticated actor could not be resolved. |
 | `KYC_GATE_FAILED` | 403 | `/link-escrow` | SME KYC status does not permit funding operations. |
 | `MISSING_SME_ID` | 400 | `/link-escrow` | Authenticated principal has no `smeId` JWT claim. |
 | `INTERNAL_SERVER_ERROR` | 500 | All | Unexpected server-side error. No retry without investigation. |
+
+**`/bulk`-only codes** — these never surface as the HTTP status/error for the
+whole request (except the first two, which reject the entire batch before
+any item runs); per-item codes are embedded in `results[].code` inside a
+`200` response instead (see
+[`docs/invoice-state-troubleshooting.md`](invoice-state-troubleshooting.md#bulk-operations-per-item-errors-are-always-200)):
+
+| Code | Scope | Description |
+|------|-------|-------------|
+| `INVALID_BATCH_TYPE` | Whole batch, 400 | Request body is not a JSON array. |
+| `EMPTY_BATCH` | Whole batch, 400 | Array is present but has zero items. |
+| `BATCH_OVER_CAP` | Whole batch, 400 | Array has more than `MAX_BULK_ITEMS` (25) items. |
+| `MISSING_INVOICE_ID` | Per-item, embedded in 200 | Item's `invoiceId` is absent, not a string, or empty after trimming. |
+| `MISSING_ACTION` | Per-item, embedded in 200 | Item's `action` is absent or not a string. |
+| `INVALID_ACTION` | Per-item, embedded in 200 | Item's `action` is not one of `approve`/`reject`/`link-escrow`/`transition`. |
+| `BULK_ITEM_ERROR` | Per-item, embedded in 200 | Fallback when a thrown error has no `.code` at all. |
+
+A per-item `transition` action can also produce any of the single-invoice
+codes above (`MISSING_TARGET_STATE`, `INVOICE_NOT_FOUND`, `TERMINAL_STATE`,
+`TRANSITION_CONFLICT`, etc.) — the dispatch reuses the exact same
+`approve`/`reject`/`linkEscrow`/`transition` service functions as the
+single-invoice endpoints.
 
 ### 6.3 Missing tenant context (400)
 


### PR DESCRIPTION
Closes #1114

## Summary

Adds `docs/invoice-state-troubleshooting.md`: a symptom-oriented companion doc — "I made a request and got an error I don't understand, what do I do" — for API integrators and on-call engineers, complementing (not duplicating) two docs that already exist in this repo:

- [`docs/invoice-state.md`](../invoice-state.md) — the API reference, which already has a `§6.2 Complete error code table`.
- [`docs/runbook-invoice-state.md`](../runbook-invoice-state.md) — the operator runbook for infra-level failures (auth, tenant resolution, rate limiting, KYC gating, DB errors).

The new doc links into both rather than repeating their content, and adds six concrete "I got X, here's why and how to fix it" scenarios (tenant-scoped 404s, `TERMINAL_STATE`/`INVALID_TRANSITION`, when a `reason` is/isn't required, `CANNOT_LINK_TO_ESCROW`, and the `409 TRANSITION_CONFLICT` optimistic-concurrency case), plus a dedicated section on `/bulk`'s error model, which is different enough from every other endpoint (batch-level 400s vs. always-200 per-item results) to deserve its own explanation and a "you will silently miss failures if you only check the HTTP status" callout.

## A real inaccuracy found and fixed in the existing "complete" error table

Before writing the new doc, I cross-referenced `docs/invoice-state.md §6.2`'s existing "Complete error code table" against the actual source (`src/services/invoiceStateMachine.js`, `src/services/invoiceService.js`, `src/services/invoiceStateService.js`) to make sure my new doc's links pointed at something accurate. It wasn't complete:

- **Missing entirely:** `TRANSITION_CONFLICT` (409) — the optimistic-concurrency-control error thrown by `invoiceService.transitionInvoice` when a concurrent write beats the current request (confirmed real and exercised by `tests/invoice.state.concurrency.test.js`, which already asserts on this exact code).
- **Missing entirely:** every `/bulk`-specific code (`INVALID_BATCH_TYPE`, `EMPTY_BATCH`, `BATCH_OVER_CAP`, `MISSING_INVOICE_ID`, `MISSING_ACTION`, `INVALID_ACTION`, `BULK_ITEM_ERROR`) — the `/bulk` endpoint isn't referenced anywhere in that table, or in the doc's endpoint list (§5) at all.
- **Missing:** `MISSING_CURRENT_STATE`, present in the state machine's own `messageMap` alongside the already-documented `INVALID_CURRENT_STATE`, but never added to the table.

I fixed the table (added the missing rows, plus a new sub-table for the `/bulk`-only codes with a note explaining why most of them show up in a `200` response body rather than as an HTTP error status) rather than let my new doc link to something I'd already found to be wrong. I did **not** attempt the larger fix of adding a full `/bulk` endpoint section to §5 (request/response schema, etc.) — flagged that as a known, separate gap in the new doc instead, since it's a bigger scope than "cross-reference the error codes" calls for.

## Accuracy verification

Every fact in both files was checked directly against source before writing it — not assumed:
- `MAX_BULK_ITEMS = 25`, `MAX_TRANSITION_REASON_LENGTH = 1024`, `REASON_REQUIRED_TARGETS = [REJECTED, CANCELLED]` (so `approve` does *not* require a reason, matching the existing default `'Invoice approved'` fallback) — all confirmed byte-for-byte against `src/services/invoiceStateMachine.js`.
- `TRANSITION_CONFLICT`'s exact throw site, message, and `409` status — confirmed in `src/services/invoiceService.js`.
- All internal cross-reference anchors (`invoice-state.md#62-complete-error-code-table`, `runbook-invoice-state.md#2-missing-tenant-context`, `runbook-invoice-state.md#5-kyc-gate-rejection-on-link-escrow`, and the new doc's own internal anchor) verified against each target heading's actual GitHub-generated slug — caught and fixed one typo'd anchor (`bulk-poperations-...` → `bulk-operations-...`) before finalizing.

## Verification

Documentation-only change (no `.js` files touched). `npx eslint` on both files — clean (markdown isn't covered by this repo's eslint config, expected). `npm test` / `npm run build` not independently re-verified for this PR — no source files touched, so neither could be implicated; `src/metrics.js` has a pre-existing, severe parse error unrelated to invoice-state, already disclosed in detail in #1110 (PR #1163) / #1111 (PR #1165) / #1113 (PR #1167).
